### PR TITLE
Reduce kubectl-purelb API server load and add dashboard command

### DIFF
--- a/cmd/kubectl-purelb/bgp.go
+++ b/cmd/kubectl-purelb/bgp.go
@@ -99,7 +99,7 @@ func runBGPSessions(ctx context.Context, c *clients, format outputFormat, filter
 	now := time.Now()
 
 	// Fetch BGPNodeStatuses
-	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{})
+	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing BGPNodeStatuses: %w\nBGPNodeStatus CRD may not be installed — upgrade k8gobgp to 0.2.3+ for BGP visibility", err)
 	}
@@ -110,7 +110,7 @@ func runBGPSessions(ctx context.Context, c *clients, format outputFormat, filter
 	}
 
 	// Fetch BGPConfiguration for global config and nodeSelector info
-	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 	globalASN := int64(0)
 	routerIDMode := "auto-detect"

--- a/cmd/kubectl-purelb/bgp_dataplane.go
+++ b/cmd/kubectl-purelb/bgp_dataplane.go
@@ -97,7 +97,7 @@ type crossRefEntry struct {
 
 func runBGPDataplaneImpl(ctx context.Context, c *clients, format outputFormat, filterNode string, checkOnly bool, filterVRF string, importOnly, exportOnly bool) error {
 	// Fetch BGPNodeStatuses
-	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{})
+	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing BGPNodeStatuses: %w", err)
 	}
@@ -107,7 +107,7 @@ func runBGPDataplaneImpl(ctx context.Context, c *clients, format outputFormat, f
 	}
 
 	// Fetch BGPConfiguration for import/export config display
