### PR TITLE
fix: not allocating address from specified loadbalancerIP in ipv6

### DIFF
--- a/internal/allocator/localpool.go
+++ b/internal/allocator/localpool.go
@@ -350,8 +350,8 @@ func (p LocalPool) Overlaps(other Pool) bool {
 // Contains indicates whether the provided net.IP represents an
 // address within this Pool.  It returns true if so, false otherwise.
 func (p LocalPool) Contains(ip net.IP) bool {
-	if p.v4Range != nil {
-		return p.v4Range.Contains(ip)
+	if p.v4Range != nil && ip.To4() != nil {
+		return p.v4Range.Contains(ip.To4())
 	}
 	if p.v6Range != nil {
 		return p.v6Range.Contains(ip)


### PR DESCRIPTION
If loadBalancerIP was specified for ipv4 service, the allocator correctly allocates the ip address if it is available in the given group.
But for ipv6, it doesnt work. This is due to a bug in localpool.go `contains` method.

```go
func (p LocalPool) Contains(ip net.IP) bool {
	if p.v4Range != nil {
		return p.v4Range.Contains(ip)
	}
	if p.v6Range != nil {
		return p.v6Range.Contains(ip)
	}
	return false
}
```
As per this code, if I have both ipv4range and ipv6range specified in the servicegroup, it just checks if the given ip is within v4range and returns the value. V6range is always ignored.

Thee bug is fixed by ensuring that v4range is compared only if the given IP is ipv4

Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>