### PR TITLE
release: v0.16.5 — fix Helm RBAC for bgpnodestatuses, add check-helm-rbac-source gate

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ This project uses GitHub Actions for CI/CD:
 
 - **Tests** run on all branches and pull requests
 - **Container images** are built and pushed to `ghcr.io/purelb/purelb` on main branch and tags
-- **Releases** are created automatically when a version tag (e.g., `v0.16.4`) is pushed
+- **Releases** are created automatically when a version tag (e.g., `v0.16.5`) is pushed
 
 ## Local Development
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help: ## Display help message
 all: check crd image ## Build it all!
 
 .PHONY: check
-check: generate check-deps ## Run "short" tests + bundled-dep consistency check
+check: generate check-deps check-helm-rbac-source ## Run "short" tests + bundled-dep consistency check
 	go vet ./...
 	NETBOX_BASE_URL=${NETBOX_BASE_URL} NETBOX_USER_TOKEN=${NETBOX_USER_TOKEN} go test -race -short ./...
 
@@ -151,6 +151,25 @@ fetch-gobgp-crd:  ## Fetch CRDs from k8gobgp ${GOBGP_TAG} release (writes 1 file
 	fi
 	echo "OK: extracted $$IN CRD(s) from k8gobgp ${GOBGP_TAG}"
 
+.PHONY: check-helm-rbac-source
+check-helm-rbac-source:  ## Verify Helm RBAC template injects rules from kustomize source
+	@set -e
+	HELM_TPL=build/helm/purelb/templates/gobgp-rbac.yaml
+	if ! grep -q '@@INJECT_RBAC_RULES@@' $$HELM_TPL; then
+	  echo "ERROR: @@INJECT_RBAC_RULES@@ marker missing from $$HELM_TPL." >&2
+	  echo "       The marker is required so 'make helm' can inject rules from" >&2
+	  echo "       deployments/components/gobgp/gobgp-rbac.yaml (the single source of truth)." >&2
+	  exit 1
+	fi
+	INLINE=$$(awk '/^rules:$$/{f=1; next} /^---$$/{f=0} f' $$HELM_TPL | grep -c '^- apiGroups:' || true)
+	if [ "$$INLINE" != "0" ]; then
+	  echo "ERROR: $$INLINE inline rule(s) found in $$HELM_TPL." >&2
+	  echo "       Rules must live ONLY in deployments/components/gobgp/gobgp-rbac.yaml." >&2
+	  echo "       Edit there; 'make helm' will inject them at chart-package time." >&2
+	  exit 1
+	fi
+	echo "OK: Helm RBAC template uses kustomize source"
+
 .PHONY: check-deps
 check-deps:  ## Verify bundled k8gobgp CRDs match the pinned GOBGP_TAG release
 	@set -e
@@ -173,6 +192,7 @@ check-deps:  ## Verify bundled k8gobgp CRDs match the pinned GOBGP_TAG release
 	echo "OK: bundled CRDs match k8gobgp ${GOBGP_TAG}"
 
 .PHONY: helm
+helm: CACHE_RULES != mktemp
 helm:  ## Package PureLB using Helm
 	rm -rf build/build
 	mkdir -p build/build
@@ -181,6 +201,17 @@ helm:  ## Package PureLB using Helm
 	cp deployments/components/gobgp/gobgp-bgpconfig-crd.yaml build/build/purelb/crds/bgp.purelb.io_bgpconfigurations.yaml
 	cp deployments/components/gobgp/gobgp-bgpnodestatus-crd.yaml build/build/purelb/crds/bgp.purelb.io_bgpnodestatuses.yaml
 	cp README.md build/build/purelb
