### PR TITLE
release: v0.16.4 — bump k8gobgp 0.2.4, add check-deps CI gate

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ This project uses GitHub Actions for CI/CD:
 
 - **Tests** run on all branches and pull requests
 - **Container images** are built and pushed to `ghcr.io/purelb/purelb` on main branch and tags
-- **Releases** are created automatically when a version tag (e.g., `v0.16.2`) is pushed
+- **Releases** are created automatically when a version tag (e.g., `v0.16.4`) is pushed
 
 ## Local Development
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ COMMANDS = $(shell find cmd -maxdepth 1 -mindepth 1 -type d)
 NETBOX_USER_TOKEN = no-op
 NETBOX_BASE_URL = http://192.168.1.40:30080/
 GOBGP_IMAGE     ?= ghcr.io/purelb/k8gobgp
-GOBGP_TAG       ?= v0.2.2
-GOBGP_IMAGE_TAG ?= 0.2.2
+GOBGP_TAG       ?= v0.2.4
+GOBGP_IMAGE_TAG ?= 0.2.4
 CRDS = deployments/crds/purelb.io_lbnodeagents.yaml deployments/crds/purelb.io_servicegroups.yaml
 
 # Tools that we use.
@@ -38,7 +38,7 @@ help: ## Display help message
 all: check crd image ## Build it all!
 
 .PHONY: check
-check: generate ## Run "short" tests
+check: generate check-deps ## Run "short" tests + bundled-dep consistency check
 	go vet ./...
 	NETBOX_BASE_URL=${NETBOX_BASE_URL} NETBOX_USER_TOKEN=${NETBOX_USER_TOKEN} go test -race -short ./...
 
@@ -127,10 +127,50 @@ install-crds-nobgp: crd  ## Generate CRDs-only install manifest (PureLB CRDs onl
 	$(KUSTOMIZE) build deployments/crds > deployments/install-crds-nobgp-${MANIFEST_SUFFIX}.yaml
 
 .PHONY: fetch-gobgp-crd
-fetch-gobgp-crd:  ## Fetch BGPConfiguration CRD from k8gobgp ${GOBGP_TAG} release
+fetch-gobgp-crd:  ## Fetch CRDs from k8gobgp ${GOBGP_TAG} release (writes 1 file per CRD)
+	@set -e
+	TMP=$$(mktemp -d)
+	trap 'rm -rf $$TMP' EXIT
 	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \
-	  | $(KUSTOMIZE) cfg grep "kind=CustomResourceDefinition" \
+	  | $(KUSTOMIZE) cfg grep "kind=CustomResourceDefinition" > $$TMP/all.yaml
+	# Known CRDs to extract by name. Add a new line here when k8gobgp adds a new CRD.
+	# Note: dots in the value must be escaped (\.) — kustomize cfg grep treats unescaped
+	# dots as path separators. Single-quote the pattern to keep backslashes intact.
+	$(KUSTOMIZE) cfg grep 'metadata.name=configs\.bgp\.purelb\.io' < $$TMP/all.yaml \
 	  > deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
+	$(KUSTOMIZE) cfg grep 'metadata.name=bgpnodestatuses\.bgp\.purelb\.io' < $$TMP/all.yaml \
+	  > deployments/components/gobgp/gobgp-bgpnodestatus-crd.yaml
+	# Validation: count CRDs in input vs total in outputs. If mismatch, fail loudly.
+	IN=$$(grep -cE "^kind: CustomResourceDefinition" $$TMP/all.yaml)
+	OUT=$$(grep -chE "^kind: CustomResourceDefinition" deployments/components/gobgp/gobgp-*-crd.yaml | paste -sd+ - | bc)
+	if [ "$$IN" != "$$OUT" ]; then
+	  echo "ERROR: $$IN CRDs in upstream install.yaml but only $$OUT extracted by name." >&2
+	  echo "       k8gobgp likely added a new CRD. Add a per-name 'kustomize cfg grep' line" >&2
+	  echo "       to fetch-gobgp-crd in the Makefile and re-run." >&2
+	  exit 1
+	fi
+	echo "OK: extracted $$IN CRD(s) from k8gobgp ${GOBGP_TAG}"
+
+.PHONY: check-deps
+check-deps:  ## Verify bundled k8gobgp CRDs match the pinned GOBGP_TAG release
+	@set -e
+	TMP=$$(mktemp -d)
+	trap 'rm -rf $$TMP' EXIT
+	echo "check-deps: fetching k8gobgp ${GOBGP_TAG} install.yaml..."
+	curl -fsSL https://github.com/purelb/k8gobgp/releases/download/${GOBGP_TAG}/install.yaml \
+	  | $(KUSTOMIZE) cfg grep "kind=CustomResourceDefinition" > $$TMP/upstream.yaml
+	UPSTREAM=$$(grep -hE "^[[:space:]]+name:[[:space:]]+[a-zA-Z0-9_-]+\.bgp\.purelb\.io" $$TMP/upstream.yaml | awk '{print $$2}' | sort -u)
+	COMMITTED=$$(grep -hE "^[[:space:]]+name:[[:space:]]+[a-zA-Z0-9_-]+\.bgp\.purelb\.io" deployments/components/gobgp/gobgp-*-crd.yaml | awk '{print $$2}' | sort -u)
+	if [ "$$UPSTREAM" != "$$COMMITTED" ]; then
+	  echo "ERROR: CRDs in deployments/components/gobgp/ do not match k8gobgp ${GOBGP_TAG}." >&2
+	  echo "Upstream produces:" >&2; echo "$$UPSTREAM" | sed 's/^/  /' >&2
+	  echo "Committed:"          >&2; echo "$$COMMITTED" | sed 's/^/  /' >&2
+	  echo "" >&2
+	  echo "If you added kubectl-purelb code that reads a CRD, you must also bump GOBGP_TAG" >&2
+	  echo "to a release that produces it, then run 'make fetch-gobgp-crd' to refresh files." >&2
+	  exit 1
+	fi
+	echo "OK: bundled CRDs match k8gobgp ${GOBGP_TAG}"
 
 .PHONY: helm
 helm:  ## Package PureLB using Helm

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 Install CRDs first, then apply the main install manifest:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-v0.16.3.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-nobgp-v0.16.3.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-nobgp-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-nobgp-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-nobgp-v0.16.4.yaml
 ```
 
 The CRDs must be applied first because the install manifest includes a default
@@ -45,7 +45,7 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.3
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.4
 ```
 
 To install without BGP support:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,208 @@
