### PR TITLE
fix: configure GitHub Pages custom domain purelb.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ systems netlink library to add and remove address from interfaces to announce se
 
 ## Documentation
 
-https://purelb.github.io/purelb/
+https://purelb.io
 
 ## Quick Start
 
@@ -37,7 +37,7 @@ The CRDs must be applied first because the install manifest includes a default
 Install PureLB using Helm for more configuration options:
 
 ```sh
-helm repo add purelb https://purelb.github.io/purelb/charts
+helm repo add purelb https://purelb.io/charts
 helm install --create-namespace --namespace=purelb-system purelb purelb/purelb
 ```
 
@@ -55,7 +55,7 @@ helm install --create-namespace --namespace=purelb-system purelb purelb/purelb \
     --set gobgp.enabled=false
 ```
 
-For detailed installation and configuration, see https://purelb.github.io/purelb/install/
+For detailed installation and configuration, see https://purelb.io/install/
 
 ### Testing Your Installation
 

--- a/build/helm/purelb/templates/NOTES.txt
+++ b/build/helm/purelb/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Thank you for using PureLB.
 
-Please see "Initial Configuration" at https://purelb.github.io/purelb/install/config/
+Please see "Initial Configuration" at https://purelb.io/install/config/

--- a/build/helm/purelb/values.yaml
+++ b/build/helm/purelb/values.yaml
@@ -111,7 +111,7 @@ Prometheus:
       rules: []
 
 # You may define a valid spec and set create: true to create a ServiceGroup.
-# See https://purelb.github.io/purelb/install/config/
+# See https://purelb.io/install/config/
 serviceGroup:
   name: "default"
   create: false
@@ -189,7 +189,7 @@ leaseConfig:
   retryPeriod: "2s"
 
 # Configurable values specific to lbnodeagent.
-# See https://purelb.github.io/purelb/install/config/
+# See https://purelb.io/install/config/
 lbnodeagent:
   localInterface: default
   dummyInterface: kube-lb0

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://purelb.github.io/purelb/"
+baseURL = "https://purelb.io/"
 languageCode = "en-us"
 title = "PureLB"
 theme = "hugo-book"

--- a/website/content/docs/installation/helm/_index.md
+++ b/website/content/docs/installation/helm/_index.md
@@ -9,7 +9,7 @@ Helm provides full configuration control and is recommended for production deplo
 ## Add the Helm Repository
 
 ```sh
-helm repo add purelb https://purelb.github.io/purelb/charts
+helm repo add purelb https://purelb.io/charts
 helm repo update
 ```
 

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+purelb.io


### PR DESCRIPTION
## Summary

- Adds `website/static/CNAME` containing `purelb.io` so the `deploy-pages` artifact claims the custom domain. This is the single root cause of the `NotServedByPagesError` GitHub was reporting in Settings > Pages — DNS was correctly configured (all four A records and the AAAA records resolve, plus the `www` CNAME), but the deployed Hugo artifact had no CNAME file, so Pages had nothing to bind the domain to.
- Updates Hugo `baseURL` from `https://purelb.github.io/purelb/` to `https://purelb.io/` so canonical link tags, sitemap.xml, RSS feeds, and og:url emit the new URL.
- Refreshes user-facing URLs in `README.md`, `website/content/docs/installation/helm/_index.md`, `build/helm/purelb/values.yaml` (config-link comments), and `build/helm/purelb/templates/NOTES.txt` (printed after `helm install`) to use `https://purelb.io/...`.

The legacy `purelb.github.io/purelb/*` URLs continue to work via GitHub's automatic 301 redirect once the custom domain is live, so existing `helm repo add` invocations and bookmarks are not broken.

## Test plan

- [ ] Merge to main; observe the `Deploy Hugo site to Pages` workflow succeed
- [ ] Confirm Settings > Pages shows the custom domain as verified (no `NotServedByPagesError`)
- [ ] `curl -I https://purelb.io/` returns 200
- [ ] `curl -I https://purelb.io/CNAME` returns 200 with body `purelb.io`
- [ ] `curl -I https://purelb.github.io/purelb/charts/index.yaml` returns 301 to `purelb.io`
- [ ] `helm repo add purelb-test https://purelb.io/charts && helm repo update` succeeds
- [ ] Existing `helm repo add purelb https://purelb.github.io/purelb/charts` still works via redirect
- [ ] `https://www.purelb.io/` redirects to `https://purelb.io/`