### PR TITLE
Fix e2e tests for k8gobgp sidecar multi-container pods

### DIFF
--- a/test/e2e/common.sh
+++ b/test/e2e/common.sh
@@ -268,9 +268,13 @@ discover_ipv6() {
         first_node=$(echo "${SUBNET_NODES[$s]}" | awk '{print $1}')
         local iface="${NODE_IFACE[$first_node]}"
 
-        # Get global-scope IPv6 address on the interface
+        # Get global-scope IPv6 address on the interface, preferring /64 over /128
         local v6addr
-        v6addr=$(node_ssh "$first_node" "ip -6 -o addr show $iface scope global 2>/dev/null | head -1 | awk '{print \$4}'" 2>/dev/null)
+        v6addr=$(node_ssh "$first_node" "ip -6 -o addr show $iface scope global 2>/dev/null | awk '{print \$4}' | grep '/64$' | head -1" 2>/dev/null)
+        # Fall back to any global address if no /64 found
+        if [ -z "$v6addr" ]; then
+            v6addr=$(node_ssh "$first_node" "ip -6 -o addr show $iface scope global 2>/dev/null | head -1 | awk '{print \$4}'" 2>/dev/null)
+        fi
 
         if [ -n "$v6addr" ]; then
             # v6addr is like "2001:470:b8f3:250:be24:11ff:fe1b:5642/64"

--- a/test/e2e/local/stress-failover.sh
+++ b/test/e2e/local/stress-failover.sh
@@ -450,7 +450,7 @@ run_single_test() {
 
     local LOG_PID=""
     if [ "$GRACE_PERIOD" != "0" ]; then
-        kubectl logs -n $PURELB_NS "$POD" -f --tail=0 >> "$LOGFILE" 2>&1 &
+        kubectl logs -n $PURELB_NS "$POD" -c lbnodeagent -f --tail=0 >> "$LOGFILE" 2>&1 &
         LOG_PID=$!
     fi
 
@@ -798,7 +798,7 @@ run_single_test() {
                 npod=$(get_pod_on_node "$node")
                 if [ -n "$npod" ]; then
                     echo "--- $(node_label $node) ($npod) ---" >> "$LOGFILE"
-                    kubectl logs -n $PURELB_NS "$npod" --tail=50 2>/dev/null >> "$LOGFILE" || true
+                    kubectl logs -n $PURELB_NS "$npod" -c lbnodeagent --tail=50 2>/dev/null >> "$LOGFILE" || true
                 fi
             done
             return 1

--- a/test/e2e/local/test-local-allocation.sh
+++ b/test/e2e/local/test-local-allocation.sh
@@ -329,7 +329,7 @@ test_local_pool_no_matching_subnet() {
 
     # Check for noLocalInterface log message
     info "Checking lbnodeagent logs for noLocalInterface message..."
-    if kubectl logs -n purelb-system -l component=lbnodeagent --tail=100 2>/dev/null | grep -q "noLocalInterface"; then
+    if kubectl logs -n purelb-system -l component=lbnodeagent -c lbnodeagent --tail=100 2>/dev/null | grep -q "noLocalInterface"; then
         pass "Found noLocalInterface message in logs (no fallback confirmed)"
     else
         info "noLocalInterface message not found (may have scrolled out)"
@@ -458,7 +458,7 @@ show_election_logs() {
     info "Recent election logs from $node (last $lines):"
     local pod=$(kubectl get pods -n purelb-system -l component=lbnodeagent -o wide 2>/dev/null | grep "$node" | awk '{print $1}')
     if [ -n "$pod" ]; then
-        kubectl logs -n purelb-system "$pod" --tail=$lines 2>/dev/null | grep -E "(electionWon|lostElection|leaseAdd|leaseDelete|leaseUpdate|rebuildMaps|withdrawAddress|ForceSync|graceful)" | while read line; do
+        kubectl logs -n purelb-system "$pod" -c lbnodeagent --tail=$lines 2>/dev/null | grep -E "(electionWon|lostElection|leaseAdd|leaseDelete|leaseUpdate|rebuildMaps|withdrawAddress|ForceSync|graceful)" | while read line; do
             detail "$line"
         done
     else
@@ -547,7 +547,7 @@ test_graceful_failover() {
 
     # Start watching pod logs in background to capture shutdown messages
     info "Starting log capture for shutdown..."
-    kubectl logs -n purelb-system "$AGENT_POD" -f --tail=0 > /tmp/shutdown-logs.txt 2>&1 &
+    kubectl logs -n purelb-system "$AGENT_POD" -c lbnodeagent -f --tail=0 > /tmp/shutdown-logs.txt 2>&1 &
     LOG_PID=$!
 
     DELETE_START=$(date +%s.%N)
@@ -1078,7 +1078,7 @@ test_leader_election() {
             pod=$(kubectl get pods -n purelb-system -l component=lbnodeagent -o wide 2>/dev/null \
                 | grep "$node" | awk '{print $1}')
             if [ -n "$pod" ]; then
-                if kubectl logs -n purelb-system "$pod" --tail=200 2>/dev/null | grep -qE "(notWinner|lostElection)"; then
+                if kubectl logs -n purelb-system "$pod" -c lbnodeagent --tail=200 2>/dev/null | grep -qE "(notWinner|lostElection)"; then
                     pass "Non-winner $node: logged 'notWinner'/'lostElection'"
                     found_loser_log=true
                     break
@@ -1097,7 +1097,7 @@ test_leader_election() {
     # Verify no panic/fatal errors
     info "Checking for absence of panic/fatal errors..."
     local panic_logs
-    panic_logs=$(kubectl logs -n purelb-system -l component=lbnodeagent --tail=200 2>/dev/null \
+    panic_logs=$(kubectl logs -n purelb-system -l component=lbnodeagent -c lbnodeagent --tail=200 2>/dev/null \
         | grep -iE "(panic|fatal|FATAL)" || true)
     [ -z "$panic_logs" ] || fail "Panic or fatal errors found in lbnodeagent logs"
     pass "No panic or fatal errors in lbnodeagent logs"
@@ -2277,7 +2277,7 @@ test_address_renewal_timer() {
     winner_pod=$(kubectl get pods -n purelb-system -l component=lbnodeagent -o wide 2>/dev/null \
         | grep "$WINNER_NODE" | awk '{print $1}')
     if [ -n "$winner_pod" ]; then
-        if kubectl logs -n purelb-system "$winner_pod" --tail=200 2>/dev/null | grep -q "renewAddress"; then
+        if kubectl logs -n purelb-system "$winner_pod" -c lbnodeagent --tail=200 2>/dev/null | grep -q "renewAddress"; then
             pass "LBNodeAgent $WINNER_NODE: logged 'renewAddress' (address lifetime renewed)"
         else
             detail "renewAddress not found in logs (debug-level, may not be visible at info level)"
@@ -4509,7 +4509,7 @@ assert_log_contains() {
         local pods
         pods=$(kubectl get pods -n purelb-system -l component=lbnodeagent -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
         for pod in $pods; do
-            if kubectl logs -n purelb-system "$pod" --tail=200 2>/dev/null | grep -q "$pattern"; then
+            if kubectl logs -n purelb-system "$pod" -c lbnodeagent --tail=200 2>/dev/null | grep -q "$pattern"; then
                 return 0
             fi
         done
@@ -4532,7 +4532,7 @@ assert_log_contains_on_node() {
     if [ -z "$pod" ]; then
         fail "No lbnodeagent pod found on node $node"
     fi
-    if kubectl logs -n purelb-system "$pod" --tail=200 2>/dev/null | grep -q "$pattern"; then
+    if kubectl logs -n purelb-system "$pod" -c lbnodeagent --tail=200 2>/dev/null | grep -q "$pattern"; then
         return 0
     fi
     fail "LBNodeAgent logs on $node missing: $description (pattern: $pattern)"

--- a/test/e2e/remote/README.md
+++ b/test/e2e/remote/README.md
@@ -125,7 +125,7 @@ Verify kube-proxy configuration. These tests require `--proxy-mode=nftables`.
 Ensure passwordless SSH to all nodes: `ssh <node> hostname`
 
 ### VIP not appearing on kube-lb0
-Check lbnodeagent logs: `kubectl logs -n purelb-system-l app.kubernetes.io/component=lbnodeagent`
+Check lbnodeagent logs: `kubectl logs -n purelb-system -l app.kubernetes.io/component=lbnodeagent -c lbnodeagent`
 
 ### nftables rules missing
 Check kube-proxy logs and verify service has an external IP assigned.

--- a/test/e2e/router/README.md
+++ b/test/e2e/router/README.md
@@ -166,7 +166,7 @@ ssh $ROUTER_HOST "sudo vtysh -c 'show version'"
 vtysh -c "show bgp summary"
 
 # On cluster node (GoBGP)
-kubectl logs -n purelb-system -l component=lbnodeagent | grep -i bgp
+kubectl logs -n purelb-system -l component=lbnodeagent -c lbnodeagent | grep -i bgp
 ```
 
 ### "ECMP not distributing traffic"

--- a/test/e2e/single-node/test-single-node.sh
+++ b/test/e2e/single-node/test-single-node.sh
@@ -52,7 +52,7 @@ dump_debug_state() {
     echo "--- Allocator logs (last 30 lines) ---"
     kubectl logs -n $PURELB_NS deployment/allocator --tail=30 2>/dev/null || echo "(failed)"
     echo "--- LBNodeAgent logs (last 30 lines) ---"
-    kubectl logs -n $PURELB_NS daemonset/lbnodeagent --tail=30 2>/dev/null || echo "(failed)"
+    kubectl logs -n $PURELB_NS daemonset/lbnodeagent -c lbnodeagent --tail=30 2>/dev/null || echo "(failed)"
     echo "========================="
 }
 


### PR DESCRIPTION
## Summary

- Add `-c lbnodeagent` to all `kubectl logs` calls targeting lbnodeagent pods across e2e tests. Without this, logs default to the k8gobgp sidecar container, causing all log assertions to fail.
- Fix IPv6 discovery in `common.sh` to prefer `/64` addresses over `/128` DHCPv6 addresses when generating ServiceGroups.
- Fix missing space typo in `remote/README.md` kubectl command.

## Test plan

- [x] Ran `test-local-allocation.sh` on local-kvm cluster — log assertions now pass
- [x] Verified IPv6 subnet detected as `/64` instead of `/128`
- [x] Verified ServiceGroup pool parsing succeeds with corrected subnet