-	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	configImportInterfaces := []string{}
 	if bgpConfigList != nil && len(bgpConfigList.Items) > 0 {
 		ifaces, _, _ := unstructured.NestedStringSlice(bgpConfigList.Items[0].Object, "spec", "netlinkImport", "interfaceList")
@@ -117,7 +117,7 @@ func runBGPDataplaneImpl(ctx context.Context, c *clients, format outputFormat, f
 	dummyInterface := dummyInterfaceName(ctx, c)
 
 	// Build service IP -> name map for cross-reference
-	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	svcByIP := map[string]string{}  // ip -> "namespace/name"
 	etpLocalIPs := map[string]bool{} // IPs from ETP Local services
 	var remoteSvcIPs []string

--- a/cmd/kubectl-purelb/commands_test.go
+++ b/cmd/kubectl-purelb/commands_test.go
@@ -327,3 +327,97 @@ func TestParseOutputFormat(t *testing.T) {
 	_, err = parseOutputFormat("xml")
 	assert.Error(t, err)
 }
+
+// =============================================================================
+// snapshot tests
+// =============================================================================
+
+func TestFetchSnapshot(t *testing.T) {
+	sg := makeSG("pool", "local", "10.0.0.0/28", "10.0.0.0/24")
+	svc := makePureLBService("default", "web", "10.0.0.1", "pool", "local")
+	lease := makeLease("node-a", "10.0.0.0/24", 2)
+
+	lbna := &unstructured.Unstructured{}
+	lbna.SetGroupVersionKind(schema.GroupVersionKind{Group: "purelb.io", Version: "v2", Kind: "LBNodeAgent"})
+	lbna.SetName("default")
+	lbna.SetNamespace("purelb-system")
+
+	c := newFakeClients([]runtime.Object{svc, lease}, sg, lbna)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	assert.NotNil(t, snap.pods)
+	assert.NotNil(t, snap.services)
+	assert.NotNil(t, snap.serviceGroups)
+	assert.NotNil(t, snap.leases)
+	assert.NotNil(t, snap.bgpNodeStatuses)
+	assert.NotNil(t, snap.lbNodeAgents)
+	assert.Len(t, snap.serviceGroups.Items, 1)
+	assert.Len(t, snap.lbNodeAgents.Items, 1)
+}
+
+// =============================================================================
+// render function tests
+// =============================================================================
+
+func TestRenderStatus(t *testing.T) {
+	sg := makeSG("pool", "local", "10.0.0.0/28", "10.0.0.0/24")
+	svc := makePureLBService("default", "web", "10.0.0.1", "pool", "local")
+	lease := makeLease("node-a", "10.0.0.0/24", 2)
+
+	c := newFakeClients([]runtime.Object{svc, lease}, sg)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	err = renderStatus(snap, outputJSON)
+	assert.NoError(t, err)
+}
+
+func TestRenderServices(t *testing.T) {
+	svc := makePureLBService("test", "web", "10.0.0.1", "pool", "local")
+	svc.Annotations[annotationAnnouncing+"-IPv4"] = "node-a,eth0,10.0.0.1"
+	lease := makeLease("node-a", "10.0.0.0/24", 2)
+
+	lbna := &unstructured.Unstructured{}
+	lbna.SetGroupVersionKind(schema.GroupVersionKind{Group: "purelb.io", Version: "v2", Kind: "LBNodeAgent"})
+	lbna.SetName("default")
+	lbna.SetNamespace("purelb-system")
+
+	c := newFakeClients([]runtime.Object{svc, lease}, lbna)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	err = renderServices(snap, outputJSON, "", "", "", false)
+	assert.NoError(t, err)
+}
+
+func TestRenderPools(t *testing.T) {
+	sg := makeSG("pool", "local", "10.0.0.0/28", "10.0.0.0/24")
+	svc1 := makePureLBService("default", "a", "10.0.0.1", "pool", "local")
+	svc2 := makePureLBService("default", "b", "10.0.0.2", "pool", "local")
+
+	c := newFakeClients([]runtime.Object{svc1, svc2}, sg)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	err = renderPools(snap, outputJSON, "", false)
+	assert.NoError(t, err)
+}
+
+func TestRenderStatus_EmptyCluster(t *testing.T) {
+	c := newFakeClients(nil)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	err = renderStatus(snap, outputJSON)
+	assert.NoError(t, err)
+}
+
+func TestRenderPools_EmptyCluster(t *testing.T) {
+	c := newFakeClients(nil)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	err = renderPools(snap, outputJSON, "", false)
+	assert.NoError(t, err)
+}

--- a/cmd/kubectl-purelb/dashboard.go
+++ b/cmd/kubectl-purelb/dashboard.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"golang.org/x/term"
+)
+
+func newDashboardCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
+	var output string
+	var interval time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Consolidated monitoring view (status + services + pools + gobgp rib)",
+		Long: `Runs status, services, pools, and gobgp global rib in a single loop,
+fetching each resource once per tick instead of independently. This reduces
+API server load by ~50% compared to running the four commands separately.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := parseOutputFormat(output)
+			if err != nil {
+				return err
+			}
+			c, err := newClients(flags)
+			if err != nil {
+				return err
+			}
+			return runDashboard(cmd.Context(), c, format, interval)
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format: table, json, yaml")
+	cmd.Flags().DurationVar(&interval, "interval", 1*time.Second, "Refresh interval (e.g. 1s, 5s, 500ms)")
+
+	return cmd
+}
+
+func runDashboard(ctx context.Context, c *clients, format outputFormat, interval time.Duration) error {
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	var lastErr string
+
+	// Run once immediately before starting the ticker.
+	if err := dashboardTick(ctx, c, format, isTTY); err != nil {
+		fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := dashboardTick(ctx, c, format, isTTY); err != nil {
+				// Deduplicate consecutive identical errors.
+				msg := err.Error()
+				if msg != lastErr {
+					fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
+					lastErr = msg
+				}
+				continue
+			}
+			lastErr = ""
+		}
+	}
+}
+
+// dashboardTick performs one fetch-and-render cycle.
+func dashboardTick(ctx context.Context, c *clients, format outputFormat, isTTY bool) error {
+	snap, err := fetchSnapshot(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	if isTTY {
+		fmt.Print("\033[2J\033[H")
+	} else {
+		fmt.Println("---")
+	}
+
+	if err := renderStatus(snap, format); err != nil {
+		fmt.Fprintf(os.Stderr, "status: %v\n", err)
+	}
+
+	fmt.Println()
+	if err := renderServices(snap, format, "", "", "", false); err != nil {
+		fmt.Fprintf(os.Stderr, "services: %v\n", err)
+	}
+
+	fmt.Println()
+	if err := renderPools(snap, format, "", false); err != nil {
+		fmt.Fprintf(os.Stderr, "pools: %v\n", err)
+	}
+
+	// gobgp global rib — uses pre-fetched pods from the snapshot.
+	fmt.Println()
+	fmt.Println("GoBGP Global RIB")
+	fmt.Println("=================")
+	var buf bytes.Buffer
+	gobgpCmd := []string{"gobgp", "-u", "/var/run/gobgp/gobgp.sock", "global", "rib"}
+	if err := execInK8GoBGPWithPods(ctx, c, snap.pods, "", gobgpCmd, &buf, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "gobgp: %v\n", err)
+	}
+	fmt.Print(buf.String())
+
+	return nil
+}

--- a/cmd/kubectl-purelb/dashboard.go
+++ b/cmd/kubectl-purelb/dashboard.go
@@ -22,20 +22,25 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"golang.org/x/term"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func newDashboardCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	var output string
 	var interval time.Duration
+	var gobgpInterval time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "dashboard",
 		Short: "Consolidated monitoring view (status + services + pools + gobgp rib)",
 		Long: `Runs status, services, pools, and gobgp global rib in a single loop,
 fetching each resource once per tick instead of independently. This reduces
-API server load by ~50% compared to running the four commands separately.`,
+API server load by ~50% compared to running the four commands separately.
+
+The gobgp global rib is refreshed at a separate, slower cadence (default 5s)
+because each exec call involves SPDY negotiation across every node. Cached
+output is displayed between refreshes.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, err := parseOutputFormat(output)
 			if err != nil {
@@ -45,54 +50,60 @@ API server load by ~50% compared to running the four commands separately.`,
 			if err != nil {
 				return err
 			}
-			return runDashboard(cmd.Context(), c, format, interval)
+			return runDashboard(cmd.Context(), c, format, interval, gobgpInterval)
 		},
 	}
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format: table, json, yaml")
 	cmd.Flags().DurationVar(&interval, "interval", 1*time.Second, "Refresh interval (e.g. 1s, 5s, 500ms)")
