### PR TITLE
fix: install procedures and helm repo index automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,24 @@
 # https://github.com/actions/starter-workflows/blob/main/pages/hugo.yml
 name: Deploy Hugo site to Pages
 
+# Triggers:
+#   - push: normal commits to main / website-exp
+#   - workflow_run: fires after Update Helm Repository Index completes
+#     successfully. Needed because helm-index.yml's commit to main is made
+#     with secrets.GITHUB_TOKEN, which does NOT trigger downstream push
+#     workflows. workflow_run bypasses that restriction so the Hugo site
+#     (which serves the helm chart index) actually gets rebuilt.
+#   - workflow_dispatch: manual catchup.
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches:
     - main
     - website-exp
 
-  # Allows you to run this workflow manually from the Actions tab
+  workflow_run:
+    workflows: ["Update Helm Repository Index"]
+    types: [completed]
+
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -33,6 +43,11 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # For workflow_run triggers, only build when the upstream workflow
+    # succeeded. push and workflow_dispatch always run.
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/helm-index.yml
+++ b/.github/workflows/helm-index.yml
@@ -1,8 +1,16 @@
 name: Update Helm Repository Index
 
+# Triggers:
+#   - workflow_run on CI completion: fires after a tag-push CI run finishes
+#     successfully. We use workflow_run rather than `release: published`
+#     because release events created via secrets.GITHUB_TOKEN do NOT trigger
+#     downstream workflows (a GitHub Actions safety behavior). workflow_run
+#     events bypass that restriction.
+#   - workflow_dispatch: manual catchup if anything ever falls behind.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -11,6 +19,13 @@ permissions:
 jobs:
   update-index:
     runs-on: ubuntu-latest
+    # Run for manual dispatch always; for workflow_run, only when CI succeeded
+    # on a tag push. workflow_run.head_branch is the tag name for tag pushes.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -58,6 +73,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add website/static/charts/index.yaml
           if ! git diff --staged --quiet; then
-            git commit -m "Update Helm repository index for ${{ github.event.release.tag_name }}"
+            git commit -m "Update Helm repository index"
             git push
           fi

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ This project uses GitHub Actions for CI/CD:
 
 - **Tests** run on all branches and pull requests
 - **Container images** are built and pushed to `ghcr.io/purelb/purelb` on main branch and tags
-- **Releases** are created automatically when a version tag (e.g., `v0.16.1`) is pushed
+- **Releases** are created automatically when a version tag (e.g., `v0.16.2`) is pushed
 
 ## Local Development
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ helm:  ## Package PureLB using Helm
 	cp -r build/helm/purelb build/build/
 	cp deployments/crds/purelb.io_*.yaml build/build/purelb/crds
 	cp deployments/components/gobgp/gobgp-bgpconfig-crd.yaml build/build/purelb/crds/bgp.purelb.io_bgpconfigurations.yaml
+	cp deployments/components/gobgp/gobgp-bgpnodestatus-crd.yaml build/build/purelb/crds/bgp.purelb.io_bgpnodestatuses.yaml
 	cp README.md build/build/purelb
 
 	sed \

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 Install PureLB with a single command:
 
 ```sh
-kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-v0.16.1.yaml
+kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.2/install-v0.16.2.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-nobgp-v0.16.1.yaml
+kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.2/install-nobgp-v0.16.2.yaml
 ```
 
 Note: `--server-side` is required because the install manifest contains both
@@ -47,7 +47,7 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.1
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.2
 ```
 
 To install without BGP support:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 Install PureLB with a single command:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-v0.16.1.yaml
+kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-v0.16.1.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-nobgp-v0.16.1.yaml
+kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.1/install-nobgp-v0.16.1.yaml
 ```
+
+Note: `--server-side` is required because the install manifest contains both
+CRDs and a default `LBNodeAgent` custom resource. Server-side apply handles
+the ordering correctly so the CR is created after its CRD is registered.
 
 ### Option 2: Helm (Recommended for Production)
 


### PR DESCRIPTION
## Summary

Four related fixes uncovered by install-procedure testing of v0.16.1 on a live cluster, plus version bumps for the v0.16.2 release. Two trigger gaps in the release pipeline, one CRD missing from the helm chart, and one ordering bug in the manifest install command.

### 1. helm-index.yml: switch to `workflow_run` trigger

**Bug:** The published helm repo index at `purelb.github.io/purelb/charts/index.yaml` had been frozen at **v0.13.0** since ~a year ago. v0.14.0, v0.14.1, v0.15.0, v0.16.0, and v0.16.1 were all missing. Anyone following the README's primary helm install path was getting an ancient version. (A manual trigger of helm-index.yml + build.yml has now caught up the published index for v0.16.1, but the underlying automation is still broken until this PR lands.)

**Cause:** `helm-index.yml` is triggered by `release: published`, but `ci.yml` creates the release using `softprops/action-gh-release@v2` with `secrets.GITHUB_TOKEN`. **GitHub Actions does not trigger downstream workflows for events created via the workflow's own GITHUB_TOKEN** — a safety behavior to prevent infinite loops. So `helm-index.yml` had not fired for any release since the trigger was added.