+
+# Inject ClusterRole rules from the kustomize source into the Helm template.
+# Single source of truth: deployments/components/gobgp/gobgp-rbac.yaml.
+# awk extracts lines between "rules:" and the next "---" (exclusive on both).
+# sed replaces the @@INJECT_RBAC_RULES@@ marker line with those rules.
+	awk '/^rules:$$/{f=1; next} /^---$$/{f=0} f' \
+	  deployments/components/gobgp/gobgp-rbac.yaml > ${CACHE_RULES}
+	sed -i "/@@INJECT_RBAC_RULES@@/r ${CACHE_RULES}" \
+	  build/build/purelb/templates/gobgp-rbac.yaml
+	sed -i "/@@INJECT_RBAC_RULES@@/d" \
+	  build/build/purelb/templates/gobgp-rbac.yaml
 
 	sed \
 	--expression="s~DEFAULT_REPO~${REGISTRY_IMAGE}~" \

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 Install CRDs first, then apply the main install manifest:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-nobgp-v0.16.4.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-nobgp-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-nobgp-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-nobgp-v0.16.5.yaml
 ```
 
 The CRDs must be applied first because the install manifest includes a default
@@ -50,7 +50,7 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.4
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.5
 ```
 
 To install without BGP support:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,10 @@
 # Releasing PureLB
 
 This document is the canonical release procedure for PureLB. The primary
-defense against drift is the `make check-deps` CI gate; this checklist is
-the secondary defense, covering what the gate cannot enforce (procedural
-drift, missed doc bumps, post-tag rollback).
+defense against drift is the CI gate stack (`make check-deps` for k8gobgp
+CRDs; `make check-helm-rbac-source` for Helm vs kustomize RBAC); this
+checklist is the secondary defense, covering what the gates cannot
+enforce (procedural drift, missed doc bumps, post-tag rollback).
 
 Run through every section in order. Each item exists because a prior
 release missed it.
@@ -11,10 +12,14 @@ release missed it.
 ## Pre-flight (hard gates)
 
 - [ ] `git status` clean on `main`, `git pull` up to date.