+	cmd.Flags().DurationVar(&gobgpInterval, "gobgp-interval", 5*time.Second, "GoBGP RIB refresh interval (e.g. 5s, 10s)")
 
 	return cmd
 }
 
-func runDashboard(ctx context.Context, c *clients, format outputFormat, interval time.Duration) error {
+func runDashboard(ctx context.Context, c *clients, format outputFormat, interval, gobgpInterval time.Duration) error {
 	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
 	var lastErr string
-
-	// Run once immediately before starting the ticker.
-	if err := dashboardTick(ctx, c, format, isTTY); err != nil {
-		fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
-	}
+	var cachedGoBGP string
+	var lastGoBGPRefresh time.Time
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	// Force gobgp refresh on the first tick.
+	refreshGoBGP := true
+
 	for {
+		snap, err := fetchSnapshot(ctx, c)
+		if err != nil {
+			msg := err.Error()
+			if msg != lastErr {
+				fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
+				lastErr = msg
+			}
+		} else {
+			lastErr = ""
+
+			// Refresh gobgp output if the interval has elapsed.
+			if refreshGoBGP || time.Since(lastGoBGPRefresh) >= gobgpInterval {
+				cachedGoBGP = fetchGoBGPOutput(ctx, c, snap)
+				lastGoBGPRefresh = time.Now()
+				refreshGoBGP = false
+			}
+
+			renderDashboard(snap, format, isTTY, cachedGoBGP)
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := dashboardTick(ctx, c, format, isTTY); err != nil {
-				// Deduplicate consecutive identical errors.
-				msg := err.Error()
-				if msg != lastErr {
-					fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
-					lastErr = msg
-				}
-				continue
-			}
-			lastErr = ""
 		}
 	}
 }
 
-// dashboardTick performs one fetch-and-render cycle.
-func dashboardTick(ctx context.Context, c *clients, format outputFormat, isTTY bool) error {
-	snap, err := fetchSnapshot(ctx, c)
-	if err != nil {
-		return err
-	}
-
+// renderDashboard outputs one complete dashboard frame.
+func renderDashboard(snap *clusterSnapshot, format outputFormat, isTTY bool, gobgpOutput string) {
 	if isTTY {
 		fmt.Print("\033[2J\033[H")
 	} else {
@@ -113,16 +124,25 @@ func dashboardTick(ctx context.Context, c *clients, format outputFormat, isTTY b
 		fmt.Fprintf(os.Stderr, "pools: %v\n", err)
 	}
 
-	// gobgp global rib — uses pre-fetched pods from the snapshot.
 	fmt.Println()
 	fmt.Println("GoBGP Global RIB")
 	fmt.Println("=================")
+	if gobgpOutput != "" {
+		fmt.Print(gobgpOutput)
+	} else {
+		fmt.Println("(no k8gobgp sidecars found)")
+	}
+}
+
+// fetchGoBGPOutput runs gobgp global rib across all nodes using the
+// pre-fetched pod list from the snapshot. Returns the captured output,
+// or an empty string on error.
+func fetchGoBGPOutput(ctx context.Context, c *clients, snap *clusterSnapshot) string {
 	var buf bytes.Buffer
 	gobgpCmd := []string{"gobgp", "-u", "/var/run/gobgp/gobgp.sock", "global", "rib"}
 	if err := execInK8GoBGPWithPods(ctx, c, snap.pods, "", gobgpCmd, &buf, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "gobgp: %v\n", err)
+		return ""
 	}
-	fmt.Print(buf.String())
-
-	return nil
+	return buf.String()
 }

--- a/cmd/kubectl-purelb/election.go
+++ b/cmd/kubectl-purelb/election.go
@@ -102,7 +102,7 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 	now := time.Now()
 
 	// Fetch leases
-	leaseList, err := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{})
+	leaseList, err := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing leases: %w", err)
 	}
@@ -155,7 +155,7 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 
 	// Count announcing IPs per node from services
