### PR TITLE
Add k8gobgp BGP sidecar to default PureLB installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,18 @@ jobs:
           MANIFEST_SUFFIX: ${{ github.ref_name }}
         run: make install-manifest
 
+      - name: Generate manifests (without BGP)
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+        run: make manifest-nobgp
+
+      - name: Generate install manifest (without BGP)
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+        run: make install-manifest-nobgp
+
       - name: Package Helm chart
         env:
           SUFFIX: ${{ github.ref_name }}
@@ -141,6 +153,8 @@ jobs:
           sha256sum purelb-${{ github.ref_name }}.tgz > SHA256SUMS
           sha256sum deployments/purelb-${{ github.ref_name }}.yaml >> SHA256SUMS
           sha256sum deployments/install-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/purelb-nobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/install-nobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -159,6 +173,8 @@ jobs:
             purelb-${{ github.ref_name }}.tgz
             deployments/purelb-${{ github.ref_name }}.yaml
             deployments/install-${{ github.ref_name }}.yaml
+            deployments/purelb-nobgp-${{ github.ref_name }}.yaml
+            deployments/install-nobgp-${{ github.ref_name }}.yaml
             SHA256SUMS
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .envrc
 deployments/purelb-*.yaml
+deployments/install-*.yaml
 deployments/crds/purelb.io_*.yaml
 configs/my-servicegroup.yaml
 build/helm/purelb/crds/purelb.io_*.yaml

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ MANIFEST_SUFFIX ?= ${SUFFIX}
 COMMANDS = $(shell find cmd -maxdepth 1 -mindepth 1 -type d)
 NETBOX_USER_TOKEN = no-op
 NETBOX_BASE_URL = http://192.168.1.40:30080/
+GOBGP_IMAGE     ?= ghcr.io/purelb/k8gobgp
+GOBGP_TAG       ?= v0.2.2
+GOBGP_IMAGE_TAG ?= 0.2.2
 CRDS = deployments/crds/purelb.io_lbnodeagents.yaml deployments/crds/purelb.io_servicegroups.yaml
 
 # Tools that we use.