+# Releasing PureLB
+
+This document is the canonical release procedure for PureLB. The primary
+defense against drift is the `make check-deps` CI gate; this checklist is
+the secondary defense, covering what the gate cannot enforce (procedural
+drift, missed doc bumps, post-tag rollback).
+
+Run through every section in order. Each item exists because a prior
+release missed it.
+
+## Pre-flight (hard gates)
+
+- [ ] `git status` clean on `main`, `git pull` up to date.
+- [ ] `make check` passes locally. **This includes `make check-deps`. If
+      `check-deps` fails, you have a CRD/version mismatch and must NOT
+      proceed — fix it via the [Dependency review](#dependency-review-k8gobgp)
+      below.**
+- [ ] **Dependabot triage**: `gh pr list -R purelb/purelb -l dependencies`.
+      For each open PR: merge, close with reason, or explicitly defer to a
+      named target release. **Empty queue or every PR explicitly
+      dispositioned — not "skip for now."**
+- [ ] Decide release type: patch (vX.Y.Z+1) for dep bumps and bug fixes,
+      minor (vX.Y+1.0) for new features. Set `NEW=vX.Y.Z`, `OLD=vX.Y.Z-1`.
+
+## Dependency review (k8gobgp)
+
+PureLB bundles k8gobgp as a sidecar; its version is pinned in 4 places
+plus the regenerated CRD files. The `check-deps` gate enforces that the
+CRDs match the pin, but won't tell you when upstream has shipped a newer
+release worth picking up.
+
+- [ ] `gh release list -R purelb/k8gobgp --limit 5` — note the latest tag.
+- [ ] For every release between the old pin and the new one:
+      `gh release view vX.Y.Z -R purelb/k8gobgp`. Look for: new CRDs,
+      breaking config changes, sidecar contract changes (env vars, sockets,
+      ports). Note material findings in the PR description and in the
+      GitHub release notes (`generate_release_notes: true` won't surface
+      these — humans must).
+- [ ] Update IN ORDER:
+      1. `Makefile`: `GOBGP_TAG ?= vX.Y.Z` and `GOBGP_IMAGE_TAG ?= X.Y.Z`
+         (note the `v` prefix difference — the GitHub release URL uses `v`,
+         the docker image tag does not, because `docker/metadata-action`
+         strips the prefix when publishing)
+      2. `build/helm/purelb/values.yaml`: `tag: "X.Y.Z"` under `gobgp.image`
+      3. `deployments/components/gobgp/gobgp-patch.yaml`: `image:` line
+      4. `website/content/docs/reference/helm-values/_index.md`: documented
+         tag value in the gobgp section
+- [ ] `make fetch-gobgp-crd`. The target writes one file per CRD and
+      validates that all upstream CRDs were extracted. **If it fails with
+      "k8gobgp likely added a new CRD"**, add a per-name `kustomize cfg
+      grep 'metadata.name=NEW_CRD\.bgp\.purelb\.io'` line to the target
+      (note the escaped dots — kustomize cfg grep treats unescaped dots as
+      path separators), then re-run.
+- [ ] Commit any non-empty diff to `deployments/components/gobgp/gobgp-*-crd.yaml`.
+- [ ] `make check-deps` PASSES. If it doesn't pass locally, neither will
+      CI on the PR.
+- [ ] Final sweep: `grep -rn "k8gobgp:0\." Makefile build/ deployments/components/ website/content/`
+      — every hit should be the new tag. Misses here are the #1 source of
+      past drift.
+
+## Version-string bump (PureLB itself)
+
+- [ ] `grep -rn "$OLD" README.md BUILDING.md website/content/docs/`
+- [ ] Update each hit to `$NEW`. Watch for:
+      - `README.md`: install URLs (5 occurrences as of v0.16.3) and the
+        helm OCI install command
+      - `BUILDING.md`: example tag in the CI/CD section (cosmetic; bump anyway)
+      - `website/content/docs/installation/manifest/_index.md`
+      - `website/content/docs/installation/helm/_index.md`
+      - `website/content/docs/migration/_index.md` (NOTE: leave `v0.15.x`
+        and other "migrating FROM" historical references alone — only bump
+        current-version strings)
+- [ ] Re-run the grep; expected hit count = 0.
+
+## Do NOT touch
+
+These look like version references but aren't:
+
+- `build/helm/purelb/Chart.yaml` — `version: 0.0.0` and `appVersion: 0.0.0`
+  are intentional placeholders; `make helm` overrides them via `--version`
+  and `--app-version` from `$SUFFIX` at package time.
+- `build/helm/purelb/values.yaml` lines 8 and 11 — `DEFAULT_REPO` /
+  `DEFAULT_TAG` are sed-substituted at package time.
+- `deployments/purelb-*.yaml`, `deployments/install-*.yaml`,
+  `deployments/crds/purelb.io_*.yaml`, `pkg/generated/`, `build/build/` —
+  gitignored or generated; any local copies are stale build artifacts.
+  (Two stuck-tracked snapshots `deployments/purelb-v0.16.0.yaml` and
+  `purelb-nobgp-v0.16.0.yaml` exist for legacy reasons; ignore them.)
+- `cmd/kubectl-purelb/main.go` (`version = "dev"`) and
+  `internal/logging/logging.go` (`release` var) — both set by ldflags at
+  build time. Default literals are dev-mode fallbacks.
+- `docs/*.md` — historical planning documents; their version references
+  describe the state at the time of writing.
+
+## Pre-tag local verification
+
+Before pushing the branch, run a clean rebuild to surface anything CI
+would catch — but with a 6-minute round-trip saved per failure:
+
+```bash
+make check                              # vet + race tests + check-deps
+SUFFIX=$NEW make manifest               # render the install manifest
+SUFFIX=$NEW make install-manifest       # render the standalone install
+SUFFIX=$NEW make helm                   # package the chart
+grep "k8gobgp:" deployments/install-${NEW}.yaml   # confirms new tag in output
+```
+
+**Required (not "if handy"): clean-cluster smoke test.** Per project
+convention, pre-existing CRDs/state mask real ordering bugs. Until CI has
+an automated end-to-end smoke test, this manual run is the only thing
+standing between a known bug and your users.
+
+```bash
+# On a clean kind/k3d cluster (kubectl context set to it):
+kubectl apply -f deployments/install-crds-${NEW}.yaml
+kubectl apply -f deployments/install-${NEW}.yaml
+kubectl -n purelb-system get pods                          # all Running
+kubectl -n purelb-system get pod -l name=lbnodeagent -o yaml | grep "image:"
+
+# Allocate a sample service:
+kubectl apply -f deployments/samples/local-servicegroup.yaml   # edit pool subnet first
+kubectl create deployment nginx --image=nginx
+kubectl apply -f deployments/samples/sample-nginx-lb.yaml
+kubectl get svc nginx                                          # EXTERNAL-IP populated
+
+# kubectl-purelb plugin checks (catch the BGPNodeStatus class of latent bugs
+# that v0.16.1-v0.16.3 shipped):
+kubectl purelb status                                          # returns data, no errors
+kubectl purelb pools                                           # shows the pool
+kubectl get bgpnodestatus -A                                   # one row per node (proves
+                                                               # the bundled k8gobgp is
+                                                               # writing the CRD that the
+                                                               # plugin reads)
+```
+
+If anything is empty, erroring, or missing, **STOP**. The release ships a
+bug.
+
+## Land the changes
+
+- [ ] Commit on `release/$NEW` branch.
+- [ ] Push, open PR, wait for the `test` job (which now includes
+      `check-deps`), merge.
+- [ ] `git checkout main && git pull && git tag $NEW <merge-sha> && git push origin $NEW`
+      — pin to the merge SHA, not HEAD, to avoid racing other merges.
+
+## CI auto-trigger chain
+
+Tag push fires:
+1. `ci.yml` (5 jobs, ~6 min): `test` → `build-images` → `build-plugin`
+   → `build-manifests` → `scan`
+2. `helm-index.yml` (workflow_run after `ci.yml` success, ~12 sec):
+   regenerates `website/static/charts/index.yaml`, commits to main
+3. `build.yml` (workflow_run after `helm-index.yml` success, ~3 min):
+   rebuilds Hugo site, deploys to GitHub Pages
+
+Total ~10 minutes from tag push to published index. No manual intervention.
+
+## Post-release verification
+
+- [ ] `gh release view $NEW` shows the expected assets (install manifests,
+      install-crds, plugin binaries × 6 platforms, chart .tgz, SHA256SUMS).
+- [ ] Both arches resolve:
+      `crane manifest --platform linux/amd64 ghcr.io/purelb/purelb/lbnodeagent:$NEW`
+      and same for `linux/arm64`.
+- [ ] Helm OCI chart resolves:
+      `crane manifest oci://ghcr.io/purelb/purelb/charts/purelb:$NEW`.
+- [ ] Helm index includes the new version:
+      `curl -s https://purelb.github.io/purelb/charts/index.yaml | grep -A2 "version: ${NEW#v}"`.
+- [ ] On a clean test cluster: install via the README URL, allocate a
+      sample service, confirm `kubectl purelb status` and
+      `kubectl get bgpnodestatus -A` return populated data.
+
+## If something goes wrong
+
+### CI partial failure after tag push
+
+If CI fails partway (e.g., images push but `build-manifests` errors), the
+GitHub release exists but is incomplete. Rollback:
+
+```bash
+gh release delete $NEW -R purelb/purelb --yes --cleanup-tag
+# (If gh is older and lacks --cleanup-tag, run:
+#   git push --delete origin $NEW && git tag -d $NEW
+#  manually after the release delete.)
+```
+
+Fix the root cause on a new branch, merge, retag with a fresh PR.
+
+### Auto-trigger chain stalls
+
+`gh workflow run helm-index.yml` then `gh workflow run build.yml`. (Has
+happened once historically; PR #46 fixed the underlying cause but keep
+this in your back pocket.)
+
+### Image deletion
+
+If you cut a tag in error and want to undo image publishes too, delete
+the relevant versions via:
+
+```bash
+gh api -X DELETE /orgs/purelb/packages/container/<pkg>/versions/<id>
+```
+
+Multi-arch indexes have child manifests that show as untagged versions —
+deleting the index alone leaves orphan children. See the GHCR cleanup
+playbook for the safe procedure (it requires `crane` to walk the index
+and identify child digests before deletion).

--- a/build/helm/purelb/values.yaml
+++ b/build/helm/purelb/values.yaml
@@ -266,7 +266,7 @@ gobgp:
 
   image:
     repository: ghcr.io/purelb/k8gobgp
-    tag: "0.2.2"
+    tag: "0.2.4"
     pullPolicy: IfNotPresent
 
   containerSecurityContext:

--- a/deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
+++ b/deployments/components/gobgp/gobgp-bgpconfig-crd.yaml
@@ -1,9 +1,10 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    config.kubernetes.io/index: '1'
+    internal.config.kubernetes.io/index: '1'
   name: configs.bgp.purelb.io
 spec:
   group: bgp.purelb.io
@@ -110,8 +111,7 @@ spec:
                         type: object
                     type: object
                   asn:
-                    description: ASN is the Autonomous System Number for this BGP
-                      speaker
+                    description: ASN is the Autonomous System Number for this BGP speaker
                     format: int32
                     type: integer
                   bindToDevice:
@@ -163,8 +163,7 @@ spec:
                     description: NodeStatus configures per-node BGPNodeStatus reporting
                     properties:
                       enabled:
-                        description: 'Enabled activates BGPNodeStatus reporting. Default:
-                          true.'
+                        description: 'Enabled activates BGPNodeStatus reporting. Default: true.'
                         type: boolean
                       heartbeatSeconds:
                         description: |-
@@ -267,8 +266,7 @@ spec:
                         adminDown:
                           type: boolean
                         authPassword:
-                          description: 'AuthPassword is the BGP authentication password
-                            (DEPRECATED: use AuthPasswordSecretRef instead)'
+                          description: 'AuthPassword is the BGP authentication password (DEPRECATED: use AuthPasswordSecretRef instead)'
                           type: string
                         authPasswordSecretRef:
                           description: |-
@@ -276,8 +274,7 @@ spec:
                             The Secret must contain a key matching the neighbor address or a default key "password"
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
                               default: ""
@@ -289,8 +286,7 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
+                              description: Specify whether the Secret or its key must be defined
                               type: boolean
                           required:
                           - key
@@ -342,16 +338,14 @@ spec:
                         label selector matches no objects.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
                             description: |-
                               A label selector requirement is a selector that contains values, a key, and an operator that
                               relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
+                                description: key is the label key that the selector applies to.
                                 type: string
                               operator:
                                 description: |-
@@ -428,65 +422,52 @@ spec:
                   type: object
                 type: array
               netlinkExport:
-                description: NetlinkExport configures global netlink export for exporting
-                  BGP routes to Linux kernel
+                description: NetlinkExport configures global netlink export for exporting BGP routes to Linux kernel
                 properties:
                   dampeningInterval:
-                    description: 'DampeningInterval in milliseconds to prevent flapping
-                      (default: 100)'
+                    description: 'DampeningInterval in milliseconds to prevent flapping (default: 100)'
                     format: int32
                     type: integer
                   enabled:
                     description: Enabled activates netlink export functionality
                     type: boolean
                   routeProtocol:
-                    description: 'RouteProtocol is the Linux route protocol identifier
-                      (default: 186 = RTPROT_BGP)'
+                    description: 'RouteProtocol is the Linux route protocol identifier (default: 186 = RTPROT_BGP)'
                     format: int32
                     type: integer
                   rules:
-                    description: Rules defines export rules for matching and exporting
-                      routes
+                    description: Rules defines export rules for matching and exporting routes
                     items:
-                      description: NetlinkExportRule defines a rule for exporting
-                        routes to Linux kernel
+                      description: NetlinkExportRule defines a rule for exporting routes to Linux kernel
                       properties:
                         communityList:
-                          description: 'CommunityList filters routes by standard BGP
-                            communities (format: "AS:VALUE" where AS and VALUE are
-                            0-65535)'
+                          description: 'CommunityList filters routes by standard BGP communities (format: "AS:VALUE" where AS and VALUE are 0-65535)'
                           items:
                             pattern: ^\d{1,5}:\d{1,5}$
                             type: string
                           type: array
                         largeCommunityList:
-                          description: 'LargeCommunityList filters routes by large
-                            BGP communities (format: "ASN:LocalData1:LocalData2")'
+                          description: 'LargeCommunityList filters routes by large BGP communities (format: "ASN:LocalData1:LocalData2")'
                           items:
                             pattern: ^\d+:\d+:\d+$
                             type: string
                           type: array
                         metric:
-                          description: 'Metric is the route metric/priority in Linux
-                            routing table (default: 20)'
+                          description: 'Metric is the route metric/priority in Linux routing table (default: 20)'
                           format: int32
                           type: integer
                         name:
-                          description: Name is a unique identifier for this export
-                            rule
+                          description: Name is a unique identifier for this export rule
                           type: string
                         tableId:
-                          description: TableId is the Linux routing table ID (0 =
-                            main table)
+                          description: TableId is the Linux routing table ID (0 = main table)
                           format: int32
                           type: integer
                         validateNexthop:
-                          description: 'ValidateNexthop enables nexthop reachability
-                            validation before exporting (default: true)'
+                          description: 'ValidateNexthop enables nexthop reachability validation before exporting (default: true)'
                           type: boolean
                         vrf:
-                          description: Vrf is the target VRF name (empty = global
-                            routing table)
+                          description: Vrf is the target VRF name (empty = global routing table)
                           type: string
                       required:
                       - name
@@ -494,21 +475,18 @@ spec:
                     type: array
                 type: object
               netlinkImport:
-                description: NetlinkImport configures global netlink import for importing
-                  connected routes
+                description: NetlinkImport configures global netlink import for importing connected routes
                 properties:
                   enabled:
                     description: Enabled activates netlink import functionality
                     type: boolean
                   interfaceList:
-                    description: InterfaceList specifies interfaces to import routes
-                      from (supports glob patterns like "eth*")
+                    description: InterfaceList specifies interfaces to import routes from (supports glob patterns like "eth*")
                     items:
                       type: string
                     type: array
                   vrf:
-                    description: Vrf specifies the VRF to import routes into (empty
-                      = global RIB)
+                    description: Vrf specifies the VRF to import routes into (empty = global RIB)
                     type: string
                 type: object
               peerGroups:
@@ -573,16 +551,13 @@ spec:
                     config:
                       properties:
                         authPassword:
-                          description: 'AuthPassword is the BGP authentication password
-                            (DEPRECATED: use AuthPasswordSecretRef instead)'
+                          description: 'AuthPassword is the BGP authentication password (DEPRECATED: use AuthPasswordSecretRef instead)'
                           type: string
                         authPasswordSecretRef:
-                          description: AuthPasswordSecretRef references a Secret containing
-                            the BGP authentication password
+                          description: AuthPasswordSecretRef references a Secret containing the BGP authentication password
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
                               default: ""
@@ -594,8 +569,7 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
+                              description: Specify whether the Secret or its key must be defined
                               type: boolean
                           required:
                           - key
@@ -621,16 +595,14 @@ spec:
                         label selector matches no objects.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
                             description: |-
                               A label selector requirement is a selector that contains values, a key, and an operator that
                               relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
+                                description: key is the label key that the selector applies to.
                                 type: string
                               operator:
                                 description: |-
@@ -816,13 +788,10 @@ spec:
                     name:
                       type: string
                     netlinkExport:
-                      description: VrfNetlinkExport configures netlink export for
-                        a specific VRF
+                      description: VrfNetlinkExport configures netlink export for a specific VRF
                       properties:
                         communityList:
-                          description: 'CommunityList filters routes by standard BGP
-                            communities (format: "AS:VALUE" where AS and VALUE are
-                            0-65535)'
+                          description: 'CommunityList filters routes by standard BGP communities (format: "AS:VALUE" where AS and VALUE are 0-65535)'
                           items:
                             pattern: ^\d{1,5}:\d{1,5}$
                             type: string
@@ -831,41 +800,34 @@ spec:
                           description: Enabled activates VRF-to-VRF export
                           type: boolean
                         largeCommunityList:
-                          description: 'LargeCommunityList filters routes by large
-                            BGP communities (format: "ASN:LocalData1:LocalData2")'
+                          description: 'LargeCommunityList filters routes by large BGP communities (format: "ASN:LocalData1:LocalData2")'
                           items:
                             pattern: ^\d+:\d+:\d+$
                             type: string
                           type: array
                         linuxTableId:
-                          description: LinuxTableId is the target Linux routing table
-                            ID (auto-lookup from Linux VRF if not specified)
+                          description: LinuxTableId is the target Linux routing table ID (auto-lookup from Linux VRF if not specified)
                           format: int32
                           type: integer
                         linuxVrf:
-                          description: LinuxVrf is the target Linux VRF name (defaults
-                            to GoBGP VRF name)
+                          description: LinuxVrf is the target Linux VRF name (defaults to GoBGP VRF name)
                           type: string
                         metric:
-                          description: Metric is the route metric/priority in Linux
-                            routing table
+                          description: Metric is the route metric/priority in Linux routing table
                           format: int32
                           type: integer
                         validateNexthop:
-                          description: 'ValidateNexthop enables nexthop reachability
-                            validation before exporting (default: true)'
+                          description: 'ValidateNexthop enables nexthop reachability validation before exporting (default: true)'
                           type: boolean
                       type: object
                     netlinkImport:
-                      description: VrfNetlinkImport configures netlink import for
-                        a specific VRF
+                      description: VrfNetlinkImport configures netlink import for a specific VRF
                       properties:
                         enabled:
                           description: Enabled activates netlink import for this VRF
                           type: boolean
                         interfaceList:
-                          description: InterfaceList specifies interfaces to import
-                            routes from (supports glob patterns)
+                          description: InterfaceList specifies interfaces to import routes from (supports glob patterns)
                           items:
                             type: string
                           type: array
@@ -882,11 +844,9 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions represent the latest available observations
-                  of the BGP configuration state
+                description: Conditions represent the latest available observations of the BGP configuration state
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -940,23 +900,20 @@ spec:
                   type: object
                 type: array
               establishedNeighbors:
-                description: EstablishedNeighbors is the count of neighbors in Established
-                  state
+                description: EstablishedNeighbors is the count of neighbors in Established state
                 type: integer
               lastReconcileTime:
                 description: LastReconcileTime is the timestamp of the last reconciliation
                 format: date-time
                 type: string
               message:
-                description: Message provides additional information about the current
-                  state
+                description: Message provides additional information about the current state
                 type: string
               neighborCount:
                 description: NeighborCount is the number of configured BGP neighbors
                 type: integer
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  by the controller
+                description: ObservedGeneration is the most recent generation observed by the controller
                 format: int64
                 type: integer
               routerIDResolutionTime:

--- a/deployments/components/gobgp/gobgp-bgpnodestatus-crd.yaml
+++ b/deployments/components/gobgp/gobgp-bgpnodestatus-crd.yaml
@@ -1,9 +1,10 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    config.kubernetes.io/index: '0'
+    internal.config.kubernetes.io/index: '0'
   name: bgpnodestatuses.bgp.purelb.io
 spec:
   group: bgp.purelb.io
@@ -57,23 +58,19 @@ spec:
           metadata:
             type: object
           spec:
-            description: BGPNodeStatusSpec is intentionally empty — BGPNodeStatus
-              is a status-only resource.
+            description: BGPNodeStatusSpec is intentionally empty — BGPNodeStatus is a status-only resource.
             type: object
           status:
-            description: BGPNodeStatusData holds the per-node BGP state reported by
-              the k8gobgp agent.
+            description: BGPNodeStatusData holds the per-node BGP state reported by the k8gobgp agent.
             properties:
               asn:
                 description: ASN is the local Autonomous System Number
                 format: int32
                 type: integer
               conditions:
-                description: Conditions represent the latest available observations
-                  of the node's BGP state
+                description: Conditions represent the latest available observations of the node's BGP state
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -132,8 +129,7 @@ spec:
                   Conditions are authoritative; this is a convenience summary.
                 type: boolean
               heartbeatSeconds:
-                description: HeartbeatSeconds is the configured heartbeat interval,
-                  echoed so the plugin can calculate staleness
+                description: HeartbeatSeconds is the configured heartbeat interval, echoed so the plugin can calculate staleness
                 format: int32
                 type: integer
               lastUpdated:
@@ -146,8 +142,7 @@ spec:
               neighbors:
                 description: Neighbors is the list of BGP neighbor session states
                 items:
-                  description: NeighborStatus reports the state of a single BGP neighbor
-                    session.
+                  description: NeighborStatus reports the state of a single BGP neighbor session.
                   properties:
                     address:
                       description: Address is the neighbor's IP address
@@ -156,8 +151,7 @@ spec:
                       description: Description is the configured neighbor description
                       type: string
                     lastError:
-                      description: LastError is the BGP notification code/subcode
-                        for non-Established neighbors
+                      description: LastError is the BGP notification code/subcode for non-Established neighbors
                       type: string
                     localASN:
                       description: LocalASN is the local AS used for this session
@@ -168,23 +162,19 @@ spec:
                       format: int32
                       type: integer
                     prefixesReceived:
-                      description: PrefixesReceived is the number of prefixes received
-                        from this neighbor
+                      description: PrefixesReceived is the number of prefixes received from this neighbor
                       format: int64
                       type: integer
                     prefixesSent:
-                      description: PrefixesSent is the number of prefixes advertised
-                        to this neighbor
+                      description: PrefixesSent is the number of prefixes advertised to this neighbor
                       format: int64
                       type: integer
                     sessionUpSince:
-                      description: SessionUpSince is when the session entered Established
-                        state
+                      description: SessionUpSince is when the session entered Established state
                       format: date-time
                       type: string
                     state:
-                      description: 'State is the BGP FSM state: Idle, Connect, Active,
-                        OpenSent, OpenConfirm, Established'
+                      description: 'State is the BGP FSM state: Idle, Connect, Active, OpenSent, OpenConfirm, Established'
                       type: string
                   required:
                   - address
@@ -202,31 +192,25 @@ spec:
                     description: Enabled indicates whether netlink export is active
                     type: boolean
                   exportedRoutes:
-                    description: ExportedRoutes lists routes exported to the Linux
-                      kernel
+                    description: ExportedRoutes lists routes exported to the Linux kernel
                     items:
-                      description: ExportedRoute reports a single route exported to
-                        the Linux kernel.
+                      description: ExportedRoute reports a single route exported to the Linux kernel.
                       properties:
                         installed:
-                          description: Installed indicates whether this route was
-                            successfully installed in the kernel
+                          description: Installed indicates whether this route was successfully installed in the kernel
                           type: boolean
                         metric:
-                          description: Metric is the route metric in the Linux routing
-                            table
+                          description: Metric is the route metric in the Linux routing table
                           format: int32
                           type: integer
                         prefix:
                           description: Prefix is the exported IP prefix
                           type: string
                         reason:
-                          description: Reason explains why a route was not installed
-                            (e.g., "nexthop unreachable")
+                          description: Reason explains why a route was not installed (e.g., "nexthop unreachable")
                           type: string
                         table:
-                          description: Table is the Linux routing table name (e.g.,
-                            "main")
+                          description: Table is the Linux routing table name (e.g., "main")
                           type: string
                       required:
                       - installed
@@ -236,19 +220,16 @@ spec:
                       type: object
                     type: array
                   protocol:
-                    description: Protocol is the Linux route protocol identifier (e.g.,
-                      186 = RTPROT_BGP)
+                    description: Protocol is the Linux route protocol identifier (e.g., 186 = RTPROT_BGP)
                     format: int32
                     type: integer
                   rules:
                     description: Rules lists the configured export rules
                     items:
-                      description: ExportRuleStatus reports the configuration of a
-                        single export rule.
+                      description: ExportRuleStatus reports the configuration of a single export rule.
                       properties:
                         metric:
-                          description: Metric is the route metric in the Linux routing
-                            table
+                          description: Metric is the route metric in the Linux routing table
                           format: int32
                           type: integer
                         name:
@@ -265,12 +246,10 @@ spec:
                       type: object
                     type: array
                   totalExported:
-                    description: TotalExported is the total count of exported routes
-                      (may exceed len(ExportedRoutes) if truncated)
+                    description: TotalExported is the total count of exported routes (may exceed len(ExportedRoutes) if truncated)
                     type: integer
                   truncated:
-                    description: Truncated indicates the exportedRoutes list was capped
-                      at the maximum
+                    description: Truncated indicates the exportedRoutes list was capped at the maximum
                     type: boolean
                 required:
                 - enabled
@@ -286,16 +265,13 @@ spec:
                   importedAddresses:
                     description: ImportedAddresses lists addresses imported from interfaces
                     items:
-                      description: ImportedAddress reports a single address imported
-                        from an interface.
+                      description: ImportedAddress reports a single address imported from an interface.
                       properties:
                         address:
-                          description: Address is the imported IP address with prefix
-                            length (e.g., "10.100.0.1/32")
+                          description: Address is the imported IP address with prefix length (e.g., "10.100.0.1/32")
                           type: string
                         inRIB:
-                          description: InRIB indicates whether this address exists
-                            as a route in the BGP RIB
+                          description: InRIB indicates whether this address exists as a route in the BGP RIB
                           type: boolean
                         interface:
                           description: Interface is the source interface name
@@ -307,22 +283,18 @@ spec:
                       type: object
                     type: array
                   interfaces:
-                    description: Interfaces reports the state of each watched import
-                      interface
+                    description: Interfaces reports the state of each watched import interface
                     items:
-                      description: ImportInterfaceStatus reports the state of a single
-                        import interface.
+                      description: ImportInterfaceStatus reports the state of a single import interface.
                       properties:
                         exists:
-                          description: Exists indicates whether the interface exists
-                            on this node
+                          description: Exists indicates whether the interface exists on this node
                           type: boolean
                         name:
                           description: Name is the interface name (e.g., "kube-lb0")
                           type: string
                         operState:
-                          description: 'OperState is the operational state: "up" or
-                            "down"'
+                          description: 'OperState is the operational state: "up" or "down"'
                           type: string
                       required:
                       - exists
@@ -331,16 +303,13 @@ spec:
                       type: object
                     type: array
                   totalImported:
-                    description: TotalImported is the total count of imported addresses
-                      (may exceed len(ImportedAddresses) if truncated)
+                    description: TotalImported is the total count of imported addresses (may exceed len(ImportedAddresses) if truncated)
                     type: integer
                   truncated:
-                    description: Truncated indicates the importedAddresses list was
-                      capped at the maximum
+                    description: Truncated indicates the importedAddresses list was capped at the maximum
                     type: boolean
                   vrf:
-                    description: VRF is the VRF that routes are imported into (empty
-                      = global RIB)
+                    description: VRF is the VRF that routes are imported into (empty = global RIB)
                     type: string
                 required:
                 - enabled
@@ -353,8 +322,7 @@ spec:
                 description: RIB reports the BGP RIB summary
                 properties:
                   localRouteCount:
-                    description: LocalRouteCount is the total count of local routes
-                      (may exceed len(LocalRoutes) if truncated)
+                    description: LocalRouteCount is the total count of local routes (may exceed len(LocalRoutes) if truncated)
                     type: integer
                   localRoutes:
                     description: LocalRoutes lists routes originating from this node
@@ -362,27 +330,23 @@ spec:
                       description: RIBRoute reports a single route in the BGP RIB.
                       properties:
                         advertisedTo:
-                          description: AdvertisedTo lists neighbor addresses this
-                            route is advertised to (only for local routes)
+                          description: AdvertisedTo lists neighbor addresses this route is advertised to (only for local routes)
                           items:
                             type: string
                           type: array
                         communities:
-                          description: Communities lists BGP communities attached
-                            to this route
+                          description: Communities lists BGP communities attached to this route
                           items:
                             type: string
                           type: array
                         fromPeer:
-                          description: FromPeer is the peer that advertised this route
-                            (only for received routes)
+                          description: FromPeer is the peer that advertised this route (only for received routes)
                           type: string
                         nextHop:
                           description: NextHop is the route's next-hop address
                           type: string
                         prefix:
-                          description: Prefix is the IP prefix (e.g., "10.100.0.1/32"
-                            or "2001:db8::/32")
+                          description: Prefix is the IP prefix (e.g., "10.100.0.1/32" or "2001:db8::/32")
                           type: string
                       required:
                       - nextHop
@@ -390,8 +354,7 @@ spec:
                       type: object
                     type: array
                   receivedRouteCount:
-                    description: ReceivedRouteCount is the total count of received
-                      routes (may exceed len(ReceivedRoutes) if truncated)
+                    description: ReceivedRouteCount is the total count of received routes (may exceed len(ReceivedRoutes) if truncated)
                     type: integer
                   receivedRoutes:
                     description: ReceivedRoutes lists routes received from BGP peers
@@ -399,27 +362,23 @@ spec:
                       description: RIBRoute reports a single route in the BGP RIB.
                       properties:
                         advertisedTo:
-                          description: AdvertisedTo lists neighbor addresses this
-                            route is advertised to (only for local routes)
+                          description: AdvertisedTo lists neighbor addresses this route is advertised to (only for local routes)
                           items:
                             type: string
                           type: array
                         communities:
-                          description: Communities lists BGP communities attached
-                            to this route
+                          description: Communities lists BGP communities attached to this route
                           items:
                             type: string
                           type: array
                         fromPeer:
-                          description: FromPeer is the peer that advertised this route
-                            (only for received routes)
+                          description: FromPeer is the peer that advertised this route (only for received routes)
                           type: string
                         nextHop:
                           description: NextHop is the route's next-hop address
                           type: string
                         prefix:
-                          description: Prefix is the IP prefix (e.g., "10.100.0.1/32"
-                            or "2001:db8::/32")
+                          description: Prefix is the IP prefix (e.g., "10.100.0.1/32" or "2001:db8::/32")
                           type: string
                       required:
                       - nextHop
@@ -427,8 +386,7 @@ spec:
                       type: object
                     type: array
                   truncated:
-                    description: Truncated indicates a route list was capped at the
-                      maximum
+                    description: Truncated indicates a route list was capped at the maximum
                     type: boolean
                 required:
                 - localRouteCount
@@ -448,12 +406,10 @@ spec:
                   description: VRFStatus reports the summary state of a single VRF.
                   properties:
                     exportedRouteCount:
-                      description: ExportedRouteCount is the number of routes exported
-                        to the kernel for this VRF
+                      description: ExportedRouteCount is the number of routes exported to the kernel for this VRF
                       type: integer
                     importedRouteCount:
-                      description: ImportedRouteCount is the number of routes in this
-                        VRF's RIB
+                      description: ImportedRouteCount is the number of routes in this VRF's RIB
                       type: integer
                     name:
                       description: Name is the VRF name

--- a/deployments/components/gobgp/gobgp-patch.yaml
+++ b/deployments/components/gobgp/gobgp-patch.yaml
@@ -13,7 +13,7 @@ spec:
         emptyDir: {}
       containers:
       - name: k8gobgp
-        image: ghcr.io/purelb/k8gobgp:0.2.3
+        image: ghcr.io/purelb/k8gobgp:0.2.4
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/website/content/docs/installation/helm/_index.md
+++ b/website/content/docs/installation/helm/_index.md
@@ -30,7 +30,7 @@ helm install --create-namespace --namespace=purelb-system purelb purelb/purelb \
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.3
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.4
 ```
 
 ## Key Configuration Values

--- a/website/content/docs/installation/manifest/_index.md
+++ b/website/content/docs/installation/manifest/_index.md
@@ -9,8 +9,8 @@ The quickest way to install PureLB is with kubectl. Installation is a two-step p
 ## With BGP Support (Default)
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-v0.16.3.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
 ```
 
 This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After installing, create a [BGPConfiguration]({{< relref "/docs/configuration/bgp" >}}) CR to configure BGP peering.
@@ -18,8 +18,8 @@ This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After
 ## Without BGP Support
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-nobgp-v0.16.3.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-nobgp-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-nobgp-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-nobgp-v0.16.4.yaml
 ```
 
 Use this variant if you only need local addresses (same subnet as your nodes) and do not need BGP routing.
@@ -62,8 +62,8 @@ The manifest creates:
 To upgrade, apply the new version's manifests:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-v0.16.3.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-v0.16.3.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
 ```
 
 Existing services retain their allocated addresses during the upgrade.

--- a/website/content/docs/migration/_index.md
+++ b/website/content/docs/migration/_index.md
@@ -168,7 +168,7 @@ Previous versions required users to install and configure standalone routing sof
 
 3. **Install the v2 CRDs** (they replace the v1 CRDs):
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-crds-v0.16.3.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
    ```
 
 4. **Apply converted CRs:**
@@ -179,7 +179,7 @@ Previous versions required users to install and configure standalone routing sof
 
 5. **Upgrade PureLB:**
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.3/install-v0.16.3.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
    ```
 
 6. **Verify:** Existing services should retain their allocated addresses. Check with:

--- a/website/content/docs/reference/helm-values/_index.md
+++ b/website/content/docs/reference/helm-values/_index.md
@@ -67,7 +67,7 @@ Value | Type | Default | Description
 ------|------|---------|------------
 `gobgp.enabled` | bool | `true` | Enable k8gobgp BGP sidecar in the lbnodeagent DaemonSet
 `gobgp.image.repository` | string | `ghcr.io/purelb/k8gobgp` | k8gobgp container image
-`gobgp.image.tag` | string | `"0.2.2"` | k8gobgp image tag
+`gobgp.image.tag` | string | `"0.2.4"` | k8gobgp image tag
 `gobgp.image.pullPolicy` | string | `IfNotPresent` | Image pull policy
 `gobgp.containerSecurityContext` | object | (see below) | Container security context
 `gobgp.resources.requests.cpu` | string | `250m` | CPU request


### PR DESCRIPTION
## Summary

- **Fix:** kubectl-purelb's BGP-visibility commands (`kubectl purelb bgp`, `kubectl get bgpnodestatus`) have been silently empty since v0.16.1 because the bundled k8gobgp 0.2.2 doesn't populate the BGPNodeStatus CRD that the plugin reads. Bumps bundled k8gobgp to 0.2.4 (skipping 0.2.3 which had a netlink fix shipped in 0.2.4).
- **Prevent recurrence:** Adds `make check-deps` gate that fails CI when bundled CRDs in `deployments/components/gobgp/` drift from what the pinned `GOBGP_TAG` produces. Wired into `make check` so the existing `test` job enforces it. This is the gate that would have failed commit `e12a83a0`'s PR 32 days ago.
- **Procedure:** Rewrites `make fetch-gobgp-crd` to extract per-CRD-name and fail loudly on unknown CRDs; codifies the manual release checklist in a new `/RELEASING.md`.

## Why this PR is bigger than a routine dep bump

This release is a process correction, not just a version bump. The same author shipping (a) the kubectl-purelb plugin code that reads BGPNodeStatus, (b) the BGPNodeStatus CRD definition, and (c) NOT bumping `GOBGP_TAG` to a release that produces the CRD — all in the same commit — was the root failure. Three subsequent release procedures rubber-stamped the gap because no automated check existed. This PR adds the automated check.

## Test plan

- [x] `make check` (now includes `check-deps`) passes locally — verified against v0.2.4
- [x] `make check-deps` fails correctly when CRDs drift (verified via negative test against v0.2.2)
- [x] `make fetch-gobgp-crd` extracts both CRDs, validates total count, fails loudly on unknown CRD names
- [x] `make manifest`, `make install-manifest`, `make helm` all render with `k8gobgp:0.2.4` baked in
- [ ] CI test job passes (verify after push)
- [ ] Clean-cluster install via `install-v0.16.4.yaml`: `kubectl get bgpnodestatus -A` returns rows (the latent-bug fix)
- [ ] Clean-cluster install via Helm OCI: same verification

## CRD diff

The bundled `gobgp-bgpconfig-crd.yaml` and `gobgp-bgpnodestatus-crd.yaml` were regenerated from k8gobgp v0.2.4. **Diffs are description-only — no schema changes, no required-field additions, no removed fields.** Pure documentation cleanup. Zero migration impact.

## Follow-ups (separate issues opened with this PR)

- #54 — Add kind-based end-to-end smoke test to CI (target before v0.16.5)
- #55 — Triage Dependabot queue weekly; close or merge within 7 days