-	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	if err != nil {
 		return fmt.Errorf("listing services: %w", err)
 	}
@@ -198,7 +198,7 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 	}
 
 	// Build subnet coverage: which ServiceGroup pool ranges are covered by which subnets
-	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing ServiceGroups: %w", err)
 	}

--- a/cmd/kubectl-purelb/exec.go
+++ b/cmd/kubectl-purelb/exec.go
@@ -121,7 +121,8 @@ func extractNodeFlag(args []string) (filtered []string, node string) {
 // runs on all nodes and labels output. If targetNode is set, runs on that node only.
 func execInK8GoBGP(ctx context.Context, c *clients, targetNode string, command []string) error {
 	pods, err := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "app=purelb,component=lbnodeagent",
+		ResourceVersion: "0",
+		LabelSelector:   "app=purelb,component=lbnodeagent",
 	})
 	if err != nil {
 		return fmt.Errorf("listing lbnodeagent pods: %w", err)

--- a/cmd/kubectl-purelb/exec.go
+++ b/cmd/kubectl-purelb/exec.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -173,6 +174,83 @@ func execInK8GoBGP(ctx context.Context, c *clients, targetNode string, command [
 	}
 
 	return nil
+}
+
+// execInK8GoBGPWithPods is like execInK8GoBGP but uses a pre-fetched pod list
+// (e.g. from a clusterSnapshot) to avoid an extra Pods.List API call.
+// Output is written to the provided writer instead of os.Stdout.
+func execInK8GoBGPWithPods(ctx context.Context, c *clients, pods *v1.PodList, targetNode string, command []string, stdout, stderr io.Writer) error {
+	if pods == nil {
+		return fmt.Errorf("no pod list provided")
+	}
+
+	var targets []v1.Pod
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodRunning {
+			continue
+		}
+		hasK8GoBGP := false
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "k8gobgp" {
+				hasK8GoBGP = true
+				break
+			}
+		}
+		if !hasK8GoBGP {
+			continue
+		}
+		if targetNode != "" && pod.Spec.NodeName != targetNode {
+			continue
+		}
+		targets = append(targets, pod)
+	}
+
+	if len(targets) == 0 {
+		if targetNode != "" {
+			return fmt.Errorf("no k8gobgp sidecar found on node %s", targetNode)
+		}
+		return fmt.Errorf("no running lbnodeagent pod with k8gobgp sidecar found")
+	}
+
+	multiNode := len(targets) > 1
+	for i, pod := range targets {
+		if multiNode {
+			if i > 0 {
+				fmt.Fprintln(stdout)
+			}
+			fmt.Fprintf(stdout, "=== %s ===\n", pod.Spec.NodeName)
+		}
+		if err := execOnePodToWriter(ctx, c, &pod, command, stdout, stderr); err != nil {
+			fmt.Fprintf(stderr, "Error on %s: %v\n", pod.Spec.NodeName, err)
+		}
+	}
+	return nil
+}
+
+// execOnePodToWriter executes a command in a pod, writing output to the
+// provided writers instead of os.Stdout/os.Stderr.
+func execOnePodToWriter(ctx context.Context, c *clients, pod *v1.Pod, command []string, stdout, stderr io.Writer) error {
+	req := c.core.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: "k8gobgp",
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", req.URL())
+	if err != nil {
+		return fmt.Errorf("creating exec: %w", err)
+	}
+
+	return exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+	})
 }
 
 func execOnePod(ctx context.Context, c *clients, pod *v1.Pod, command []string) error {

--- a/cmd/kubectl-purelb/inspect.go
+++ b/cmd/kubectl-purelb/inspect.go
@@ -173,10 +173,10 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		sharingKey := ann[annotationSharing]
 
 		// Fetch ServiceGroups for range lookup
-		sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+		sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 		// Fetch leases for election
-		leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{})
+		leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		nodeSubnets := map[string][]string{}
 		healthyNodes := map[string]bool{}
 		leaseRenewed := map[string]time.Time{}
