### PR TITLE
fix: split install manifest to resolve CRD/CR ordering race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,18 @@ jobs:
           MANIFEST_SUFFIX: ${{ github.ref_name }}
         run: make install-manifest-nobgp
 
+      - name: Generate CRDs-only install manifest
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+        run: make install-crds
+
+      - name: Generate CRDs-only install manifest (without BGP)
+        env:
+          SUFFIX: ${{ github.ref_name }}
+          MANIFEST_SUFFIX: ${{ github.ref_name }}
+        run: make install-crds-nobgp
+
       - name: Package Helm chart
         env:
           SUFFIX: ${{ github.ref_name }}
@@ -221,6 +233,8 @@ jobs:
           sha256sum deployments/install-${{ github.ref_name }}.yaml >> SHA256SUMS
           sha256sum deployments/purelb-nobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
           sha256sum deployments/install-nobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/install-crds-${{ github.ref_name }}.yaml >> SHA256SUMS
+          sha256sum deployments/install-crds-nobgp-${{ github.ref_name }}.yaml >> SHA256SUMS
           sha256sum kubectl-purelb-* >> SHA256SUMS
 
       - name: Upload artifacts
@@ -243,6 +257,8 @@ jobs:
             deployments/install-${{ github.ref_name }}.yaml
             deployments/purelb-nobgp-${{ github.ref_name }}.yaml
             deployments/install-nobgp-${{ github.ref_name }}.yaml
+            deployments/install-crds-${{ github.ref_name }}.yaml
+            deployments/install-crds-nobgp-${{ github.ref_name }}.yaml
             kubectl-purelb-linux-amd64
             kubectl-purelb-linux-arm64
             kubectl-purelb-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,14 @@ install-manifest-nobgp: crd  ## Generate standalone install.yaml without k8gobgp
 # restore kustomization.yaml
 	cp ${CACHE} kustomization.yaml
 
+.PHONY: install-crds
+install-crds: crd  ## Generate CRDs-only install manifest (with k8gobgp CRDs)
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone deployments/crds-all > deployments/install-crds-${MANIFEST_SUFFIX}.yaml
+
+.PHONY: install-crds-nobgp
+install-crds-nobgp: crd  ## Generate CRDs-only install manifest (PureLB CRDs only)
+	$(KUSTOMIZE) build deployments/crds > deployments/install-crds-nobgp-${MANIFEST_SUFFIX}.yaml
+
 .PHONY: fetch-gobgp-crd
 fetch-gobgp-crd:  ## Fetch BGPConfiguration CRD from k8gobgp ${GOBGP_TAG} release
 	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \

--- a/README.md
+++ b/README.md
@@ -18,21 +18,22 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 
 ### Option 1: Simple Manifest
 
-Install PureLB with a single command:
+Install CRDs first, then apply the main install manifest:
 
 ```sh
-kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.2/install-v0.16.2.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-v0.16.3.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply --server-side -f https://github.com/purelb/purelb/releases/download/v0.16.2/install-nobgp-v0.16.2.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-nobgp-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-nobgp-v0.16.3.yaml
 ```
 
-Note: `--server-side` is required because the install manifest contains both
-CRDs and a default `LBNodeAgent` custom resource. Server-side apply handles
-the ordering correctly so the CR is created after its CRD is registered.
+The CRDs must be applied first because the install manifest includes a default
+`LBNodeAgent` custom resource that requires its CRD to be registered.
 
 ### Option 2: Helm (Recommended for Production)
 
@@ -47,7 +48,7 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.2
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.3
 ```
 
 To install without BGP support:

--- a/deployments/crds-all/kustomization.yaml
+++ b/deployments/crds-all/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../crds/purelb.io_servicegroups.yaml
+- ../crds/purelb.io_lbnodeagents.yaml
+- ../components/gobgp/gobgp-bgpconfig-crd.yaml
+- ../components/gobgp/gobgp-bgpnodestatus-crd.yaml


### PR DESCRIPTION
## Summary

- On a fresh cluster, the single-file `install-v*.yaml` manifest fails because `kubectl apply` tries to create the `LBNodeAgent` CR before its CRD is registered in the API server's discovery cache
- The v0.16.2 `--server-side` workaround does not fix this (verified on a clean cluster)
- Ships separate CRD-only manifests (`install-crds-v*.yaml`) so users apply CRDs first, then the main install manifest
- Existing install manifests are unchanged (still include CRDs for backwards compatibility)

## Changes

- Add `deployments/crds-all/` kustomize overlay combining all 4 CRDs (PureLB + GoBGP)
- Add Makefile targets: `install-crds`, `install-crds-nobgp`
- Update CI to generate, checksum, and upload CRD manifests as release assets
- Update README with two-step install instructions, remove incorrect `--server-side` note
- Bump version refs to v0.16.3

## Test plan

- [x] `make install-crds MANIFEST_SUFFIX=test` produces 4 CRDs, no namespace
- [x] `make install-crds-nobgp MANIFEST_SUFFIX=test` produces 2 CRDs, no namespace
- [x] Existing `make install-manifest` and `make install-manifest-nobgp` unchanged
- [ ] After release: verify two-step install on a clean cluster (uninstall CRDs first)