### PR TITLE
docs: add GitHub Sponsors funding links and CI/release/license badges

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [purelb]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # PureLB - is a Service Load Balancer for Kubernetes
 
+[![Tests](https://github.com/purelb/purelb/actions/workflows/ci.yml/badge.svg)](https://github.com/purelb/purelb/actions/workflows/ci.yml)
+[![Releases](https://img.shields.io/github/release/purelb/purelb/all.svg?style=flat-square)](https://github.com/purelb/purelb/releases)
+[![LICENSE](https://img.shields.io/github/license/purelb/purelb.svg?style=flat-square)](https://github.com/purelb/purelb/blob/main/LICENSE)
+[![Sponsor](https://img.shields.io/badge/Sponsor-PureLB-ea4aaa?logo=github)](https://github.com/sponsors/purelb)
+
 [PureLB](https://purelb.io) is a load-balancer orchestrator for  [Kubernetes](https://kubernetes.io) clusters. It uses standard
 Linux networking, integrates goBGP for routing, and works with the operating
 systems netlink library to add and remove address from interfaces to announce service addresses.
@@ -179,3 +184,8 @@ to your own registry or to a tarball.
 ## Credits
 
 PureLB was forked from MetalLB in 2020.  We believed a better solution was to use Linux networking functionality instead of working around it but the maintainers at the time had no interest in making any changes.  We would like to acknowledge the original developer, [Dave Anderson](https://www.dave.tf/) we hope you would be pleased with our work!!
+
+## Support PureLB
+
+PureLB is open source. If your organization relies on it, please consider
+sponsoring development: [github.com/sponsors/purelb](https://github.com/sponsors/purelb).

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 PureLB is a Kubernetes [Service LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) for bare metal deployments. It allocates IP addresses from configured pools, uses standard Linux networking and optionally BGP to announce them, giving your services external reachability.
 
-**[GitHub](https://github.com/purelb/purelb)** | **[#purelb-users on Kubernetes Slack](https://kubernetes.slack.com/messages/purelb-users)**
+**[GitHub](https://github.com/purelb/purelb)** | **[#purelb-users on Kubernetes Slack](https://kubernetes.slack.com/messages/purelb-users)** | **[Sponsor on GitHub](https://github.com/sponsors/purelb)**
 
 ## Features
 

--- a/website/content/docs/contributing/_index.md
+++ b/website/content/docs/contributing/_index.md
@@ -30,6 +30,10 @@ make plugin         # Build kubectl-purelb binary
 - **Slack:** [#purelb-users](https://kubernetes.slack.com/messages/purelb-users) in the Kubernetes workspace
 - **Issues:** [GitHub Issues](https://github.com/purelb/purelb/issues)
 
+## Sponsor PureLB
+
+If your organization uses PureLB, please consider sponsoring ongoing development via [GitHub Sponsors](https://github.com/sponsors/purelb).
+
 ## Credits
 
 PureLB was forked from MetalLB in 2020. We believed a better solution was to use Linux networking functionality instead of working around it. We would like to acknowledge the original developer, [Dave Anderson](https://www.dave.tf/).


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` pointing to `github.com/sponsors/purelb`, which enables the **Sponsor** button on the repo page
- Adds funding links to three user-facing surfaces:
  - `README.md` header (Sponsor badge) and a new `## Support PureLB` section after Credits
  - `website/content/_index.md` (homepage) — appended to the existing GitHub/Slack link line
  - `website/content/docs/contributing/_index.md` — new `## Sponsor PureLB` subsection between "Getting Help" and "Credits"
- Adds Tests, Releases, and LICENSE badges to the README header, matching the [gobgp-netlink](https://github.com/purelb/gobgp-netlink) pattern for cross-repo consistency

No code changes. 16 lines added across 4 files.

## Test plan

- [ ] Confirm `https://github.com/sponsors/purelb` is published before merging (badges/links will 404 otherwise)
- [ ] After merge, verify the **Sponsor** button appears on the repo page next to Watch / Star / Fork
- [ ] After merge, click the Sponsor button and confirm it routes to `github.com/sponsors/purelb`
- [ ] Verify README badges render correctly on GitHub (Tests, Releases, LICENSE, Sponsor)
- [ ] Verify website renders cleanly on `purelb.io` after deploy — homepage Sponsor link and contributing page Sponsor section