@@ -64,11 +67,11 @@ $(CRDS) &: pkg/apis/purelb/v2/*.go
 .ONESHELL:
 .PHONY: manifest
 manifest: CACHE != mktemp
-manifest:  ## Generate deployment manifest (with samples)
-	cd deployments/samples
+manifest:  ## Generate deployment manifest (with samples and k8gobgp)
+	cd deployments/samples-with-gobgp
 # cache kustomization.yaml because "kustomize edit" modifies it
 	cp kustomization.yaml ${CACHE}
-	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX}
+	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX} ghcr.io/purelb/k8gobgp=${GOBGP_IMAGE}:${GOBGP_IMAGE_TAG}
 	$(KUSTOMIZE) build . > ../${PROJECT}-${MANIFEST_SUFFIX}.yaml
 # restore kustomization.yaml
 	cp ${CACHE} kustomization.yaml
@@ -76,14 +79,44 @@ manifest:  ## Generate deployment manifest (with samples)
 .ONESHELL:
 .PHONY: install-manifest
 install-manifest: CACHE != mktemp
-install-manifest: crd  ## Generate standalone install.yaml manifest
+install-manifest: crd  ## Generate standalone install.yaml manifest (with k8gobgp)
+	cd deployments/with-gobgp
+# cache kustomization.yaml because "kustomize edit" modifies it
+	cp kustomization.yaml ${CACHE}
+	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX} ghcr.io/purelb/k8gobgp=${GOBGP_IMAGE}:${GOBGP_IMAGE_TAG}
+	$(KUSTOMIZE) build . > ../install-${MANIFEST_SUFFIX}.yaml
+# restore kustomization.yaml
+	cp ${CACHE} kustomization.yaml
+
+.ONESHELL:
+.PHONY: manifest-nobgp
+manifest-nobgp: CACHE != mktemp
+manifest-nobgp:  ## Generate deployment manifest without k8gobgp (with samples)
+	cd deployments/samples
+# cache kustomization.yaml because "kustomize edit" modifies it
+	cp kustomization.yaml ${CACHE}
+	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX}
+	$(KUSTOMIZE) build . > ../${PROJECT}-nobgp-${MANIFEST_SUFFIX}.yaml
+# restore kustomization.yaml
+	cp ${CACHE} kustomization.yaml
+
+.ONESHELL:
+.PHONY: install-manifest-nobgp
+install-manifest-nobgp: CACHE != mktemp
+install-manifest-nobgp: crd  ## Generate standalone install.yaml without k8gobgp
 	cd deployments/default
 # cache kustomization.yaml because "kustomize edit" modifies it
 	cp kustomization.yaml ${CACHE}
 	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX}
-	$(KUSTOMIZE) build . > ../install-${MANIFEST_SUFFIX}.yaml
+	$(KUSTOMIZE) build . > ../install-nobgp-${MANIFEST_SUFFIX}.yaml
 # restore kustomization.yaml
 	cp ${CACHE} kustomization.yaml
+
+.PHONY: fetch-gobgp-crd
+fetch-gobgp-crd:  ## Fetch BGPConfiguration CRD from k8gobgp ${GOBGP_TAG} release
+	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \
+	  | $(KUSTOMIZE) cfg grep "kind=CustomResourceDefinition" \
+	  > deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
 
 .PHONY: helm
 helm:  ## Package PureLB using Helm
@@ -91,6 +124,7 @@ helm:  ## Package PureLB using Helm
 	mkdir -p build/build
 	cp -r build/helm/purelb build/build/
 	cp deployments/crds/purelb.io_*.yaml build/build/purelb/crds
+	cp deployments/components/gobgp/gobgp-bgpconfig-crd.yaml build/build/purelb/crds/bgp.purelb.io_bgpconfigurations.yaml
 	cp README.md build/build/purelb
 
 	sed \

--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ https://purelb.io/
 
 ## Quick Start
 
+The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) as a sidecar for BGP route announcement. After installing, apply a `BGPConfiguration` CR to configure BGP peering (see [sample](deployments/samples-with-gobgp/sample-bgpconfig.yaml)). If you don't need BGP, use the `-nobgp` manifest variants or set `gobgp.enabled=false` in Helm.
+
 ### Option 1: Simple Manifest
 
 Install PureLB with a single command:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.15.0/install-v0.15.0.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.0/install-v0.16.0.yaml
+```
+
+Without BGP support:
+
+```sh
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.0/install-nobgp-v0.16.0.yaml
 ```
 
 ### Option 2: Helm (Recommended for Production)
@@ -31,7 +39,14 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.15.0
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.0
+```
+
+To install without BGP support:
+
+```sh
+helm install --create-namespace --namespace=purelb-system purelb purelb/purelb \
+    --set gobgp.enabled=false
 ```
 
 For detailed installation and configuration, see https://purelb.github.io/purelb/install/

--- a/build/helm/purelb/templates/daemonset.yaml
+++ b/build/helm/purelb/templates/daemonset.yaml
@@ -70,6 +70,58 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.gobgp.enabled }}
+        volumeMounts:
+        - name: gobgp-socket
+          mountPath: /var/run/gobgp
+      - name: k8gobgp
+        image: "{{ .Values.gobgp.image.repository }}:{{ .Values.gobgp.image.tag }}"
+        imagePullPolicy: {{ .Values.gobgp.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 7473
+          name: gobgp-metrics
+        - containerPort: 7474
+          name: gobgp-health
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7474
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+        {{- with .Values.gobgp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- with .Values.gobgp.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        volumeMounts:
+        - name: gobgp-socket
+          mountPath: /var/run/gobgp
+        {{- end }}
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -89,4 +141,9 @@ spec:
       {{- with .Values.lbnodeagent.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gobgp.enabled }}
+      volumes:
+      - name: gobgp-socket
+        emptyDir: {}
       {{- end }}

--- a/build/helm/purelb/templates/gobgp-metrics-service.yaml
+++ b/build/helm/purelb/templates/gobgp-metrics-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.gobgp.enabled .Values.Prometheus.lbnodeagent.Metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "purelb.fullname" . }}-k8gobgp-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: k8gobgp
+spec:
+  selector:
+    {{- include "purelb.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: lbnodeagent
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 7473
+    targetPort: 7473
+    protocol: TCP
+{{- end }}

--- a/build/helm/purelb/templates/gobgp-rbac.yaml
+++ b/build/helm/purelb/templates/gobgp-rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gobgp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["bgp.purelb.io"]
+  resources: ["configs", "configs/finalizers", "configs/status"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+subjects:
+- kind: ServiceAccount
+  name: lbnodeagent
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/build/helm/purelb/values.yaml
+++ b/build/helm/purelb/values.yaml
@@ -251,3 +251,39 @@ allocator:
     runAsUser: 65534
     seccompProfile:
       type: RuntimeDefault
+
+# k8gobgp sidecar — per-node BGP route announcement for remote VIPs.
+# When enabled, k8gobgp runs as a sidecar in the lbnodeagent DaemonSet pod.
+# It shares hostNetwork:true and announces VIP routes to upstream BGP routers.
+#
+# Prerequisites:
+#   - Port 179 must be free on every node (no other BGP daemon running).
+#   - Firewall must allow TCP 179 between nodes and upstream router.
+#   - Apply a BGPConfiguration CR after install to configure peers/ASNs.
+#   - Upstream router must be configured to peer with each node IP.
+gobgp:
+  enabled: true
+
+  image:
+    repository: ghcr.io/purelb/k8gobgp
+    tag: "0.2.2"
+    pullPolicy: IfNotPresent
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      add:
+      - NET_ADMIN
+      - NET_BIND_SERVICE
+      - NET_RAW
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi

--- a/deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
+++ b/deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
@@ -1,0 +1,922 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+    config.kubernetes.io/index: '1'
+    internal.config.kubernetes.io/index: '1'
+  name: configs.bgp.purelb.io
+spec:
+  group: bgp.purelb.io
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: configs
+    shortNames:
+    - bgpconfig
+    singular: config
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              definedSets:
+                items:
+                  properties:
+                    list:
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    prefixes:
+                      items:
+                        properties:
+                          ipPrefix:
+                            type: string
+                          maskLengthMax:
+                            format: int32
+                            type: integer
+                          maskLengthMin:
+                            format: int32
+                            type: integer
+                        required:
+                        - ipPrefix
+                        type: object
+                      type: array
+                    type:
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              dynamicNeighbors:
+                items:
+                  properties:
+                    peerGroup:
+                      type: string
+                    prefix:
+                      type: string
+                  required:
+                  - peerGroup
+                  - prefix
+                  type: object
+                type: array
+              global:
+                properties:
+                  applyPolicy:
+                    properties:
+                      exportPolicy:
+                        properties:
+                          defaultAction:
+                            type: string
+                          name:
+                            type: string
+                          policies:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      importPolicy:
+                        properties:
+                          defaultAction:
+                            type: string
+                          name:
+                            type: string
+                          policies:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  asn:
+                    description: ASN is the Autonomous System Number for this BGP speaker
+                    format: int32
+                    type: integer
+                  bindToDevice:
+                    type: string
+                  confederation:
+                    properties:
+                      enabled:
+                        type: boolean
+                      identifier:
+                        format: int32
+                        type: integer
+                      memberAsList:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                    type: object
+                  defaultRouteDistance:
+                    properties:
+                      externalRouteDistance:
+                        format: int32
+                        type: integer
+                      internalRouteDistance:
+                        format: int32
+                        type: integer
+                    type: object
+                  families:
+                    items:
+                      type: string
+                    type: array
+                  gracefulRestart:
+                    properties:
+                      enabled:
+                        type: boolean
+                      helperOnly:
+                        type: boolean
+                      restartTime:
+                        format: int32
+                        type: integer
+                    type: object
+                  listenAddresses:
+                    items:
+                      type: string
+                    type: array
+                  listenPort:
+                    format: int32
+                    type: integer
+                  routeSelectionOptions:
+                    properties:
+                      advertiseInactiveRoutes:
+                        type: boolean
+                      alwaysCompareMed:
+                        type: boolean
+                    type: object
+                  routerID:
+                    description: |-
+                      RouterID is the BGP router identifier. Must be a valid IPv4 address.
+                      Supports three resolution modes:
+                      1. Explicit IPv4: "192.168.1.1" - used as-is
+                      2. Template variable: "${NODE_IP}", "${NODE_IPV4}", "${NODE_EXTERNAL_IP}",
+                         or "${node.annotations['key']}" - resolved from node
+                      3. Auto-detect: when omitted, auto-detects from node's internal IPv4,
+                         or generates from node name hash if no IPv4 available
+                    type: string
+                  routerIDPool:
+                    description: |-
+                      RouterIDPool is the CIDR pool for hash-based router ID generation.
+                      Used when RouterID is omitted and node has no IPv4 address (IPv6-only nodes).
+                      Must be at least /24 (256 addresses). Each cluster should use a unique pool.
+                      Default: "10.255.0.0/16"
+                    type: string
+                  useMultiplePaths:
+                    type: boolean
+                required:
+                - asn
+                type: object
+              neighbors:
+                items:
+                  properties:
+                    afiSafis:
+                      items:
+                        properties:
+                          addPaths:
+                            properties:
+                              receive:
+                                type: boolean
+                              sendMax:
+                                format: int32
+                                type: integer
+                            type: object
+                          enabled:
+                            type: boolean
+                          family:
+                            type: string
+                          prefixLimit:
+                            properties:
+                              maxPrefixes:
+                                format: int32
+                                type: integer
+                              shutdownThresholdPct:
+                                format: int32
+                                type: integer
+                            required:
+                            - maxPrefixes
+                            type: object
+                        required:
+                        - enabled
+                        - family
+                        type: object
+                      type: array
+                    applyPolicy:
+                      properties:
+                        exportPolicy:
+                          properties:
+                            defaultAction:
+                              type: string
+                            name:
+                              type: string
+                            policies:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        importPolicy:
+                          properties:
+                            defaultAction:
+                              type: string
+                            name:
+                              type: string
+                            policies:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    config:
+                      properties:
+                        adminDown:
+                          type: boolean
+                        authPassword:
+                          description: 'AuthPassword is the BGP authentication password (DEPRECATED: use AuthPasswordSecretRef instead)'
+                          type: string
+                        authPasswordSecretRef:
+                          description: |-
+                            AuthPasswordSecretRef references a Secret containing the BGP authentication password
+                            The Secret must contain a key matching the neighbor address or a default key "password"
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        description:
+                          type: string
+                        localAsn:
+                          format: int32
+                          type: integer
+                        neighborAddress:
+                          type: string
+                        neighborInterface:
+                          type: string
+                        peerAsn:
+                          format: int32
+                          type: integer
+                        peerGroup:
+                          type: string
+                        vrf:
+                          type: string
+                      required:
+                      - peerAsn
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either neighborAddress or neighborInterface must be set
+                        rule: self.neighborAddress != '' || self.neighborInterface != ''
+                    ebgpMultihop:
+                      properties:
+                        enabled:
+                          type: boolean
+                        multihopTtl:
+                          format: int32
+                          type: integer
+                      required:
+                      - enabled
+                      type: object
+                    gracefulRestart:
+                      properties:
+                        enabled:
+                          type: boolean
+                        helperOnly:
+                          type: boolean
+                        restartTime:
+                          format: int32
+                          type: integer
+                      type: object
+                    nodeSelector:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    routeReflector:
+                      properties:
+                        routeReflectorClient:
+                          type: boolean
+                        routeReflectorClusterId:
+                          type: string
+                      required:
+                      - routeReflectorClient
+                      - routeReflectorClusterId
+                      type: object
+                    timers:
+                      properties:
+                        config:
+                          properties:
+                            connectRetry:
+                              format: int64
+                              type: integer
+                            holdTime:
+                              format: int64
+                              type: integer
+                            keepaliveInterval:
+                              format: int64
+                              type: integer
+                            minimumAdvertisementInterval:
+                              format: int64
+                              type: integer
+                          type: object
+                      required:
+                      - config
+                      type: object
+                    transport:
+                      properties:
+                        bindInterface:
+                          type: string
+                        localAddress:
+                          type: string
+                        passiveMode:
+                          type: boolean
+                      type: object
+                  required:
+                  - config
+                  type: object
+                type: array
+              netlinkExport:
+                description: NetlinkExport configures global netlink export for exporting BGP routes to Linux kernel
+                properties:
+                  dampeningInterval:
+                    description: 'DampeningInterval in milliseconds to prevent flapping (default: 100)'
+                    format: int32
+                    type: integer
+                  enabled:
+                    description: Enabled activates netlink export functionality
+                    type: boolean
+                  routeProtocol:
+                    description: 'RouteProtocol is the Linux route protocol identifier (default: 186 = RTPROT_BGP)'
+                    format: int32
+                    type: integer
+                  rules:
+                    description: Rules defines export rules for matching and exporting routes
+                    items:
+                      description: NetlinkExportRule defines a rule for exporting routes to Linux kernel
+                      properties:
+                        communityList:
+                          description: 'CommunityList filters routes by standard BGP communities (format: "AS:VALUE" where AS and VALUE are 0-65535)'
+                          items:
+                            pattern: ^\d{1,5}:\d{1,5}$
+                            type: string
+                          type: array
+                        largeCommunityList:
+                          description: 'LargeCommunityList filters routes by large BGP communities (format: "ASN:LocalData1:LocalData2")'
+                          items:
+                            pattern: ^\d+:\d+:\d+$
+                            type: string
+                          type: array
+                        metric:
+                          description: 'Metric is the route metric/priority in Linux routing table (default: 20)'
+                          format: int32
+                          type: integer
+                        name:
+                          description: Name is a unique identifier for this export rule
+                          type: string
+                        tableId:
+                          description: TableId is the Linux routing table ID (0 = main table)
+                          format: int32
+                          type: integer
+                        validateNexthop:
+                          description: 'ValidateNexthop enables nexthop reachability validation before exporting (default: true)'
+                          type: boolean
+                        vrf:
+                          description: Vrf is the target VRF name (empty = global routing table)
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              netlinkImport:
+                description: NetlinkImport configures global netlink import for importing connected routes
+                properties:
+                  enabled:
+                    description: Enabled activates netlink import functionality
+                    type: boolean
+                  interfaceList:
+                    description: InterfaceList specifies interfaces to import routes from (supports glob patterns like "eth*")
+                    items:
+                      type: string
+                    type: array
+                  vrf:
+                    description: Vrf specifies the VRF to import routes into (empty = global RIB)
+                    type: string
+                type: object
+              peerGroups:
+                items:
+                  properties:
+                    afiSafis:
+                      items:
+                        properties:
+                          addPaths:
+                            properties:
+                              receive:
+                                type: boolean
+                              sendMax:
+                                format: int32
+                                type: integer
+                            type: object
+                          enabled:
+                            type: boolean
+                          family:
+                            type: string
+                          prefixLimit:
+                            properties:
+                              maxPrefixes:
+                                format: int32
+                                type: integer
+                              shutdownThresholdPct:
+                                format: int32
+                                type: integer
+                            required:
+                            - maxPrefixes
+                            type: object
+                        required:
+                        - enabled
+                        - family
+                        type: object
+                      type: array
+                    applyPolicy:
+                      properties:
+                        exportPolicy:
+                          properties:
+                            defaultAction:
+                              type: string
+                            name:
+                              type: string
+                            policies:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        importPolicy:
+                          properties:
+                            defaultAction:
+                              type: string
+                            name:
+                              type: string
+                            policies:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    config:
+                      properties:
+                        authPassword:
+                          description: 'AuthPassword is the BGP authentication password (DEPRECATED: use AuthPasswordSecretRef instead)'
+                          type: string
+                        authPasswordSecretRef:
+                          description: AuthPasswordSecretRef references a Secret containing the BGP authentication password
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        description:
+                          type: string
+                        localAsn:
+                          format: int32
+                          type: integer
+                        peerAsn:
+                          format: int32
+                          type: integer
+                        peerGroupName:
+                          type: string
+                      required:
+                      - peerGroupName
+                      type: object
+                    nodeSelector:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    timers:
+                      properties:
+                        config:
+                          properties:
+                            connectRetry:
+                              format: int64
+                              type: integer
+                            holdTime:
+                              format: int64
+                              type: integer
+                            keepaliveInterval:
+                              format: int64
+                              type: integer
+                            minimumAdvertisementInterval:
+                              format: int64
+                              type: integer
+                          type: object
+                      required:
+                      - config
+                      type: object
+                    transport:
+                      properties:
+                        bindInterface:
+                          type: string
+                        localAddress:
+                          type: string
+                        passiveMode:
+                          type: boolean
+                      type: object
+                  required:
+                  - config
+                  type: object
+                type: array
+              policyDefinitions:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    statements:
+                      items:
+                        properties:
+                          actions:
+                            properties:
+                              asPrepend:
+                                properties:
+                                  asn:
+                                    format: int32
+                                    type: integer
+                                  repeat:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - asn
+                                type: object
+                              community:
+                                properties:
+                                  communities:
+                                    items:
+                                      type: string
+                                    type: array
+                                  type:
+                                    type: string
+                                required:
+                                - communities
+                                - type
+                                type: object
+                              localPref:
+                                format: int32
+                                type: integer
+                              med:
+                                properties:
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int64
+                                    type: integer
+                                required:
+                                - type
+                                - value
+                                type: object
+                              routeAction:
+                                type: string
+                            required:
+                            - routeAction
+                            type: object
+                          conditions:
+                            properties:
+                              asPathSet:
+                                properties:
+                                  match:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              communitySet:
+                                properties:
+                                  match:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              neighborSet:
+                                properties:
+                                  match:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              prefixSet:
+                                properties:
+                                  match:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              rpkiResult:
+                                type: string
+                            type: object
+                          name:
+                            type: string
+                        required:
+                        - actions
+                        - conditions
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - statements
+                  type: object
+                type: array
+              vrfs:
+                items:
+                  properties:
+                    exportRt:
+                      items:
+                        type: string
+                      type: array
+                    importRt:
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    netlinkExport:
+                      description: VrfNetlinkExport configures netlink export for a specific VRF
+                      properties:
+                        communityList:
+                          description: 'CommunityList filters routes by standard BGP communities (format: "AS:VALUE" where AS and VALUE are 0-65535)'
+                          items:
+                            pattern: ^\d{1,5}:\d{1,5}$
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enabled activates VRF-to-VRF export
+                          type: boolean
+                        largeCommunityList:
+                          description: 'LargeCommunityList filters routes by large BGP communities (format: "ASN:LocalData1:LocalData2")'
+                          items:
+                            pattern: ^\d+:\d+:\d+$
+                            type: string
+                          type: array
+                        linuxTableId:
+                          description: LinuxTableId is the target Linux routing table ID (auto-lookup from Linux VRF if not specified)
+                          format: int32
+                          type: integer
+                        linuxVrf:
+                          description: LinuxVrf is the target Linux VRF name (defaults to GoBGP VRF name)
+                          type: string
+                        metric:
+                          description: Metric is the route metric/priority in Linux routing table
+                          format: int32
+                          type: integer
+                        validateNexthop:
+                          description: 'ValidateNexthop enables nexthop reachability validation before exporting (default: true)'
+                          type: boolean
+                      type: object
+                    netlinkImport:
+                      description: VrfNetlinkImport configures netlink import for a specific VRF
+                      properties:
+                        enabled:
+                          description: Enabled activates netlink import for this VRF
+                          type: boolean
+                        interfaceList:
+                          description: InterfaceList specifies interfaces to import routes from (supports glob patterns)
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    rd:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - global
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations of the BGP configuration state
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              establishedNeighbors:
+                description: EstablishedNeighbors is the count of neighbors in Established state
+                type: integer
+              lastReconcileTime:
+                description: LastReconcileTime is the timestamp of the last reconciliation
+                format: date-time
+                type: string
+              message:
+                description: Message provides additional information about the current state
+                type: string
+              neighborCount:
+                description: NeighborCount is the number of configured BGP neighbors
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed by the controller
+                format: int64
+                type: integer
+              routerIDResolutionTime:
+                description: RouterIDResolutionTime is when the router ID was resolved
+                format: date-time
+                type: string
+              routerIDSource:
+                description: |-
+                  RouterIDSource indicates how the router ID was resolved:
+                  "explicit", "template", "node-ipv4", or "hash-from-node-name"
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/components/gobgp/gobgp-patch.yaml
+++ b/deployments/components/gobgp/gobgp-patch.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lbnodeagent
+  namespace: purelb-system
+spec:
+  template:
+    spec:
+      volumes:
+      - name: gobgp-socket
+        emptyDir: {}
+      containers:
+      - name: k8gobgp
+        image: ghcr.io/purelb/k8gobgp:0.2.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 7473
+          name: gobgp-metrics
+        - containerPort: 7474
+          name: gobgp-health
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7474
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_BIND_SERVICE
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        resources:
+          requests:
+            cpu: 250m
+            memory: 128Mi
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+        volumeMounts:
+        - name: gobgp-socket
+          mountPath: /var/run/gobgp

--- a/deployments/components/gobgp/gobgp-rbac.yaml
+++ b/deployments/components/gobgp/gobgp-rbac.yaml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: purelb
+  name: purelb:k8gobgp
+rules:
+- apiGroups:
+  - bgp.purelb.io
+  resources:
+  - configs
+  - configs/finalizers
+  - configs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: purelb
+  name: purelb:k8gobgp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: purelb:k8gobgp
+subjects:
+- kind: ServiceAccount
+  name: lbnodeagent
+  namespace: purelb-system

--- a/deployments/components/gobgp/kustomization.yaml
+++ b/deployments/components/gobgp/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- gobgp-bgpconfig-crd.yaml
+- gobgp-rbac.yaml
+
+patches:
+- path: gobgp-patch.yaml
+  target:
+    kind: DaemonSet
+    name: lbnodeagent

--- a/deployments/samples-with-gobgp/kustomization.yaml
+++ b/deployments/samples-with-gobgp/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../samples
+- sample-bgpconfig.yaml
+
+components:
+- ../components/gobgp

--- a/deployments/samples-with-gobgp/sample-bgpconfig.yaml
+++ b/deployments/samples-with-gobgp/sample-bgpconfig.yaml
@@ -1,0 +1,41 @@
+apiVersion: bgp.purelb.io/v1
+kind: BGPConfiguration
+metadata:
+  name: default
+  namespace: purelb-system
+spec:
+  global:
+    # Use a private ASN from range 64512-65534.
+    # All nodes share this ASN (eBGP topology: upstream router uses a different ASN).
+    asn: 65000
+    # Leave empty for auto-detection, OR set explicitly to node's
+    # BGP-facing IP to avoid ambiguity on multi-homed nodes (recommended).
+    routerID: ""
+    listenPort: 179
+    families:
+    - "ipv4-unicast"
+    - "ipv6-unicast"
+
+  # netlinkImport controls which kernel routes are imported into BGP for advertisement.
+  # REQUIRED: without this block, k8gobgp starts but advertises NO routes.
+  # For PureLB, restrict to kube-lb0 — the dummy interface where VIPs are placed.
+  # Importing from other interfaces is a custom configuration, not the default use case.
+  netlinkImport:
+    enabled: true
+    interfaceList:
+    - "kube-lb0"
+
+  neighbors:
+  - config:
+      # REQUIRED: Replace with your upstream BGP router's IP address.
+      neighborAddress: "192.0.2.1"
+      # REQUIRED: Replace with your upstream router's ASN (must differ from 'asn' above for eBGP).
+      peerAsn: 65001
+      description: "Upstream BGP router"
+    # Enable both IPv4 and IPv6 address families.
+    # Remove the ipv6-unicast entry if you only use IPv4 VIPs.
+    afiSafis:
+    - family: "ipv4-unicast"
+      enabled: true
+    - family: "ipv6-unicast"
+      enabled: true

--- a/deployments/with-gobgp/kustomization.yaml
+++ b/deployments/with-gobgp/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../default
+
+components:
+- ../components/gobgp

--- a/docs/GOBGP_INTEGRATION_PLAN.md
+++ b/docs/GOBGP_INTEGRATION_PLAN.md
@@ -1,0 +1,728 @@
+# Plan: Split PureLB Installation — Base vs. With k8gobgp
+
+## Context
+
+PureLB currently ships a single installation variant. Users who want BGP route announcement (via k8gobgp) must set it up manually and separately. The goal is to provide official "with k8gobgp" variants of all three installation mechanisms — kustomize install-manifest, kustomize manifest-with-samples, and Helm chart — while leaving the existing base variants 100% unchanged.
+
+k8gobgp (https://github.com/purelb/k8gobgp) is a Kubernetes controller that manages GoBGP daemon(s) via a `BGPConfiguration` CRD (`bgp.purelb.io`). It will run as a **sidecar** in the existing `lbnodeagent` DaemonSet pod, which already has `hostNetwork: true`, so it inherits the host network namespace automatically. Configuration is declarative via Kubernetes CRs — no ConfigMap needed.
+
+## Key Facts About k8gobgp
+
+- **Image**: `ghcr.io/purelb/k8gobgp:v0.2.2` (pinned; separate release cadence from PureLB)
+- **Configuration**: Via `BGPConfiguration` CRD (`bgp.purelb.io`), NOT a ConfigMap
+- **Capabilities required**: `NET_ADMIN`, `NET_BIND_SERVICE`, `NET_RAW`
+- **Environment variables**: `NODE_NAME`, `POD_NAME`, `POD_NAMESPACE` (downward API)
+- **Ports**: 179 (BGP), 7473 (metrics), 7474 (health probes) — defaults changed in k8gobgp repo (see prerequisite below)
+- **Unix socket**: `/var/run/gobgp/gobgp.sock` — shared `emptyDir` volume within the pod
+- **RBAC**: Needs its own ClusterRole (bgp.purelb.io/configs, nodes, secrets, pods, events)
+- **BGPConfiguration CRD** must be installed alongside the PureLB CRDs
+
+## Deployment Prerequisites
+
+These must be documented at install time (not enforced by manifests):
+
+1. **k8gobgp repo must be updated first** — change `--metrics-bind-address` default from `:8080` to `:7473` and `--health-probe-bind-address` default from `:8081` to `:7474` in the k8gobgp source. Cut a new release and update `GOBGP_TAG` here before implementing. Port 8080 is unsafe for `hostNetwork: true` pods; 7473/7474 keep all PureLB-related ports in a consistent range alongside lbnodeagent's 7472.
+2. **Port 179 must be available** on every node — no other BGP daemon (Calico BGP, BIRD, FRR, Cilium BGP) may be listening on port 179. k8gobgp binds to `0.0.0.0:179` in the host network namespace; `bind()` will fail with EADDRINUSE if another process owns that port.
+3. **Firewall/iptables must allow port 179** ingress and egress between cluster nodes and the upstream BGP router. Verify with `nc -zv <router-ip> 179` from a node.
+4. **Upstream router must be configured** to peer with each node's IP at the agreed ASN before BGP sessions can establish.
+5. **ECMP must be enabled** on the upstream router if multi-node load distribution is desired.
+
+## Route Filtering
+
+Netlink import is **disabled by default** in k8gobgp. Routes are only imported when `netlinkImport.enabled: true` is set in the BGPConfiguration CR, and only from interfaces listed in `interfaceList`. The default sample CR explicitly sets `interfaceList: ["kube-lb0"]`, so only PureLB VIPs are advertised. Importing routes from other interfaces (e.g., eth0, cluster CIDRs, default route) requires deliberately adding those interfaces to the list — there is no route leakage risk with the default configuration.
+
+## RBAC Strategy for the Sidecar
+
+A Kubernetes pod has exactly **one** ServiceAccount. k8gobgp running in the lbnodeagent pod gains k8s API access via an additional binding — clean and additive:
+
+1. Create a **new** `ClusterRole purelb:k8gobgp` with k8gobgp's specific rules
+2. Create a **new** `ClusterRoleBinding purelb:k8gobgp` binding that role to the existing `lbnodeagent` ServiceAccount
+3. No modifications to the existing `purelb:lbnodeagent` ClusterRole or ClusterRoleBinding
+
+---
+
+## Implementation Plan
+
+### Option Chosen: Kustomize Component + Single Helm Chart with Feature Flag
+
+**Rejected alternatives:**
+- Two separate Helm charts — duplicates all templates, high maintenance cost
+- Simple overlay (no Component) — cannot be composed into custom user overlays; patch duplication across `with-gobgp/` and `samples-with-gobgp/`
+
+---
+
+### 1. New Directory/File Structure
+
+```
+deployments/
+  components/
+    gobgp/
+      kustomization.yaml           # Component declaration (kind: Component)
+      gobgp-patch.yaml             # Strategic merge patch: adds sidecar to lbnodeagent DaemonSet
+      gobgp-rbac.yaml              # ClusterRole + ClusterRoleBinding for k8gobgp
+      gobgp-bgpconfig-crd.yaml     # BGPConfiguration CRD (fetched via make fetch-gobgp-crd)
+  with-gobgp/
+    kustomization.yaml             # Overlay: default + gobgp component
+  samples-with-gobgp/
+    kustomization.yaml             # Overlay: samples + gobgp component
+    sample-bgpconfig.yaml          # Sample BGPConfiguration CR (IPv4 + IPv6)
+
+build/helm/purelb/
+  templates/
+    gobgp-rbac.yaml                # New: conditional RBAC for k8gobgp
+    gobgp-metrics-service.yaml     # New: conditional metrics Service (gated on gobgp.enabled AND Prometheus.lbnodeagent.Metrics.enabled)
+    (daemonset.yaml modified)      # Add conditional sidecar container + emptyDir volume
+  values.yaml                      # Add gobgp: stanza
+```
+
+Makefile: two new build targets + one CRD-fetch utility target.
+CI: `.github/workflows/ci.yml` updated for gobgp release artifacts.
+
+---
+
+### 2. `deployments/components/gobgp/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- gobgp-bgpconfig-crd.yaml
+- gobgp-rbac.yaml
+
+patches:
+- path: gobgp-patch.yaml
+  target:
+    kind: DaemonSet
+    name: lbnodeagent
+```
+
+`kind: Component` (not `Kustomization`) is required. Components cannot be built standalone — they only apply when composed into an overlay.
+
+---
+
+### 3. `deployments/components/gobgp/gobgp-patch.yaml`
+
+Strategic merge patch. Kubernetes merges `containers:` lists by `name` key — the new `k8gobgp` container appends cleanly without touching the existing `lbnodeagent` container. The `volumes:` key is also additive.
+
+**Note on image tags**: The image here is the default pinned version. The Makefile runs `kustomize edit set image ghcr.io/purelb/k8gobgp=...` in the overlay's kustomization.yaml, which adds an `images:` override that Kustomize applies by matching the image name (ignoring the tag in the patch). This is the standard Kustomize image override mechanism — the overlay's `images:` stanza takes precedence over the patch's hardcoded tag at build time.
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lbnodeagent
+  namespace: purelb-system
+spec:
+  template:
+    spec:
+      volumes:
+      - name: gobgp-socket
+        emptyDir: {}
+      containers:
+      - name: k8gobgp
+        image: ghcr.io/purelb/k8gobgp:v0.2.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 7473
+          name: gobgp-metrics
+        - containerPort: 7474
+          name: gobgp-health
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12   # 60s total startup window
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7474
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_BIND_SERVICE
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        resources:
+          requests:
+            cpu: 250m
+            memory: 128Mi
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+        volumeMounts:
+        - name: gobgp-socket
+          mountPath: /var/run/gobgp
+```
+
+---
+
+### 4. `deployments/components/gobgp/gobgp-rbac.yaml`
+
+Additive RBAC — binds to the existing `lbnodeagent` ServiceAccount, no changes to existing roles.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: purelb
+  name: purelb:k8gobgp
+rules:
+- apiGroups:
+  - bgp.purelb.io
+  resources:
+  - configs
+  - configs/finalizers
+  - configs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: purelb
+  name: purelb:k8gobgp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: purelb:k8gobgp
+subjects:
+- kind: ServiceAccount
+  name: lbnodeagent
+  namespace: purelb-system
+```
+
+---
+
+### 5. `deployments/components/gobgp/gobgp-bgpconfig-crd.yaml`
+
+Generated by `make fetch-gobgp-crd` (see Makefile section). Do not edit manually. Contains only the `CustomResourceDefinition` for `bgp.purelb.io` extracted from the k8gobgp v0.2.2 release.
+
+---
+
+### 6. `deployments/with-gobgp/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../default
+
+components:
+- ../components/gobgp
+```
+
+---
+
+### 7. `deployments/samples-with-gobgp/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../samples
+- sample-bgpconfig.yaml
+
+components:
+- ../components/gobgp
+```
+
+---
+
+### 8. `deployments/samples-with-gobgp/sample-bgpconfig.yaml`
+
+Includes both IPv4 and IPv6 address families. `routerId` left empty for auto-detection; **operators should explicitly set it to the node's BGP-facing IP** if nodes have multiple network interfaces to avoid ambiguity.
+
+```yaml
+apiVersion: bgp.purelb.io/v1
+kind: BGPConfiguration
+metadata:
+  name: default
+  namespace: purelb-system
+spec:
+  global:
+    config:
+      # Use a private ASN from range 64512-65534.
+      # All nodes share this ASN (eBGP topology: upstream router uses a different ASN).
+      as: 65000
+      # Leave empty for auto-detection from NODE_NAME, OR set explicitly to node's
+      # BGP-facing IP to avoid ambiguity on multi-homed nodes (recommended).
+      routerId: ""
+
+  # netlinkImport controls which kernel routes are imported into BGP for advertisement.
+  # REQUIRED: without this block, k8gobgp starts but advertises NO routes.
+  # For PureLB, restrict to kube-lb0 — the dummy interface where VIPs are placed.
+  # Importing from other interfaces is a custom configuration, not the default use case.
+  netlinkImport:
+    enabled: true
+    interfaceList:
+    - "kube-lb0"
+
+  neighbors:
+  - config:
+      # REQUIRED: Replace with your upstream BGP router's IP address.
+      neighborAddress: 192.0.2.1
+      # REQUIRED: Replace with your upstream router's ASN (must differ from 'as' above for eBGP).
+      peerAs: 65001
+    # Enable both IPv4 and IPv6 address families.
+    # Remove the ipv6-unicast entry if you only use IPv4 VIPs.
+    afiSafis:
+    - config:
+        family:
+          afi: AFI_IP
+          safi: SAFI_UNICAST
+    - config:
+        family:
+          afi: AFI_IP6
+          safi: SAFI_UNICAST
+```
+
+---
+
+### 9. Makefile Additions
+
+**New variables** (add near top with other defaults):
+```makefile
+GOBGP_IMAGE ?= ghcr.io/purelb/k8gobgp
+GOBGP_TAG   ?= v0.2.2
+```
+
+**New targets** (insert after existing `install-manifest` and `manifest` targets):
+
+```makefile
+.ONESHELL:
+.PHONY: install-manifest-gobgp
+install-manifest-gobgp: CACHE != mktemp
+install-manifest-gobgp: crd  ## Generate standalone install.yaml with k8gobgp sidecar
+	cd deployments/with-gobgp
+	cp kustomization.yaml ${CACHE}
+	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX} ghcr.io/purelb/k8gobgp=${GOBGP_IMAGE}:${GOBGP_TAG}
+	$(KUSTOMIZE) build . > ../install-gobgp-${MANIFEST_SUFFIX}.yaml
+	cp ${CACHE} kustomization.yaml
+
+.ONESHELL:
+.PHONY: manifest-gobgp
+manifest-gobgp: CACHE != mktemp
+manifest-gobgp:  ## Generate deployment manifest with samples and k8gobgp sidecar
+	cd deployments/samples-with-gobgp
+	cp kustomization.yaml ${CACHE}
+	$(KUSTOMIZE) edit set image ghcr.io/purelb/purelb/allocator=${REGISTRY_IMAGE}/allocator:${SUFFIX} ghcr.io/purelb/purelb/lbnodeagent=${REGISTRY_IMAGE}/lbnodeagent:${SUFFIX} ghcr.io/purelb/k8gobgp=${GOBGP_IMAGE}:${GOBGP_TAG}
+	$(KUSTOMIZE) build . > ../${PROJECT}-gobgp-${MANIFEST_SUFFIX}.yaml
+	cp ${CACHE} kustomization.yaml
+
+.PHONY: fetch-gobgp-crd
+fetch-gobgp-crd:  ## Fetch BGPConfiguration CRD from k8gobgp ${GOBGP_TAG} release
+	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \
+	  | go run sigs.k8s.io/kustomize/kustomize/v4@v4.5.2 cfg grep "kind=CustomResourceDefinition" \
+	  > deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
+```
+
+**Update `helm` target** — add CRD fetch step after copying PureLB CRDs:
+```makefile
+helm:  ## Package PureLB using Helm
+	rm -rf build/build
+	mkdir -p build/build
+	cp -r build/helm/purelb build/build/
+	cp deployments/crds/purelb.io_*.yaml build/build/purelb/crds
+	# Bundle BGPConfiguration CRD so `gobgp.enabled=true` works without a separate CRD install
+	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \
+	  | go run sigs.k8s.io/kustomize/kustomize/v4@v4.5.2 cfg grep "kind=CustomResourceDefinition" \
+	  > build/build/purelb/crds/bgp.purelb.io_bgpconfigurations.yaml
+	cp README.md build/build/purelb
+	sed \
+	--expression="s~DEFAULT_REPO~${REGISTRY_IMAGE}~" \
+	--expression="s~DEFAULT_TAG~${SUFFIX}~" \
+	build/helm/purelb/values.yaml > build/build/purelb/values.yaml
+	${HELM} package \
+	--version "${SUFFIX}" --app-version "${SUFFIX}" \
+	build/build/purelb
+```
+
+Output files:
+- `deployments/install-gobgp-${SUFFIX}.yaml`
+- `deployments/${PROJECT}-gobgp-${SUFFIX}.yaml`
+
+---
+
+### 10. CI/CD: `.github/workflows/ci.yml` Changes
+
+Add two steps immediately after the existing "Generate install manifest" step:
+
+```yaml
+      - name: Generate manifests (with k8gobgp)
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+          GOBGP_TAG: v0.2.2
+        run: make manifest-gobgp
+
+      - name: Generate install manifest (with k8gobgp)
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+          GOBGP_TAG: v0.2.2
+        run: make install-manifest-gobgp
+```
+
+Update the "Generate checksums" step:
+```yaml
+      - name: Generate checksums
+        run: |
+          sha256sum purelb-${{ github.ref_name }}.tgz > SHA256SUMS
+          sha256sum deployments/purelb-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/install-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/purelb-gobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/install-gobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
+```
+
+Update the "Create Release" step files list:
+```yaml
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            purelb-${{ github.ref_name }}.tgz
+            deployments/purelb-${{ github.ref_name }}.yaml
+            deployments/install-${{ github.ref_name }}.yaml
+            deployments/purelb-gobgp-${{ github.ref_name }}.yaml
+            deployments/install-gobgp-${{ github.ref_name }}.yaml
+            SHA256SUMS
+          generate_release_notes: true
+```
+
+---
+
+### 11. Helm Chart — `values.yaml` Additions
+
+Add at end of `build/helm/purelb/values.yaml`:
+
+```yaml
+# k8gobgp sidecar — per-node BGP route announcement for remote VIPs.
+# When enabled, k8gobgp runs as a sidecar in the lbnodeagent DaemonSet pod.
+# It shares hostNetwork:true and announces VIP routes to upstream BGP routers.
+#
+# Prerequisites:
+#   - Port 179 must be free on every node (no other BGP daemon running).
+#   - Firewall must allow TCP 179 between nodes and upstream router.
+#   - Apply a BGPConfiguration CR after install to configure peers/ASNs.
+#   - Upstream router must be configured to peer with each node IP.
+gobgp:
+  enabled: false
+
+  image:
+    repository: ghcr.io/purelb/k8gobgp
+    tag: v0.2.2
+    pullPolicy: IfNotPresent
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      add:
+      - NET_ADMIN
+      - NET_BIND_SERVICE
+      - NET_RAW
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+```
+
+---
+
+### 12. Helm Template — `daemonset.yaml` Changes
+
+Two additions inside the existing pod `spec:` block:
+
+**a) After the `tolerations` block, add the shared emptyDir volume:**
+```yaml
+      {{- if .Values.gobgp.enabled }}
+      volumes:
+      - name: gobgp-socket
+        emptyDir: {}
+      {{- end }}
+```
+
+**b) After the closing of the lbnodeagent container spec, add the sidecar:**
+```yaml
+      {{- if .Values.gobgp.enabled }}
+      - name: k8gobgp
+        image: "{{ .Values.gobgp.image.repository }}:{{ .Values.gobgp.image.tag }}"
+        imagePullPolicy: {{ .Values.gobgp.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 7473
+          name: gobgp-metrics
+        - containerPort: 7474
+          name: gobgp-health
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7474
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 7474
+        {{- with .Values.gobgp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- with .Values.gobgp.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        volumeMounts:
+        - name: gobgp-socket
+          mountPath: /var/run/gobgp
+      {{- end }}
+```
+
+---
+
+### 13. Helm Template — `gobgp-rbac.yaml` (new file)
+
+```yaml
+{{- if .Values.gobgp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["bgp.purelb.io"]
+  resources: ["configs", "configs/finalizers", "configs/status"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "purelb.fullname" . }}:k8gobgp
+subjects:
+- kind: ServiceAccount
+  name: lbnodeagent
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+```
+
+---
+
+### 14. Helm Template — `gobgp-metrics-service.yaml` (new file)
+
+Gated on **both** `gobgp.enabled` AND `Prometheus.lbnodeagent.Metrics.enabled` — consistent with the existing `service-metrics-lbnodeagent.yaml` pattern. In kustomize, lbnodeagent metrics use pod annotation-based discovery only (no Service); we follow the same convention for k8gobgp — no metrics Service in the kustomize path.
+
+```yaml
+{{- if and .Values.gobgp.enabled .Values.Prometheus.lbnodeagent.Metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "purelb.fullname" . }}-k8gobgp-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "purelb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: k8gobgp
+spec:
+  selector:
+    {{- include "purelb.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: lbnodeagent
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 7473
+    targetPort: 7473
+    protocol: TCP
+{{- end }}
+```
+
+---
+
+## Implementation Order
+
+**Step 1** (prerequisite): Update k8gobgp repo — change `--metrics-bind-address` default to `:7473` and `--health-probe-bind-address` to `:7474`, cut a new release, update `GOBGP_TAG` here.
+
+**Step 2**: `make fetch-gobgp-crd` — generates `deployments/components/gobgp/gobgp-bgpconfig-crd.yaml`.
+
+**Steps 3+**: Implement remaining files per the plan above.
+
+---
+
+## Critical Files to Modify
+
+| File | Change |
+|------|--------|
+| `Makefile` | Add `GOBGP_IMAGE`, `GOBGP_TAG` vars; add `install-manifest-gobgp`, `manifest-gobgp`, `fetch-gobgp-crd` targets; update `helm` target to bundle BGPConfiguration CRD |
+| `build/helm/purelb/values.yaml` | Add `gobgp:` stanza |
+| `build/helm/purelb/templates/daemonset.yaml` | Add conditional sidecar container + emptyDir volume |
+| `.github/workflows/ci.yml` | Add gobgp manifest generation + checksums + release artifact upload |
+
+## New Files to Create
+
+| File | Purpose |
+|------|---------|
+| `deployments/components/gobgp/kustomization.yaml` | Kustomize Component declaration |
+| `deployments/components/gobgp/gobgp-patch.yaml` | Strategic merge patch for lbnodeagent DaemonSet |
+| `deployments/components/gobgp/gobgp-rbac.yaml` | ClusterRole + ClusterRoleBinding for k8gobgp |
+| `deployments/components/gobgp/gobgp-bgpconfig-crd.yaml` | BGPConfiguration CRD (generated by `make fetch-gobgp-crd`) |
+| `deployments/with-gobgp/kustomization.yaml` | Overlay: default + gobgp component |
+| `deployments/samples-with-gobgp/kustomization.yaml` | Overlay: samples + gobgp component |
+| `deployments/samples-with-gobgp/sample-bgpconfig.yaml` | Sample BGPConfiguration CR (IPv4 + IPv6) |
+| `build/helm/purelb/templates/gobgp-rbac.yaml` | Helm conditional RBAC template |
+| `build/helm/purelb/templates/gobgp-metrics-service.yaml` | Helm conditional metrics Service (requires gobgp.enabled AND Prometheus.lbnodeagent.Metrics.enabled) |
+
+## Verification
+
+### Offline (no cluster required)
+1. `make fetch-gobgp-crd` — downloads CRD; verify file is valid YAML with `kind: CustomResourceDefinition`
+2. `make install-manifest` — output **identical** to pre-change baseline (regression)
+3. `make manifest` — output **identical** to pre-change baseline (regression)
+4. `make install-manifest-gobgp` — output contains: BGPConfiguration CRD, k8gobgp ClusterRole/Binding, lbnodeagent DaemonSet with 2 containers
+5. `make manifest-gobgp` — same as above plus sample ServiceGroup, sample BGPConfiguration CR
+6. `make helm` — `helm lint build/build/purelb` passes; `helm template . --set gobgp.enabled=false` identical to baseline; `helm template . --set gobgp.enabled=true` contains 2 containers, RBAC, metrics Service
+
+### On test cluster — Kustomize install-manifest-gobgp (prox-purelb2)
+7. `kubectl apply -f deployments/install-gobgp-${SUFFIX}.yaml` — all pods reach Running state
+8. `kubectl get pods -n purelb-system -l component=lbnodeagent -o jsonpath='{.items[*].spec.containers[*].name}'` — shows `lbnodeagent k8gobgp` for every pod
+9. `kubectl exec -n purelb-system <pod> -c k8gobgp -- curl -sf http://localhost:7474/readyz` — returns 200
+10. `kubectl get clusterrole purelb:k8gobgp && kubectl get clusterrolebinding purelb:k8gobgp` — exist
+11. Apply sample BGPConfiguration CR — verify BGP sessions establish with FRR router (`vtysh -c 'show bgp summary'`)
+12. **Route filtering check**: `gobgp global rib` from k8gobgp container — confirm only kube-lb0 routes present
+13. Deploy a test LoadBalancer Service — confirm VIP route appears on FRR router; delete service — confirm route withdraws
+14. **readOnlyRootFilesystem test**: check k8gobgp logs for any "read-only file system" errors over 5 minutes of operation
+15. Clean up: `kubectl delete -f deployments/install-gobgp-${SUFFIX}.yaml`
+
+### On test cluster — Kustomize manifest-gobgp (prox-purelb2)
+16. `kubectl apply -f deployments/${PROJECT}-gobgp-${SUFFIX}.yaml` — all pods Running, sample BGPConfiguration CR applied
+17. Verify same pod/container/RBAC checks as items 8-10
+18. Verify sample BGPConfiguration CR is present: `kubectl get bgpconfigurations.bgp.purelb.io -n purelb-system`
+19. Verify sample ServiceGroup is present: `kubectl get servicegroups.purelb.io -n purelb-system`
+20. Deploy a test LoadBalancer Service — confirm VIP allocation and BGP route advertisement
+21. Clean up: `kubectl delete -f deployments/${PROJECT}-gobgp-${SUFFIX}.yaml`
+
+### On test cluster — Helm with gobgp.enabled=true (prox-purelb2)
+22. `helm install --create-namespace --namespace=purelb-system purelb ./build/build/purelb --set gobgp.enabled=true` — all pods Running
+23. Verify same pod/container/RBAC checks as items 8-10
+24. `kubectl get svc -n purelb-system` — verify k8gobgp-metrics Service exists (only in Helm path, gated on Prometheus.lbnodeagent.Metrics.enabled)
+25. Verify BGPConfiguration CRD is installed: `kubectl get crd bgpconfigurations.bgp.purelb.io`
+26. Apply a BGPConfiguration CR, deploy test LoadBalancer Service — confirm VIP route advertisement
+27. **Helm upgrade test**: `helm upgrade purelb ./build/build/purelb --set gobgp.enabled=false -n purelb-system` — verify k8gobgp sidecar is removed, RBAC cleaned up, lbnodeagent pod restarts with single container
+28. **Helm re-enable**: `helm upgrade purelb ./build/build/purelb --set gobgp.enabled=true -n purelb-system` — verify sidecar returns, RBAC recreated
+29. Clean up: `helm uninstall purelb -n purelb-system`
+
+### On test cluster — Base install regression (local-kvm or prox-purelb2)
+30. `make install-manifest` then `kubectl apply -f deployments/install-${SUFFIX}.yaml` — verify lbnodeagent pods have **only 1 container** (no k8gobgp), no k8gobgp RBAC exists, no BGPConfiguration CRD installed
+31. `helm install purelb ./build/build/purelb -n purelb-system` (without `--set gobgp.enabled=true`) — verify same: single container, no k8gobgp resources
+
+## Notes
+
+- k8gobgp pinned to `v0.2.2` (latest as of 2026-03-30). To upgrade: bump `GOBGP_TAG`, run `make fetch-gobgp-crd`, re-run `make helm` and manifest targets.
+- The BGPConfiguration CRD is bundled in both kustomize and Helm — operators do NOT need a separate k8gobgp install.
+- k8gobgp runs in `purelb-system` (not `k8gobgp-system`). This is intentional for the sidecar model.
+- **Metrics pattern**: Kustomize uses pod annotation-based Prometheus discovery (`prometheus.io/port: '7472'`) — no Service needed and none is added. The k8gobgp port 7473 is only exposed via a Service in Helm, gated on `Prometheus.lbnodeagent.Metrics.enabled`, matching the existing `service-metrics-lbnodeagent.yaml` pattern.
+- **Port consistency**: lbnodeagent=7472, k8gobgp-metrics=7473, k8gobgp-health=7474. All PureLB-related ports in a consistent range. Port 179 is BGP standard (reserved on host).

--- a/internal/election/election_test.go
+++ b/internal/election/election_test.go
@@ -963,7 +963,7 @@ func TestRebuildMapsFiltersExpiredLeases(t *testing.T) {
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       ptr.To("node-a"),
-			LeaseDurationSeconds: ptr.To(int32(10)),
+			LeaseDurationSeconds: ptr.To(int32(300)), // Long duration so fresh lease doesn't expire during slow CI
 			RenewTime:            &freshRenewTime,
 		},
 	}
@@ -977,7 +977,7 @@ func TestRebuildMapsFiltersExpiredLeases(t *testing.T) {
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       ptr.To("node-b"),
-			LeaseDurationSeconds: ptr.To(int32(10)),
+			LeaseDurationSeconds: ptr.To(int32(10)), // Intentionally short — already expired via expiredRenewTime
 			RenewTime:            &expiredRenewTime,
 		},
 	}
@@ -991,7 +991,7 @@ func TestRebuildMapsFiltersExpiredLeases(t *testing.T) {
 		Namespace:     "purelb",
 		NodeName:      "test-node",
 		Client:        client,
-		LeaseDuration: 5 * time.Second,
+		LeaseDuration: 300 * time.Second, // Long duration to prevent test-node lease expiry during slow CI
 		StopCh:        stopCh,
 		GetLocalSubnets: func() ([]string, error) {
 			return []string{"192.168.1.0/24"}, nil
@@ -1049,7 +1049,7 @@ func TestOnLeaseUpdateDetectsMembershipChange(t *testing.T) {
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       ptr.To("node-a"),
-			LeaseDurationSeconds: ptr.To(int32(10)),
+			LeaseDurationSeconds: ptr.To(int32(300)), // Long duration so fresh lease doesn't expire during slow CI
 			RenewTime:            &freshRenewTime,
 		},
 	}
@@ -1063,7 +1063,7 @@ func TestOnLeaseUpdateDetectsMembershipChange(t *testing.T) {
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       ptr.To("node-b"),
-			LeaseDurationSeconds: ptr.To(int32(10)),
+			LeaseDurationSeconds: ptr.To(int32(10)), // Intentionally short — already expired via expiredRenewTime
 			RenewTime:            &expiredRenewTime,
 		},
 	}
@@ -1078,7 +1078,7 @@ func TestOnLeaseUpdateDetectsMembershipChange(t *testing.T) {
 		Namespace:     "purelb",
 		NodeName:      "test-node",
 		Client:        client,
-		LeaseDuration: 5 * time.Second,
+		LeaseDuration: 300 * time.Second, // Long duration to prevent test-node lease expiry during slow CI
 		StopCh:        stopCh,
 		OnMemberChange: func() {
 			memberChangeCount++
@@ -1156,7 +1156,7 @@ func TestOnLeaseUpdateNoChangeNoCallback(t *testing.T) {
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       ptr.To("node-a"),
-			LeaseDurationSeconds: ptr.To(int32(10)),
+			LeaseDurationSeconds: ptr.To(int32(300)),
 			RenewTime:            &freshRenewTime,
 		},
 	}
@@ -1171,7 +1171,7 @@ func TestOnLeaseUpdateNoChangeNoCallback(t *testing.T) {
 		Namespace:     "purelb",
 		NodeName:      "test-node",
 		Client:        client,
-		LeaseDuration: 5 * time.Second,
+		LeaseDuration: 300 * time.Second, // Long duration to prevent expiry during slow CI
 		StopCh:        stopCh,
 		OnMemberChange: func() {
 			memberChangeCount++


### PR DESCRIPTION
## Summary

- Integrates k8gobgp as a sidecar container in the lbnodeagent DaemonSet pod, making BGP route announcement the default installation
- Default `make install-manifest` and `make manifest` now include k8gobgp sidecar; new `make install-manifest-nobgp` and `make manifest-nobgp` targets for installs without BGP
- Helm chart defaults to `gobgp.enabled: true`; set `gobgp.enabled=false` to disable
- CI workflow builds all four manifest variants and includes them in GitHub releases
- README updated for v0.16.0 with BGP and nobgp install instructions

## Details

**Kustomize**: Uses a reusable `kind: Component` in `deployments/components/gobgp/` composed into overlays. Additive RBAC via separate `purelb:k8gobgp` ClusterRole bound to existing `lbnodeagent` ServiceAccount.

**Helm**: Conditional sidecar, RBAC, emptyDir volume, and metrics Service (gated on `gobgp.enabled AND Prometheus.lbnodeagent.Metrics.enabled`).

**k8gobgp**: Image `ghcr.io/purelb/k8gobgp:0.2.2`, ports 7473 (metrics), 7474 (health), 179 (BGP).

**Sample BGPConfiguration CR** included in `make manifest` output with `netlinkImport` explicitly set to `kube-lb0` (required — without it k8gobgp starts but advertises no routes).

## Release artifacts for v0.16.0

| Artifact | Contents |
|----------|----------|
| `install-v0.16.0.yaml` | Default install with k8gobgp sidecar |
| `purelb-v0.16.0.yaml` | Install + samples + sample BGPConfiguration CR |
| `install-nobgp-v0.16.0.yaml` | Install without BGP |
| `purelb-nobgp-v0.16.0.yaml` | Install + samples, no BGP |
| `purelb-v0.16.0.tgz` | Helm chart (`gobgp.enabled: true`) |

## Test plan

- [x] Offline: `make install-manifest` / `make manifest` produce manifests with k8gobgp sidecar, CRD, RBAC
- [x] Offline: `make install-manifest-nobgp` / `make manifest-nobgp` produce clean manifests without k8gobgp
- [x] Offline: `helm lint` passes; `helm template` with default values includes sidecar; `--set gobgp.enabled=false` excludes it
- [x] On-cluster (local-kvm): Default install — 2/2 containers running, k8gobgp readyz=ok, RBAC and CRD created
- [x] On-cluster: `manifest` with samples — BGPConfiguration CR and ServiceGroup CR created, k8gobgp reconciled config
- [x] On-cluster: Helm install with default values — sidecar running; upgrade toggle disable/re-enable works cleanly
- [x] On-cluster: nobgp install — single container, no k8gobgp RBAC or CRD
- [x] On-cluster: Helm install with `gobgp.enabled=false` — single container, no k8gobgp resources