-- [ ] `make check` passes locally. **This includes `make check-deps`. If
-      `check-deps` fails, you have a CRD/version mismatch and must NOT
+- [ ] `make check` passes locally. **This includes `make check-deps`
+      (CRD pin consistency) and `make check-helm-rbac-source` (Helm RBAC
+      template is a thin wrapper around `deployments/components/gobgp/gobgp-rbac.yaml`).
+      If `check-deps` fails, you have a CRD/version mismatch and must NOT
       proceed — fix it via the [Dependency review](#dependency-review-k8gobgp)
-      below.**
+      below. If `check-helm-rbac-source` fails, the Helm template lost its
+      injection marker or someone added inline rules — restore the marker,
+      move any rule additions to the kustomize source.**
 - [ ] **Dependabot triage**: `gh pr list -R purelb/purelb -l dependencies`.
       For each open PR: merge, close with reason, or explicitly defer to a
       named target release. **Empty queue or every PR explicitly
@@ -98,17 +103,32 @@ Before pushing the branch, run a clean rebuild to surface anything CI
 would catch — but with a 6-minute round-trip saved per failure:
 
 ```bash
-make check                              # vet + race tests + check-deps
+make check                              # vet + race tests + check-deps + check-helm-rbac-source
 SUFFIX=$NEW make manifest               # render the install manifest
 SUFFIX=$NEW make install-manifest       # render the standalone install
 SUFFIX=$NEW make helm                   # package the chart
-grep "k8gobgp:" deployments/install-${NEW}.yaml   # confirms new tag in output
+grep "k8gobgp:" deployments/install-${NEW}.yaml          # confirms new tag in output
+grep bgpnodestatuses build/build/purelb/templates/gobgp-rbac.yaml  # confirms rule injection
 ```
 
 **Required (not "if handy"): clean-cluster smoke test.** Per project
 convention, pre-existing CRDs/state mask real ordering bugs. Until CI has
 an automated end-to-end smoke test, this manual run is the only thing
 standing between a known bug and your users.
+
+**You must run both pre-tag smoke tests.** The manifest path and the
+Helm chart path are distinct artifacts; v0.16.1–v0.16.4 shipped a broken
+Helm chart for 32+ days because only the manifest path was smoke-tested.
+
+Pre-tag, there is no "OCI vs classic repo" distinction yet — neither
+distribution channel has a chart for `$NEW` until the tag is pushed and
+CI publishes. Pre-tag smoke test B installs the local `.tgz` that
+`make helm` just produced; that is the exact byte stream both
+distribution channels will serve post-release. The OCI-vs-classic
+distinction is validated **post-release** in [Post-release
+verification](#post-release-verification).
+
+### Smoke test A — manifest install
 
 ```bash
 # On a clean kind/k3d cluster (kubectl context set to it):
@@ -133,14 +153,79 @@ kubectl get bgpnodestatus -A                                   # one row per nod
                                                                # plugin reads)
 ```
 
-If anything is empty, erroring, or missing, **STOP**. The release ships a
-bug.
+Tear down before the next test:
+
+```bash
+kubectl delete -f deployments/install-${NEW}.yaml
+kubectl delete -f deployments/install-crds-${NEW}.yaml
+```
+
+### Smoke test B — Helm install (local tgz)
+
+The chart `.tgz` produced by `make helm` is the exact byte stream that
+will land in the OCI registry and the classic-repo index post-release.
+Pre-tag, install it directly from disk to verify the chart contents
+before any publishing happens. The container images the chart references
+do need to be pullable, so build and push them under an `rc1` tag first.
+
+```bash
+export KO_DOCKER_REPO=ghcr.io/purelb/purelb
+export TAG=${NEW}-rc1
+go run github.com/google/ko@v0.17.1 build --base-import-paths --tags=$TAG ./cmd/allocator
+go run github.com/google/ko@v0.17.1 build --base-import-paths --tags=$TAG ./cmd/lbnodeagent
+SUFFIX=$TAG REGISTRY_IMAGE=ghcr.io/purelb/purelb make helm
+# Now ./purelb-${TAG}.tgz contains a chart whose values.yaml references
+# the rc1 images we just pushed.
+
+helm install --create-namespace -n purelb-system purelb \
+  ./purelb-${TAG}.tgz
+kubectl -n purelb-system get pods                              # all Running
+
+# CRITICAL: the v0.16.5 release was cut because this assertion was
+# never run before. The Helm RBAC was missing bgpnodestatuses.
+kubectl get clusterrole purelb:k8gobgp -o yaml | grep -A1 bgpnodestatuses
+# Expected: bgpnodestatuses AND bgpnodestatuses/status both present.
+
+# Then run the sample-service + plugin checks:
+kubectl apply -f deployments/samples/local-servicegroup.yaml
+kubectl create deployment nginx --image=nginx
+kubectl apply -f deployments/samples/sample-nginx-lb.yaml
+kubectl get svc nginx                                          # EXTERNAL-IP populated
+kubectl purelb status                                          # no errors
+kubectl get bgpnodestatus -A                                   # one row per node
+```
+
+Tear down:
+
+```bash
+helm uninstall purelb -n purelb-system
+kubectl delete crd servicegroups.purelb.io lbnodeagents.purelb.io \
+  configs.bgp.purelb.io bgpnodestatuses.bgp.purelb.io
+kubectl delete ns purelb-system
+```
+
+If anything is empty, erroring, or missing in either of the two
+pre-tag smoke tests, **STOP**. The release ships a bug.
+
+### Cleanup of rc1 artifacts
+
+After the pre-tag smoke tests pass, delete the rc1 container image
+versions from ghcr.io so they don't clutter the registry:
+
+```bash
+gh api -X DELETE /orgs/purelb/packages/container/purelb%2Fallocator/versions/<id-of-rc1>
+gh api -X DELETE /orgs/purelb/packages/container/purelb%2Flbnodeagent/versions/<id-of-rc1>
+```
+
+(Use `gh api /orgs/purelb/packages/container/<pkg>/versions` to find IDs.
+No chart cleanup needed since pre-tag smoke uses a local tgz, never a
+published chart.)
 
 ## Land the changes
 
 - [ ] Commit on `release/$NEW` branch.
 - [ ] Push, open PR, wait for the `test` job (which now includes
-      `check-deps`), merge.
+      `check-deps` and `check-helm-rbac-source`), merge.
 - [ ] `git checkout main && git pull && git tag $NEW <merge-sha> && git push origin $NEW`
       — pin to the merge SHA, not HEAD, to avoid racing other merges.
 
@@ -167,9 +252,21 @@ Total ~10 minutes from tag push to published index. No manual intervention.
       `crane manifest oci://ghcr.io/purelb/purelb/charts/purelb:$NEW`.
 - [ ] Helm index includes the new version:
       `curl -s https://purelb.github.io/purelb/charts/index.yaml | grep -A2 "version: ${NEW#v}"`.
-- [ ] On a clean test cluster: install via the README URL, allocate a
-      sample service, confirm `kubectl purelb status` and
-      `kubectl get bgpnodestatus -A` return populated data.
+- [ ] **On a clean test cluster, repeat all three install paths against
+      the official tag** (now that the chart is in the classic-repo index):
+      - [ ] manifest install: `kubectl apply -f install-crds-${NEW}.yaml`
+            then `install-${NEW}.yaml`
+      - [ ] Helm OCI install: `helm install ... oci://ghcr.io/purelb/purelb/charts/purelb --version $NEW`
+      - [ ] Helm classic-repo install:
+            `helm repo add purelb https://purelb.github.io/purelb/charts && helm install ... purelb/purelb --version $NEW`
+      For each: assert `kubectl get clusterrole purelb:k8gobgp -o yaml | grep -A1 bgpnodestatuses`
+      shows both `bgpnodestatuses` and `bgpnodestatuses/status`, allocate
+      a sample service, and confirm `kubectl purelb status` and
+      `kubectl get bgpnodestatus -A` return populated data. **The point
+      of repeating the test post-release is to validate that what
+      shipped is what was tested** — pre-tag rc1 testing used different
+      image tags and a local tgz; post-release validates the real
+      artifacts that users will pull.
 
 ## If something goes wrong
 

--- a/build/helm/purelb/templates/gobgp-rbac.yaml
+++ b/build/helm/purelb/templates/gobgp-rbac.yaml
@@ -7,21 +7,10 @@ metadata:
   labels:
     {{- include "purelb.labels" . | nindent 4 }}
 rules:
-- apiGroups: ["bgp.purelb.io"]
-  resources: ["configs", "configs/finalizers", "configs/status"]
-  verbs: ["create","delete","get","list","patch","update","watch"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get","list","watch"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["patch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get","list","watch"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create","patch"]
+# Rules below are injected from deployments/components/gobgp/gobgp-rbac.yaml
+# at `make helm` time — that file is the single source of truth. Direct
+# edits here fail `make check-helm-rbac-source`.
+# @@INJECT_RBAC_RULES@@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/website/content/docs/installation/helm/_index.md
+++ b/website/content/docs/installation/helm/_index.md
@@ -30,7 +30,7 @@ helm install --create-namespace --namespace=purelb-system purelb purelb/purelb \
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.4
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.5
 ```
 
 ## Key Configuration Values

--- a/website/content/docs/installation/manifest/_index.md
+++ b/website/content/docs/installation/manifest/_index.md
@@ -9,8 +9,8 @@ The quickest way to install PureLB is with kubectl. Installation is a two-step p
 ## With BGP Support (Default)
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
 ```
 
 This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After installing, create a [BGPConfiguration]({{< relref "/docs/configuration/bgp" >}}) CR to configure BGP peering.
@@ -18,8 +18,8 @@ This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After
 ## Without BGP Support
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-nobgp-v0.16.4.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-nobgp-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-nobgp-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-nobgp-v0.16.5.yaml
 ```
 
 Use this variant if you only need local addresses (same subnet as your nodes) and do not need BGP routing.
@@ -62,8 +62,8 @@ The manifest creates:
 To upgrade, apply the new version's manifests:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
 ```
 
 Existing services retain their allocated addresses during the upgrade.

--- a/website/content/docs/migration/_index.md
+++ b/website/content/docs/migration/_index.md
@@ -168,7 +168,7 @@ Previous versions required users to install and configure standalone routing sof
 
 3. **Install the v2 CRDs** (they replace the v1 CRDs):
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-crds-v0.16.4.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
    ```
 
 4. **Apply converted CRs:**
@@ -179,7 +179,7 @@ Previous versions required users to install and configure standalone routing sof
 
 5. **Upgrade PureLB:**
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.4/install-v0.16.4.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
    ```
 
 6. **Verify:** Existing services should retain their allocated addresses. Check with:


### PR DESCRIPTION
## Summary

- **Fix #59:** Helm-installed PureLB was missing ClusterRole permissions for the `bgpnodestatuses` CRD. Users who installed via `helm install purelb/purelb` (the path documented on the website) got a chart that breaks kubectl-purelb's BGP commands and lbnodeagent's ability to write BGPNodeStatus. Has been broken since v0.16.1 (32+ days).
- **Structural prevention:** The Helm chart's gobgp ClusterRole rules block is now injected from `deployments/components/gobgp/gobgp-rbac.yaml` (the single source of truth) at `make helm` time via the `@@INJECT_RBAC_RULES@@` marker. The two files cannot drift again.
- **Drift gate:** New `make check-helm-rbac-source` target wired into `make check`. Fails CI if the marker is removed or inline rules are added to the Helm template. Same dual-defense pattern as v0.16.4's `check-deps`.
- **Procedure:** RELEASING.md now requires BOTH manifest install AND Helm install (from local tgz) on a clean cluster pre-tag. Post-release verification requires all three install paths (manifest URL, Helm OCI, Helm classic-repo) — the path the user actually took.

## Why this PR is bigger than a Helm template fix

v0.16.1–v0.16.4 shipped the broken chart because the v0.16.4 smoke test exercised the manifest install path only, and CI builds the chart but never installs it. A one-line fix to the Helm template would have left the underlying gap — two independent hand-maintained RBAC sources with no automated check — intact. Same failure-class as the v0.16.4 BGPNodeStatus latent bug. This release closes the gap structurally: the rules now live in exactly one file, and a CI gate enforces it.

## Test plan

- [x] `make check-helm-rbac-source` — positive test passes
- [x] Negative test: remove marker → gate fails with clear error
- [x] Negative test: add inline rule → gate fails with clear error
- [x] `SUFFIX=v0.16.5-rc1 make helm` packages the chart; injected template contains `bgpnodestatuses` and `bgpnodestatuses/status`
- [x] `helm template` against packaged tgz: rendered `ClusterRole/purelb:k8gobgp` contains all expected rules
- [x] `make -n check` confirms `check-helm-rbac-source` is wired between `check-deps` and tests
- [ ] CI `test` job passes (verify after push)
- [ ] Pre-tag smoke test A — manifest install on clean cluster, `kubectl get bgpnodestatus -A` populated
- [ ] Pre-tag smoke test B — `helm install ./purelb-v0.16.5-rc1.tgz` on clean cluster, `kubectl get clusterrole purelb:k8gobgp -o yaml | grep bgpnodestatuses` shows both `bgpnodestatuses` and `bgpnodestatuses/status`, `kubectl get bgpnodestatus -A` populated

## Files changed

- `build/helm/purelb/templates/gobgp-rbac.yaml` — inline rules replaced with `@@INJECT_RBAC_RULES@@` marker
- `Makefile` — `make helm` extends to inject rules from kustomize source; new `check-helm-rbac-source` target; wired into `make check`
- `RELEASING.md` — pre-tag smoke split into A (manifest) and B (helm local tgz), both required; post-release requires all three install paths
- `README.md`, `BUILDING.md`, `website/content/docs/installation/{manifest,helm}/_index.md`, `website/content/docs/migration/_index.md` — `v0.16.4` → `v0.16.5` (15 hits)