### PR TITLE
Fix netlink v1.3.1 compatibility and harden netlink layer

### DIFF
--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/lbnodeagent/controller.go
+++ b/cmd/lbnodeagent/controller.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/lbnodeagent/main.go
+++ b/cmd/lbnodeagent/main.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020,2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/controller.go
+++ b/internal/allocator/controller.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/controller_test.go
+++ b/internal/allocator/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/ingress.go
+++ b/internal/allocator/ingress.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/k8salloc.go
+++ b/internal/allocator/k8salloc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/localpool.go
+++ b/internal/allocator/localpool.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/localpool_test.go
+++ b/internal/allocator/localpool_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/netboxpool.go
+++ b/internal/allocator/netboxpool.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020,2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/netboxpool_test.go
+++ b/internal/allocator/netboxpool_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/allocator/pool.go
+++ b/internal/allocator/pool.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020,2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/service.go
+++ b/internal/allocator/service.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/allocator/stats.go
+++ b/internal/allocator/stats.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/election/election.go
+++ b/internal/election/election.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/election/election_test.go
+++ b/internal/election/election_test.go
@@ -1116,6 +1116,10 @@ func TestOnLeaseUpdateDetectsMembershipChange(t *testing.T) {
 		},
 	})
 
+	// Reset counter after initial setup — informer sync and rebuildMaps
+	// may have legitimately triggered OnMemberChange during startup
+	memberChangeCount = 0
+
 	// Simulate onLeaseUpdate triggered by another node's renewal or resync.
 	// This should detect that node-b's lease is expired.
 	e.onLeaseUpdate(freshLease, freshLease)
