### PR TITLE
docs: refine homepage tagline

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -5,7 +5,7 @@ type: docs
 
 # PureLB
 
-PureLB is a lightweight Kubernetes [Service LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) for non-cloud deployments. It allocates IP addresses from configured pools and uses standard Linux networking to announce them, giving your services external reachability without a cloud provider.
+PureLB is a Kubernetes [Service LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) for bare metal deployments. It allocates IP addresses from configured pools, uses standard Linux networking and optionally BGP to announce them, giving your services external reachability.
 
 **[GitHub](https://github.com/purelb/purelb)** | **[#purelb-users on Kubernetes Slack](https://kubernetes.slack.com/messages/purelb-users)**
 

--- a/website/layouts/_partials/google_analytics.html
+++ b/website/layouts/_partials/google_analytics.html
@@ -1,0 +1,11 @@
+{{- with site.Config.Services.GoogleAnalytics.ID -}}
+{{- if hugo.IsProduction -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ . }}');
+</script>
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- Drop "lightweight", reframe as bare-metal deployments, mention BGP in the announcement description, tighten wording.

## Test plan
- [ ] After merge, verify https://purelb.io/ renders the updated description in the hero/lead paragraph.