**Fix:** Replace `release: published` with `workflow_run` listening for CI completion. `workflow_run` events are not subject to the GITHUB_TOKEN restriction. Filter the job to only run when CI succeeded on a tag push (`workflow_run.head_branch` is the tag name for tag pushes).

### 2. build.yml: add `workflow_run` trigger for helm-index completion

**Bug:** Even after fixing #1, the published index would still not update — there's a *second* broken trigger link further down the chain.

**Cause:** `helm-index.yml` writes to `website/static/charts/index.yaml` and commits to main using `secrets.GITHUB_TOKEN`. That commit's `push` event does not trigger `build.yml` (the Hugo Pages deploy) because of the same GITHUB_TOKEN safety. So the file in main was being updated but the static site was never rebuilt.

**Fix:** Add a `workflow_run` trigger to `build.yml` listening for helm-index completion. Keep the existing `push` trigger so normal content commits still rebuild the site.

### 3. Makefile: copy the BGPNodeStatus CRD into the helm chart

**Bug:** Helm installs are missing the `bgpnodestatuses.bgp.purelb.io` CRD. Manifest installs include all 4 CRDs (servicegroups, lbnodeagents, configs, bgpnodestatuses); helm installs only get 3. Once k8gobgp tries to write a node status on a helm-installed cluster, it would fail with "no matches for kind BGPNodeStatus".

**Cause:** The `make helm` target copies `gobgp-bgpconfig-crd.yaml` into the chart's `crds/` directory but never copies `gobgp-bgpnodestatus-crd.yaml`.

**Fix:** Add a single `cp` line to the `helm` target. Verified locally — `make helm` now produces a chart containing all 4 CRDs.

### 4. README.md: add `--server-side` to the manifest install command

**Bug:** Following the README's manifest install command exactly produces a non-functional install on the first try. The install manifest contains both the PureLB CRDs *and* a default `LBNodeAgent` custom resource. Client-side apply sends them to the API server in order, but the CRD's discovery cache hasn't refreshed by the time the LBNodeAgent CR is processed, and the CR fails with:

```
no matches for kind "LBNodeAgent" in version "purelb.io/v2"
```

The pods come up Running with the correct image tag, so a casual observer would think the install succeeded — but the lbnodeagent has no configuration CR and is idle.

**Fix:** Add `--server-side` to the install command. Server-side apply handles CRD-then-CR ordering correctly. Verified on local-kvm: `kubectl apply --server-side -f https://.../install-v0.16.1.yaml` installs everything including the `lbnodeagent.purelb.io/default` CR on the first try.

### 5. Version bumps for v0.16.2

Second commit (`c832dfff`) bumps the four hardcoded version references in user-facing docs:
- `README.md` × 3 (install-v*.yaml URL, install-nobgp-v*.yaml URL, helm OCI `--version`)
- `BUILDING.md` × 1 (CI/CD example tag)

These will resolve to working URLs once v0.16.2 is tagged after this PR merges.

## Test plan

- [x] `make helm` locally — chart contains all 4 CRDs
- [x] `kubectl apply --server-side` against the v0.16.1 install manifest on local-kvm — verified all resources land cleanly including the LBNodeAgent default CR on the first try
- [x] CI passes on this PR (`make check`)
- [ ] After merge: tag `v0.16.2` from main HEAD and push to validate the new pipeline end-to-end:
  - Tag and push `v0.16.2`
  - Watch CI fire all 5 jobs
  - **Verify the new chain: ci.yml → helm-index.yml (auto, no manual trigger) → build.yml (auto) → published index updated to include v0.16.2**
  - Re-test both install paths on local-kvm (manifest with `--server-side`, helm via repo path AND OCI)
  - Confirm helm-installed cluster has all 4 CRDs

## Notes for reviewers

- `workflow_run.head_branch` is the tag name for tag pushes (despite the misleading "branch" naming). The filter `startsWith(github.event.workflow_run.head_branch, 'v')` matches our tag convention. This is the one assumption I'm slightly nervous about — if it doesn't behave as expected on the v0.16.2 tag push, helm-index won't fire and we'll need to switch to a `head_sha`-based filter.
- The `build.yml` job filter `github.event_name != 'workflow_run' || conclusion == 'success'` allows push and workflow_dispatch triggers to always run while only running workflow_run when the upstream succeeded.
- The Hugo deploy is now triggered after every successful helm-index run, not just release-time runs. Manual workflow_dispatch of helm-index will also rebuild the site. This is intentional — if helm-index has anything to commit, the site should publish it.
- Item 1 from the original install-test findings (catching up the stale index) was completed via manual `gh workflow run` of helm-index.yml + build.yml before this PR was opened. The published index now contains v0.14.0 through v0.16.1; this PR makes the automation work for v0.16.2 onward.