@@ -1194,6 +1198,10 @@ func TestOnLeaseUpdateNoChangeNoCallback(t *testing.T) {
 
 	// Build initial state from cache (both nodes fresh)
 	e.rebuildMaps()
+
+	// Reset counter after initial setup — informer sync and rebuildMaps
+	// may have legitimately triggered OnMemberChange during startup
+	memberChangeCount = 0
 
 	// Simulate onLeaseUpdate (e.g., node-a renewed) - no membership change
 	e.onLeaseUpdate(leaseA, leaseA)

--- a/internal/election/election_test.go
+++ b/internal/election/election_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/election/metrics.go
+++ b/internal/election/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -15,6 +15,7 @@
 package election
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -25,6 +26,7 @@ import (
 	"github.com/vishvananda/netlink/nl"
 
 	"purelb.io/internal/logging"
+	"purelb.io/internal/netutil"
 )
 
 // SubnetsAnnotation is the annotation key used on leases to store
@@ -37,11 +39,6 @@ const SubnetsAnnotation = "purelb.io/subnets"
 // recreation where an old pod might delete a new pod's lease.
 const InstanceAnnotation = "purelb.io/instance"
 
-// IPv6 address flags that indicate an address should NOT be used:
-// - IFA_F_DADFAILED (0x08): Duplicate address detection failed
-// - IFA_F_DEPRECATED (0x20): Address is deprecated, don't use for new connections
-// - IFA_F_TENTATIVE (0x40): DAD not complete, address not yet usable
-const ipv6BadFlags = 0x08 | 0x20 | 0x40
 
 // GetLocalSubnets returns all subnets from the specified interfaces.
 // If includeDefault is true, the interface with the default route is
@@ -81,7 +78,7 @@ func GetLocalSubnets(interfaces []string, includeDefault bool, logger log.Logger
 	// Include default interface if requested
 	if includeDefault {
 		// Try IPv4 default first
-		if link, err := defaultInterface(nl.FAMILY_V4); err == nil {
+		if link, err := netutil.DefaultInterface(nl.FAMILY_V4); err == nil {
 			ifName := link.Attrs().Name
 			if logger != nil {
 				logging.Debug(logger, "op", "getLocalSubnets", "interface", ifName,
@@ -96,7 +93,7 @@ func GetLocalSubnets(interfaces []string, includeDefault bool, logger log.Logger
 		}
 
 		// Also try IPv6 default (may be different interface)
-		if link, err := defaultInterface(nl.FAMILY_V6); err == nil {
+		if link, err := netutil.DefaultInterface(nl.FAMILY_V6); err == nil {
 			ifName := link.Attrs().Name
 			if logger != nil {
 				logging.Debug(logger, "op", "getLocalSubnets", "interface", ifName,
@@ -134,8 +131,13 @@ func collectSubnetsFromLink(link netlink.Link, subnets map[string]struct{}, logg
 
 	// Collect IPv4 subnets
 	addrsV4, err := netlink.AddrList(link, nl.FAMILY_V4)
-	if err != nil {
+	if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
 		return fmt.Errorf("failed to list IPv4 addresses: %w", err)
+	}
+	if errors.Is(err, netlink.ErrDumpInterrupted) && logger != nil {
+		logging.Info(logger, "op", "collectSubnets", "interface", ifName,
+			"family", "IPv4", "count", len(addrsV4),
+			"msg", "partial results from AddrList (ErrDumpInterrupted)")
 	}
 	for _, addr := range addrsV4 {
 		if addr.IPNet != nil {
@@ -151,12 +153,17 @@ func collectSubnetsFromLink(link netlink.Link, subnets map[string]struct{}, logg
 
 	// Collect IPv6 subnets (filtering out bad addresses)
 	addrsV6, err := netlink.AddrList(link, nl.FAMILY_V6)
-	if err != nil {
+	if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
 		return fmt.Errorf("failed to list IPv6 addresses: %w", err)
+	}
+	if errors.Is(err, netlink.ErrDumpInterrupted) && logger != nil {
+		logging.Info(logger, "op", "collectSubnets", "interface", ifName,
+			"family", "IPv6", "count", len(addrsV6),
+			"msg", "partial results from AddrList (ErrDumpInterrupted)")
 	}
 	for _, addr := range addrsV6 {
 		// Skip addresses with bad flags
-		if (addr.Flags & ipv6BadFlags) != 0 {
+		if (addr.Flags & netutil.IPv6BadFlags) != 0 {
 			if logger != nil {
 				logging.Debug(logger, "op", "collectSubnets", "interface", ifName,
 					"address", addr.IPNet.String(), "flags", fmt.Sprintf("0x%x", addr.Flags),
@@ -197,46 +204,6 @@ func networkAddress(ipnet *net.IPNet) string {
 	return fmt.Sprintf("%s/%d", network.String(), ones)
 }
 
-// isDefaultRoute returns true if the route is a default route.
-// Handles both netlink v1.1.0 (Dst == nil) and v1.3.1+ (Dst = 0.0.0.0/0 or ::/0).
-func isDefaultRoute(r netlink.Route) bool {
-	if r.Dst == nil {
-		return true
-	}
-	ones, _ := r.Dst.Mask.Size()
-	return ones == 0
-}
-
-// defaultInterface finds the interface with the default route for the
-// given address family (nl.FAMILY_V4 or nl.FAMILY_V6).
-func defaultInterface(family int) (netlink.Link, error) {
-	routes, err := netlink.RouteList(nil, family)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list routes: %w", err)
-	}
-
-	var defaultIdx int
-	var defaultMetric int
-	first := true
-
-	for _, r := range routes {
-		if !isDefaultRoute(r) {
-			continue
-		}
-		// Take first default route, or one with lower metric
-		if first || r.Priority < defaultMetric {
-			defaultIdx = r.LinkIndex
-			defaultMetric = r.Priority
-			first = false
-		}
-	}
-
-	if first {
-		return nil, fmt.Errorf("no default route found for family %d", family)
-	}
-
-	return netlink.LinkByIndex(defaultIdx)
-}
 
 // FormatSubnetsAnnotation formats a slice of subnets into the annotation
 // value format (comma-separated).

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -197,6 +197,16 @@ func networkAddress(ipnet *net.IPNet) string {
 	return fmt.Sprintf("%s/%d", network.String(), ones)
 }
 
+// isDefaultRoute returns true if the route is a default route.
+// Handles both netlink v1.1.0 (Dst == nil) and v1.3.1+ (Dst = 0.0.0.0/0 or ::/0).
+func isDefaultRoute(r netlink.Route) bool {
+	if r.Dst == nil {
+		return true
+	}
+	ones, _ := r.Dst.Mask.Size()
+	return ones == 0
+}
+
 // defaultInterface finds the interface with the default route for the
 // given address family (nl.FAMILY_V4 or nl.FAMILY_V6).
 func defaultInterface(family int) (netlink.Link, error) {
@@ -210,8 +220,7 @@ func defaultInterface(family int) (netlink.Link, error) {
 	first := true
 
 	for _, r := range routes {
-		// Default route has nil destination
-		if r.Dst != nil {
+		if !isDefaultRoute(r) {
 			continue
 		}
 		// Take first default route, or one with lower metric

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/election/subnets_test.go
+++ b/internal/election/subnets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/k8s/cr-controller-test.go
+++ b/internal/k8s/cr-controller-test.go
@@ -1,5 +1,5 @@
 // Copyright 2017 The Kubernetes Authors.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -1,5 +1,5 @@
 // Copyright 2017 The Kubernetes Authors.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/k8s/stats.go
+++ b/internal/k8s/stats.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/lbnodeagent/announcer.go
+++ b/internal/lbnodeagent/announcer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -30,6 +30,7 @@ import (
 	"purelb.io/internal/k8s"
 	"purelb.io/internal/lbnodeagent"
 	"purelb.io/internal/logging"
+	"purelb.io/internal/netutil"
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 
 	"github.com/go-kit/log"
@@ -210,7 +211,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 
 		} else {
 			// The user wants us to determine the "default" interface
-			announceInt, err := defaultInterface(purelbv2.AddrFamily(lbIP))
+			announceInt, err := netutil.DefaultInterface(purelbv2.AddrFamily(lbIP))
 			if err != nil {
 				logging.Info(l, "event", "announceError", "err", err)
 				retErr = err

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/local/metrics.go
+++ b/internal/local/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/local/network.go
+++ b/internal/local/network.go
@@ -15,15 +15,18 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
+	"syscall"
 
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ethernet"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 
+	"purelb.io/internal/netutil"
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
 
@@ -68,31 +71,27 @@ func checkLocal(intf netlink.Link, lbIP net.IP) (net.IPNet, netlink.Link, error)
 	family := purelbv2.AddrFamily(lbIP)
 
 	defaddrs, err := netlink.AddrList(intf, family)
-	if err != nil {
+	if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
 		return lbIPNet, intf, err
 	}
 
 	if family == nl.FAMILY_V4 {
 		for _, addrs := range defaddrs {
-			localnet := addrs.IPNet
-
-			if localnet.Contains(lbIPNet.IP) {
-				lbIPNet.Mask = localnet.Mask
+			if addrs.IPNet == nil {
+				continue
+			}
+			if addrs.IPNet.Contains(lbIPNet.IP) {
+				lbIPNet.Mask = addrs.IPNet.Mask
 			}
 		}
 
 	} else {
-		// IPv6 address flags that indicate an address should NOT be used:
-		// - IFA_F_DADFAILED (0x08): Duplicate address detection failed
-		// - IFA_F_DEPRECATED (0x20): Address is deprecated, don't use for new connections
-		// - IFA_F_TENTATIVE (0x40): DAD not complete, address not yet usable
-		const badFlags = 0x08 | 0x20 | 0x40
-
 		for _, addrs := range defaddrs {
-			localnet := addrs.IPNet
-
-			if localnet.Contains(lbIPNet.IP) && (addrs.Flags&badFlags) == 0 {
-				lbIPNet.Mask = localnet.Mask
+			if addrs.IPNet == nil {
+				continue
+			}
+			if addrs.IPNet.Contains(lbIPNet.IP) && (addrs.Flags&netutil.IPv6BadFlags) == 0 {
+				lbIPNet.Mask = addrs.IPNet.Mask
 			}
 		}
 	}
@@ -102,63 +101,6 @@ func checkLocal(intf netlink.Link, lbIP net.IP) (net.IPNet, netlink.Link, error)
 	}
 
 	return lbIPNet, intf, nil
-}
-
-// isDefaultRoute returns true if the route is a default route.
-// Handles both netlink v1.1.0 (Dst == nil) and v1.3.1+ (Dst = 0.0.0.0/0 or ::/0).
-func isDefaultRoute(r netlink.Route) bool {
-	if r.Dst == nil {
-		return true
-	}
-	ones, _ := r.Dst.Mask.Size()
-	return ones == 0
-}
-
-// defaultInterface finds the default interface (i.e., the one with
-// the default route) for the given family, which should be either
-// nl.FAMILY_V6 or nl.FAMILY_V4.
-func defaultInterface(family int) (netlink.Link, error) {
-	var defaultifindex int = 0
-	var defaultifmetric int = 0
-
-	rt, err := netlink.RouteList(nil, family)
-	if err != nil {
-		return nil, err
-	}
-	for _, r := range rt {
-		// check each route to see if it's the default (i.e., no destination)
-		if isDefaultRoute(r) && defaultifindex == 0 {
-			// this is the first default route we've seen
-			defaultifindex = r.LinkIndex
-			defaultifmetric = r.Priority
-		} else if isDefaultRoute(r) && defaultifindex != 0 && r.Priority < defaultifmetric {
-			// if there's another default route with a lower metric use it
-			defaultifindex = r.LinkIndex
-			defaultifmetric = r.Priority
-		}
-	}
-
-	// If none of our routes matched our criteria then we can't pick an
-	// interface
-	if defaultifindex == 0 {
-		return nil, fmt.Errorf("No default interface for family %d can be determined", family)
-	}
-
-	// there's only one default route
-	defaultint, err := netlink.LinkByIndex(defaultifindex)
-	return defaultint, err
-}
-
-// addNetwork adds lbIPNet to link.
-func addNetwork(lbIPNet net.IPNet, link netlink.Link) error {
-	addr, err := netlink.ParseAddr(lbIPNet.String())
-	if err != nil {
-		return err
-	}
-	if err := netlink.AddrReplace(link, addr); err != nil {
-		return fmt.Errorf("could not add %v: to %v %w", addr, link, err)
-	}
-	return nil
 }
 
 // AddressOptions configures how an address is added to an interface.
@@ -207,18 +149,33 @@ func addDummyInterface(name string) (netlink.Link, error) {
 	// check if there's already an interface with that name
 	link, err := netlink.LinkByName(name)
 	if err != nil {
+		var lnfErr netlink.LinkNotFoundError
+		if !errors.As(err, &lnfErr) {
+			return nil, fmt.Errorf("checking for interface %s: %w", name, err)
+		}
 
 		// the interface doesn't exist, so we can add it
 		dumint := netlink.NewLinkAttrs()
 		dumint.Name = name
 		link = &netlink.Dummy{LinkAttrs: dumint}
 		if err = netlink.LinkAdd(link); err != nil {
-			return nil, fmt.Errorf("failed adding dummy int %s: %w", name, err)
+			// Handle TOCTOU race: another process created the interface
+			// between our LinkByName and LinkAdd
+			if errors.Is(err, syscall.EEXIST) {
+				link, err = netlink.LinkByName(name)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get existing interface %s: %w", name, err)
+				}
+			} else {
+				return nil, fmt.Errorf("failed adding dummy int %s: %w", name, err)
+			}
 		}
 
 	}
 	// Make sure that "dummy" interface is set to up.
-	netlink.LinkSetUp(link)
+	if err := netlink.LinkSetUp(link); err != nil {
+		return nil, fmt.Errorf("failed to set %s up: %w", name, err)
+	}
 	return link, nil
 }
 

--- a/internal/local/network.go
+++ b/internal/local/network.go
@@ -104,6 +104,16 @@ func checkLocal(intf netlink.Link, lbIP net.IP) (net.IPNet, netlink.Link, error)
 	return lbIPNet, intf, nil
 }
 
+// isDefaultRoute returns true if the route is a default route.
+// Handles both netlink v1.1.0 (Dst == nil) and v1.3.1+ (Dst = 0.0.0.0/0 or ::/0).
+func isDefaultRoute(r netlink.Route) bool {
+	if r.Dst == nil {
+		return true
+	}
+	ones, _ := r.Dst.Mask.Size()
+	return ones == 0
+}
+
 // defaultInterface finds the default interface (i.e., the one with
 // the default route) for the given family, which should be either
 // nl.FAMILY_V6 or nl.FAMILY_V4.
@@ -117,13 +127,14 @@ func defaultInterface(family int) (netlink.Link, error) {
 	}
 	for _, r := range rt {
 		// check each route to see if it's the default (i.e., no destination)
-		if r.Dst == nil && defaultifindex == 0 {
+		if isDefaultRoute(r) && defaultifindex == 0 {
 			// this is the first default route we've seen
 			defaultifindex = r.LinkIndex
 			defaultifmetric = r.Priority
-		} else if r.Dst == nil && defaultifindex != 0 && r.Priority < defaultifmetric {
+		} else if isDefaultRoute(r) && defaultifindex != 0 && r.Priority < defaultifmetric {
 			// if there's another default route with a lower metric use it
 			defaultifindex = r.LinkIndex
+			defaultifmetric = r.Priority
 		}
 	}
 

--- a/internal/local/network.go
+++ b/internal/local/network.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Google Inc.
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/netbox/fake/netbox.go
+++ b/internal/netbox/fake/netbox.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/netbox/netbox.go
+++ b/internal/netbox/netbox.go
@@ -1,4 +1,4 @@
-// Copyright 2020,2021 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package netutil provides shared network utility functions for
+// interacting with the Linux netlink subsystem.
+package netutil
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+)
+
+// IPv6BadFlags contains IPv6 address flags that indicate an address
+// should NOT be used:
+//   - IFA_F_DADFAILED (0x08): Duplicate address detection failed
+//   - IFA_F_DEPRECATED (0x20): Address is deprecated, don't use for new connections
+//   - IFA_F_TENTATIVE (0x40): DAD not complete, address not yet usable
+const IPv6BadFlags = 0x08 | 0x20 | 0x40
+
+// IsDefaultRoute returns true if the route is a default route.
+// Handles both netlink v1.1.0 (Dst == nil) and v1.3.1+ (Dst = 0.0.0.0/0 or ::/0).
+func IsDefaultRoute(r netlink.Route) bool {
+	if r.Dst == nil {
+		return true
+	}
+	ones, _ := r.Dst.Mask.Size()
+	return ones == 0
+}
+
+// DefaultInterface finds the interface with the default route for the
+// given address family (nl.FAMILY_V4 or nl.FAMILY_V6). If multiple
+// default routes exist, the one with the lowest metric is preferred.
+func DefaultInterface(family int) (netlink.Link, error) {
+	routes, err := netlink.RouteList(nil, family)
+	if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
+		return nil, fmt.Errorf("failed to list routes: %w", err)
+	}
+
+	var defaultIdx int
+	var defaultMetric int
+	first := true
+
+	for _, r := range routes {
+		if !IsDefaultRoute(r) {
+			continue
+		}
+		// Take first default route, or one with lower metric
+		if first || r.Priority < defaultMetric {
+			defaultIdx = r.LinkIndex
+			defaultMetric = r.Priority
+			first = false
+		}
+	}
+
+	if first {
+		return nil, fmt.Errorf("no default route found for family %d", family)
+	}
+
+	return netlink.LinkByIndex(defaultIdx)
+}

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -1,0 +1,86 @@
+package netutil
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+func TestIsDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    netlink.Route
+		expected bool
+	}{
+		{
+			name:     "nil Dst (netlink v1.1.0 style)",
+			route:    netlink.Route{Dst: nil},
+			expected: true,
+		},
+		{
+			name: "IPv4 default 0.0.0.0/0 (netlink v1.3.1 style)",
+			route: netlink.Route{Dst: &net.IPNet{
+				IP:   net.IPv4zero,
+				Mask: net.CIDRMask(0, 32),
+			}},
+			expected: true,
+		},
+		{
+			name: "IPv6 default ::/0 (netlink v1.3.1 style)",
+			route: netlink.Route{Dst: &net.IPNet{
+				IP:   net.IPv6zero,
+				Mask: net.CIDRMask(0, 128),
+			}},
+			expected: true,
+		},
+		{
+			name: "IPv4 non-default 192.168.1.0/24",
+			route: netlink.Route{Dst: &net.IPNet{
+				IP:   net.ParseIP("192.168.1.0"),
+				Mask: net.CIDRMask(24, 32),
+			}},
+			expected: false,
+		},
+		{
+			name: "IPv6 non-default ::/64",
+			route: netlink.Route{Dst: &net.IPNet{
+				IP:   net.IPv6zero,
+				Mask: net.CIDRMask(64, 128),
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDefaultRoute(tt.route)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLinkNotFoundErrorMatch(t *testing.T) {
+	// Verify that errors.As works with netlink.LinkNotFoundError
+	// in our pinned v1.3.1. Get a real error from the library by
+	// looking up a non-existent interface.
+	_, err := netlink.LinkByName("nonexistent-test-interface-xyz")
+	assert.Error(t, err)
+
+	var lnfErr netlink.LinkNotFoundError
+	assert.True(t, errors.As(err, &lnfErr),
+		"errors.As should match LinkNotFoundError with value-type target")
+}
+
+func TestDefaultInterface(t *testing.T) {
+	// Integration test — requires real netlink access.
+	// Skip gracefully in CI environments without a default route.
+	link, err := DefaultInterface(2) // nl.FAMILY_V4
+	if err != nil {
+		t.Skipf("Skipping: no default route available: %v", err)
+	}
+	assert.NotNil(t, link)
+	assert.NotEmpty(t, link.Attrs().Name)
+}

--- a/pkg/apis/purelb/register.go
+++ b/pkg/apis/purelb/register.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/annotations.go
+++ b/pkg/apis/purelb/v2/annotations.go
@@ -1,5 +1,4 @@
-// Copyright 2020 Acnodal Inc.
-// Copyright 2024 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/classes.go
+++ b/pkg/apis/purelb/v2/classes.go
@@ -1,5 +1,4 @@
-// Copyright 2020 Acnodal Inc.
-// Copyright 2024 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/config.go
+++ b/pkg/apis/purelb/v2/config.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Acnodal, Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/doc.go
+++ b/pkg/apis/purelb/v2/doc.go
@@ -1,5 +1,4 @@
-// Copyright 2020 Acnodal, Inc.
-// Copyright 2024 Acnodal, Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/iprange.go
+++ b/pkg/apis/purelb/v2/iprange.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/iprange_test.go
+++ b/pkg/apis/purelb/v2/iprange_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/register.go
+++ b/pkg/apis/purelb/v2/register.go
@@ -1,5 +1,4 @@
-// Copyright 2020 Acnodal, Inc.
-// Copyright 2024 Acnodal, Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/purelb/v2/types.go
+++ b/pkg/apis/purelb/v2/types.go
@@ -1,5 +1,4 @@
-// Copyright 2020 Acnodal, Inc.
-// Copyright 2024 Acnodal, Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Acnodal Inc.
+// Copyright 2020-2026 Acnodal Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Fix default route detection broken by netlink v1.3.1 upgrade (PR #20) — `RouteList()` now returns `Dst = 0.0.0.0/0` instead of `Dst == nil`, causing lbnodeagent to detect 0 subnets and never announce LoadBalancer IPs on real interfaces
- Create `internal/netutil` shared package to consolidate duplicated `defaultInterface` and `isDefaultRoute` across `election` and `local` packages
- Handle `ErrDumpInterrupted` from `RouteList`/`AddrList` — accept partial results with info-level logging instead of discarding valid data
- Fix `addDummyInterface`: distinguish `LinkNotFoundError` from other errors, handle EEXIST race on `LinkAdd`, propagate `LinkSetUp` errors
- Add nil guard on `addr.IPNet` in `checkLocal` to prevent potential panic
- Remove dead `addNetwork` function superseded by `addNetworkWithOptions`
- Update copyright notices to 2020-2026 Acnodal Inc.

## Test plan

- [x] `make check` — all unit tests pass including new `internal/netutil` tests
- [x] Single-node e2e (`local-kvm`): all 10 phases passed — IPv4, IPv6, dual-stack, pool arrays, lease election, metrics, graceful shutdown, address lifecycle, GARP config
- [x] Multi-node e2e (`prox-purelb2`, 5 nodes, 2 subnets): all 25 tests passed, 216 assertions, 0 failures — multi-subnet VIP placement, pool exhaustion, graceful shutdown, IPv6 multi-subnet, dual-stack multi-subnet