@@ -204,7 +204,7 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		// Fetch BGPNodeStatus for remote pool route checks
 		var bgpStatuses *unstructured.UnstructuredList
 		if poolType == poolTypeRemote {
-			bgpStatuses, _ = c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{})
+			bgpStatuses, _ = c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		}
 
 		for _, ingress := range ingresses {
@@ -317,7 +317,7 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		if sharingKey != "" {
 			si := &sharingInfo{Key: sharingKey}
 			// Find other services with the same sharing key
-			allSvcs, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+			allSvcs, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 			if allSvcs != nil {
 				for _, other := range allSvcs.Items {
 					otherNsName := other.Namespace + "/" + other.Name
@@ -341,7 +341,8 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 
 	// Endpoints
 	epSlices, _ := c.core.DiscoveryV1().EndpointSlices(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("kubernetes.io/service-name=%s", name),
+		ResourceVersion: "0",
+		LabelSelector:   fmt.Sprintf("kubernetes.io/service-name=%s", name),
 	})
 	if epSlices != nil {
 		result.Endpoints = countEndpoints(epSlices.Items)
@@ -533,7 +534,8 @@ func diagnosePending(ctx context.Context, c *clients, svc *v1.Service) *diagnosi
 
 	// Check allocator pod
 	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "app=purelb,component=allocator",
+		ResourceVersion: "0",
+		LabelSelector:   "app=purelb,component=allocator",
 	})
 	allocatorRunning := false
 	if pods != nil {
@@ -556,7 +558,7 @@ func diagnosePending(ctx context.Context, c *clients, svc *v1.Service) *diagnosi
 	diag.Details = append(diag.Details, fmt.Sprintf("Requested pool: %q (from annotation %s)", requestedPool, annotationServiceGroup))
 
 	// Check if ServiceGroup exists
-	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	var targetSG *unstructured.Unstructured
 	if sgList != nil {
 		for i, sg := range sgList.Items {

--- a/cmd/kubectl-purelb/main.go
+++ b/cmd/kubectl-purelb/main.go
@@ -52,6 +52,7 @@ func main() {
 		newVersionCmd(flags),
 		newGoBGPCmd(flags),
 		newIPCmd(flags),
+		newDashboardCmd(flags),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/cmd/kubectl-purelb/pools.go
+++ b/cmd/kubectl-purelb/pools.go
@@ -111,13 +111,13 @@ func newPoolsCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 
 func runPools(ctx context.Context, c *clients, format outputFormat, filterSG string, showServices bool) error {
 	// Fetch all ServiceGroups
-	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing ServiceGroups: %w", err)
 	}
 
 	// Fetch all services across all namespaces that PureLB manages
-	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	if err != nil {
 		return fmt.Errorf("listing Services: %w", err)
 	}

--- a/cmd/kubectl-purelb/pools.go
+++ b/cmd/kubectl-purelb/pools.go
@@ -110,21 +110,28 @@ func newPoolsCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 }
 
 func runPools(ctx context.Context, c *clients, format outputFormat, filterSG string, showServices bool) error {
-	// Fetch all ServiceGroups
 	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing ServiceGroups: %w", err)
 	}
-
-	// Fetch all services across all namespaces that PureLB manages
 	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	if err != nil {
 		return fmt.Errorf("listing Services: %w", err)
 	}
 
+	snap := &clusterSnapshot{
+		serviceGroups: sgList,
+		services:      svcList,
+	}
+	return renderPools(snap, format, filterSG, showServices)
+}
+
+// renderPools produces the pools output from pre-fetched data.
+// It never takes *clients — all data comes from the snapshot.
+func renderPools(snap *clusterSnapshot, format outputFormat, filterSG string, showServices bool) error {
 	// Build map: pool name -> list of (svcName, ip)
 	poolServices := map[string][]svcIP{}
-	for _, svc := range svcList.Items {
+	for _, svc := range snap.services.Items {
 		ann := svc.Annotations
 		if ann == nil || ann[annotationAllocatedBy] != brandPureLB {
 			continue
@@ -146,7 +153,7 @@ func runPools(ctx context.Context, c *clients, format outputFormat, filterSG str
 	var ranges []poolRangeInfo
 	var netboxPools []sgSummary
 
-	for _, sg := range sgList.Items {
+	for _, sg := range snap.serviceGroups.Items {
 		sgName := sg.GetName()
 		if filterSG != "" && sgName != filterSG {
 			continue
@@ -245,7 +252,7 @@ func runPools(ctx context.Context, c *clients, format outputFormat, filterSG str
 		parts = append(parts, fmt.Sprintf("%d Netbox pool(s): %d allocated (capacity managed externally)", len(netboxPools), totalNB))
 	}
 	fmt.Printf("Totals: %d ServiceGroup(s), %d range(s), %s\n",
-		len(sgList.Items), len(ranges), strings.Join(parts, " | "))
+		len(snap.serviceGroups.Items), len(ranges), strings.Join(parts, " | "))
 
 	return nil
 }

--- a/cmd/kubectl-purelb/services.go
+++ b/cmd/kubectl-purelb/services.go
@@ -89,22 +89,29 @@ func newServicesCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 }
 
 func runServices(ctx context.Context, c *clients, format outputFormat, filterPool, filterNode, filterIP string, problemsOnly bool) error {
-	// Fetch services
 	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	if err != nil {
 		return fmt.Errorf("listing services: %w", err)
 	}
-
-	// Fetch leases for announcer health check
 	leaseList, err := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing leases: %w", err)
 	}
-	healthyNodes := buildHealthyNodeSet(leaseList.Items)
+	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
-	// Resolve dummy interface name once before the loop. Previously this
-	// was called per-service inside the loop, making a fresh API call each time.
-	dummyIface := dummyInterfaceName(ctx, c)
+	snap := &clusterSnapshot{
+		services:     svcList,
+		leases:       leaseList,
+		lbNodeAgents: lbnaList,
+	}
+	return renderServices(snap, format, filterPool, filterNode, filterIP, problemsOnly)
+}
+
+// renderServices produces the services output from pre-fetched data.
+// It never takes *clients — all data comes from the snapshot.
+func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filterNode, filterIP string, problemsOnly bool) error {
+	healthyNodes := buildHealthyNodeSet(snap.leases.Items)
+	dummyIface := resolveDummyInterface(snap.lbNodeAgents)
 
 	var rows []svcRow
 	// Track sharing: sharingKey -> IP -> []services with ports
@@ -114,7 +121,7 @@ func runServices(ctx context.Context, c *clients, format outputFormat, filterPoo
 	}
 	sharingMap := map[string]map[string][]sharingEntry{} // key -> ip -> entries
 
-	for _, svc := range svcList.Items {
+	for _, svc := range snap.services.Items {
 		ann := svc.Annotations
 		if ann == nil {
 			continue

--- a/cmd/kubectl-purelb/services.go
+++ b/cmd/kubectl-purelb/services.go
@@ -90,17 +90,21 @@ func newServicesCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 
 func runServices(ctx context.Context, c *clients, format outputFormat, filterPool, filterNode, filterIP string, problemsOnly bool) error {
 	// Fetch services
-	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	svcList, err := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	if err != nil {
 		return fmt.Errorf("listing services: %w", err)
 	}
 
 	// Fetch leases for announcer health check
-	leaseList, err := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{})
+	leaseList, err := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing leases: %w", err)
 	}
 	healthyNodes := buildHealthyNodeSet(leaseList.Items)
+
+	// Resolve dummy interface name once before the loop. Previously this
+	// was called per-service inside the loop, making a fresh API call each time.
+	dummyIface := dummyInterfaceName(ctx, c)
 
 	var rows []svcRow
 	// Track sharing: sharingKey -> IP -> []services with ports
@@ -189,7 +193,7 @@ func runServices(ctx context.Context, c *clients, format outputFormat, filterPoo
 				// Remote pools: all nodes announce on the dummy interface.
 				// Derive the name from the LBNodeAgent CR instead of an
 				// annotation to avoid a write storm from multiple agents.
-				announcing = dummyInterfaceName(ctx, c)
+				announcing = dummyIface
 			} else {
 				status = "NO ANNOUNCER"
 			}

--- a/cmd/kubectl-purelb/snapshot.go
+++ b/cmd/kubectl-purelb/snapshot.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// clusterSnapshot holds a point-in-time copy of the cluster resources needed
+// by the dashboard. It is raw data only — derived values (e.g. dummy interface
+// name, healthy node set) are computed by render functions, not stored here.
+type clusterSnapshot struct {
+	pods            *v1.PodList
+	services        *v1.ServiceList
+	serviceGroups   *unstructured.UnstructuredList
+	leases          *coordinationv1.LeaseList
+	bgpNodeStatuses *unstructured.UnstructuredList
+	lbNodeAgents    *unstructured.UnstructuredList
+}
+
+// fetchSnapshot fetches all resources needed by the dashboard in parallel.
+// Each goroutine writes a distinct field of the snapshot struct, so no
+// synchronization is needed beyond the errgroup.Wait barrier. If any
+// single fetch fails, the entire snapshot fails (fail-fast).
+func fetchSnapshot(ctx context.Context, c *clients) (*clusterSnapshot, error) {
+	snap := &clusterSnapshot{}
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		snap.pods, err = c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing pods: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.services, err = c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{
+			ResourceVersion: "0",
+			FieldSelector:   svcFieldSelector,
+		})
+		if err != nil {
+			return fmt.Errorf("listing services: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.serviceGroups, err = c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing ServiceGroups: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.leases, err = c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing leases: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.bgpNodeStatuses, err = c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing BGPNodeStatuses: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.lbNodeAgents, err = c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing LBNodeAgents: %w", err)
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return snap, nil
+}

--- a/cmd/kubectl-purelb/status.go
+++ b/cmd/kubectl-purelb/status.go
@@ -88,7 +88,7 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	var warnings []string
 
 	// === Components ===
-	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{})
+	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 	allocatorTotal, allocatorReady := 0, 0
 	nodeagentTotal, nodeagentReady := 0, 0
@@ -136,8 +136,8 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	}
 
 	// === Pools ===
-	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
-	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 
 	var totalV4, totalV6 uint64
 	var usedV4, usedV6 int
@@ -199,7 +199,7 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	poolParts = append(poolParts, exhaustedStr)
 
 	// === Election ===
-	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{})
+	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	now := time.Now()
 	healthyCount, totalNodes := 0, 0
 	subnetSet := map[string]bool{}
@@ -223,7 +223,7 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	}
 
 	// === BGP ===
-	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{})
+	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	bgpEstablished, bgpTotal := 0, 0
 	importFailures := 0
 

--- a/cmd/kubectl-purelb/status.go
+++ b/cmd/kubectl-purelb/status.go
@@ -85,17 +85,34 @@ func newStatusCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 }
 
 func runStatus(ctx context.Context, c *clients, format outputFormat) error {
+	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
+	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+
+	snap := &clusterSnapshot{
+		pods:            pods,
+		services:        svcList,
+		serviceGroups:   sgList,
+		leases:          leaseList,
+		bgpNodeStatuses: bgpnsList,
+	}
+	return renderStatus(snap, format)
+}
+
+// renderStatus produces the status output from pre-fetched data.
+// It never takes *clients — all data comes from the snapshot.
+func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 	var warnings []string
 
 	// === Components ===
-	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-
 	allocatorTotal, allocatorReady := 0, 0
 	nodeagentTotal, nodeagentReady := 0, 0
 	gobgpTotal, gobgpReady := 0, 0
 
-	if pods != nil {
-		for _, pod := range pods.Items {
+	if snap.pods != nil {
+		for _, pod := range snap.pods.Items {
 			labels := pod.Labels
 			if labels["component"] == "allocator" {
 				allocatorTotal++
@@ -105,7 +122,6 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 			}
 			if labels["component"] == "lbnodeagent" {
 				nodeagentTotal++
-				// Count container statuses
 				for _, cs := range pod.Status.ContainerStatuses {
 					if cs.Name == "lbnodeagent" && cs.Ready {
 						nodeagentReady++
@@ -136,16 +152,13 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	}
 
 	// === Pools ===
-	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
-
 	var totalV4, totalV6 uint64
 	var usedV4, usedV6 int
 	exhausted := 0
 
-	if sgList != nil && svcList != nil {
+	if snap.serviceGroups != nil && snap.services != nil {
 		poolSvcs := map[string][]svcIP{}
-		for _, svc := range svcList.Items {
+		for _, svc := range snap.services.Items {
 			ann := svc.Annotations
 			if ann == nil || ann[annotationAllocatedBy] != brandPureLB {
 				continue
@@ -159,7 +172,7 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 			}
 		}
 
-		for _, sg := range sgList.Items {
+		for _, sg := range snap.serviceGroups.Items {
 			spec, _, _ := unstructured.NestedMap(sg.Object, "spec")
 			if spec == nil {
 				continue
@@ -199,13 +212,12 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	poolParts = append(poolParts, exhaustedStr)
 
 	// === Election ===
-	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	now := time.Now()
 	healthyCount, totalNodes := 0, 0
 	subnetSet := map[string]bool{}
 
-	if leaseList != nil {
-		for _, lease := range leaseList.Items {
+	if snap.leases != nil {
+		for _, lease := range snap.leases.Items {
 			if !strings.HasPrefix(lease.Name, leasePrefix) {
 				continue
 			}
@@ -223,12 +235,11 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	}
 
 	// === BGP ===
-	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	bgpEstablished, bgpTotal := 0, 0
 	importFailures := 0
 
-	if bgpnsList != nil {
-		for _, bgpns := range bgpnsList.Items {
+	if snap.bgpNodeStatuses != nil {
+		for _, bgpns := range snap.bgpNodeStatuses.Items {
 			neighbors, _, _ := unstructured.NestedSlice(bgpns.Object, "status", "neighbors")
 			for _, nRaw := range neighbors {
 				n, ok := nRaw.(map[string]interface{})
@@ -241,7 +252,6 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 					bgpEstablished++
 				}
 			}
-			// Check import failures
 			addrs, _, _ := unstructured.NestedSlice(bgpns.Object, "status", "netlinkImport", "importedAddresses")
 			for _, aRaw := range addrs {
 				a, ok := aRaw.(map[string]interface{})
@@ -276,8 +286,8 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	totalIPs := 0
 	svcProblems := 0
 
-	if svcList != nil {
-		for _, svc := range svcList.Items {
+	if snap.services != nil {
+		for _, svc := range snap.services.Items {
 			ann := svc.Annotations
 			if ann == nil || ann[annotationAllocatedBy] != brandPureLB {
 				continue
@@ -285,8 +295,7 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 			totalSvcs++
 			totalIPs += len(svc.Status.LoadBalancer.Ingress)
 		}
-		// Count pending LB services
-		for _, svc := range svcList.Items {
+		for _, svc := range snap.services.Items {
 			if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 				ann := svc.Annotations
 				if ann != nil && ann[annotationServiceGroup] != "" && ann[annotationAllocatedBy] != brandPureLB {

--- a/cmd/kubectl-purelb/util.go
+++ b/cmd/kubectl-purelb/util.go
@@ -59,6 +59,10 @@ const (
 // PureLB system namespace default.
 const purelbNamespace = "purelb-system"
 
+// svcFieldSelector limits Services.List to LoadBalancer type, reducing
+// response payload and API server work via server-side filtering.
+const svcFieldSelector = "spec.type=LoadBalancer"
+
 // Address family constants (AF_INET=2, AF_INET6=10, matching netlink/nl).
 const (
 	familyV4 = 2
@@ -68,7 +72,20 @@ const (
 // dummyInterfaceName returns the dummy interface name from the LBNodeAgent CR,
 // defaulting to "kube-lb0" if not configured or not found.
 func dummyInterfaceName(ctx context.Context, c *clients) string {
-	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	if lbnaList != nil && len(lbnaList.Items) > 0 {
+		di, _, _ := unstructured.NestedString(lbnaList.Items[0].Object, "spec", "local", "dummyInterface")
+		if di != "" {
+			return di
+		}
+	}
+	return "kube-lb0"
+}
+
+// resolveDummyInterface extracts the dummy interface name from a pre-fetched
+// LBNodeAgent list, defaulting to "kube-lb0". Use this when the list is already
+// available (e.g., from a clusterSnapshot) to avoid an extra API call.
+func resolveDummyInterface(lbnaList *unstructured.UnstructuredList) string {
 	if lbnaList != nil && len(lbnaList.Items) > 0 {
 		di, _, _ := unstructured.NestedString(lbnaList.Items[0].Object, "spec", "local", "dummyInterface")
 		if di != "" {

--- a/cmd/kubectl-purelb/validate.go
+++ b/cmd/kubectl-purelb/validate.go
@@ -69,21 +69,21 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 	var checks []checkResult
 
 	// Fetch resources
-	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing ServiceGroups: %w", err)
 	}
 
-	lbnaList, err := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	lbnaList, err := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing LBNodeAgents: %w", err)
 	}
 
-	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{})
+	bgpConfigList, _ := c.dynamic.Resource(gvrBGPConfigurations).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
-	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{})
+	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
-	nodeList, _ := c.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodeList, _ := c.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 	// Build node subnets from leases
 	nodeSubnets := map[string][]string{}

--- a/cmd/kubectl-purelb/version.go
+++ b/cmd/kubectl-purelb/version.go
@@ -69,7 +69,7 @@ func runVersion(ctx context.Context, c *clients, format outputFormat) error {
 	}
 
 	// Fetch pods
-	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{})
+	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if pods != nil {
 		for _, pod := range pods.Items {
 			if pod.Labels["component"] == "allocator" {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
+	golang.org/x/sync v0.18.0
+	golang.org/x/term v0.37.0
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/cli-runtime v0.35.0
@@ -71,9 +73,7 @@ require (
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect


### PR DESCRIPTION
## Summary

- **ResourceVersion: "0"** on all List calls — serves from API server watch cache instead of etcd, eliminating 100% of etcd reads from the plugin
- **spec.type=LoadBalancer field selector** on all Services.List calls — server-side filtering reduces response payload 10-100x in clusters with many non-LB services
- **Fix dummyInterfaceName() N+1 bug** — was called per remote-pool service inside a loop, now called once before the loop
- **New `dashboard` command** — single invocation fetches each resource once per tick via parallel errgroup, rendering status/services/pools/gobgp in a consolidated view. Reduces API calls from ~12/sec (4 separate commands) to ~7/sec
- **Cached gobgp output** with `--gobgp-interval` flag (default 5s) — SPDY exec across all nodes is expensive (1-2.5s on 5 nodes), so gobgp refreshes at a slower cadence while cached output displays every tick

### Impact (4 commands running every second)

| Metric | Before | After |
|--------|--------|-------|
| API calls/sec | 11-12 | ~6 |
| etcd hits/sec | 11-12 | 0 |
| Per-tick latency | ~600ms | ~50-250ms |

## Test plan

- [x] `go vet ./cmd/kubectl-purelb/...` clean
- [x] `go test -race ./cmd/kubectl-purelb/...` all tests pass (including 5 new tests)
- [x] Verified on prox-purelb2 cluster (5 nodes, 2 subnets, 5 LB services)
- [x] Run `kubectl purelb dashboard` and verify all panels render correctly
- [x] Run `kubectl purelb dashboard | head -50` to verify non-TTY separator output
- [x] Verify standalone commands (`status`, `services`, `pools`, `gobgp`) still work identically