### PR TITLE
Improve installation and local development experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,15 @@ jobs:
         if: github.ref_type == 'tag'
         run: helm push purelb-${{ steps.tag.outputs.tag }}.tgz oci://ghcr.io/purelb/purelb/charts
 
+      - name: Tag Helm chart as 'latest' in OCI registry
+        if: github.ref_type == 'tag'
+        run: |
+          # Install oras CLI
+          curl -sLO https://github.com/oras-project/oras/releases/download/v1.2.2/oras_1.2.2_linux_amd64.tar.gz
+          tar -xzf oras_1.2.2_linux_amd64.tar.gz
+          # Tag the versioned chart as 'latest' so users can install without --version
+          ./oras tag ghcr.io/purelb/purelb/charts/purelb:${{ steps.tag.outputs.tag }} latest
+
       - name: Generate checksums
         run: |
           sha256sum purelb-${{ steps.tag.outputs.tag }}.tgz > SHA256SUMS

--- a/build/helm/purelb/values.yaml
+++ b/build/helm/purelb/values.yaml
@@ -6,7 +6,7 @@
 # Docker image configuration
 image:
   repository: DEFAULT_REPO
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: DEFAULT_TAG
 


### PR DESCRIPTION
## Summary

- Add 'latest' tag to OCI Helm chart releases using oras, enabling versionless `helm install` from OCI registry
- Change default `imagePullPolicy` from `Always` to `IfNotPresent` for faster pod restarts with immutable version tags
- Document local development workflow without registry access using ko tarballs and direct containerd import

## Details

### OCI Registry Latest Tag
The OCI registry at `ghcr.io/purelb/purelb/charts/purelb` requires `--version` flag because anonymous users cannot enumerate tags. Adding a `latest` tag allows:
```sh
helm install purelb oci://ghcr.io/purelb/purelb/charts/purelb
```

### imagePullPolicy
Changed from `Always` to `IfNotPresent` since PureLB uses immutable semantic version tags. This improves pod startup time and resilience to registry outages.

### Local Development
Added documentation for building and testing locally without pushing to a registry, using `ko build --tarball` and `ctr images import`.

## Test plan

- [x] Tested all 3 Helm installation methods (repo, OCI with version, direct URL)
- [x] Tested local development workflow with ko tarballs and containerd import
- [x] CI workflow change will be validated on next tag release