### PR TITLE
fix: kubectl-purelb BGP state messaging + Helm install pod discovery + gobgp 4.x flag

### DIFF
--- a/cmd/kubectl-purelb/bgp.go
+++ b/cmd/kubectl-purelb/bgp.go
@@ -98,14 +98,14 @@ func newBGPSessionsCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 func runBGPSessions(ctx context.Context, c *clients, format outputFormat, filterNode string, checkOnly bool) error {
 	now := time.Now()
 
-	// Fetch BGPNodeStatuses
-	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-	if err != nil {
-		return fmt.Errorf("listing BGPNodeStatuses: %w\nBGPNodeStatus CRD may not be installed — upgrade k8gobgp to 0.2.3+ for BGP visibility", err)
-	}
-	if len(bgpnsList.Items) == 0 {
-		fmt.Println("No BGPNodeStatus resources found.")
-		fmt.Println("Either k8gobgp is not deployed, nodeStatus.enabled is false, or k8gobgp version < 0.2.3")
+	// Fetch BGPNodeStatuses. List errors are not fatal — they usually mean
+	// the BGP CRDs aren't installed, which is a supported "BGP not enabled"
+	// state; detectBGPState figures it out from pod presence.
+	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	pods, _ := listAndCategorizePureLBPods(ctx, c)
+	info := detectBGPState(bgpnsList, pods)
+	if info.state != bgpStateActive {
+		fmt.Println(info.sentence())
 		return nil
 	}
 

--- a/cmd/kubectl-purelb/bgp_dataplane.go
+++ b/cmd/kubectl-purelb/bgp_dataplane.go
@@ -96,13 +96,14 @@ type crossRefEntry struct {
 }
 
 func runBGPDataplaneImpl(ctx context.Context, c *clients, format outputFormat, filterNode string, checkOnly bool, filterVRF string, importOnly, exportOnly bool) error {
-	// Fetch BGPNodeStatuses
-	bgpnsList, err := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-	if err != nil {
-		return fmt.Errorf("listing BGPNodeStatuses: %w", err)
-	}
-	if len(bgpnsList.Items) == 0 {
-		fmt.Println("No BGPNodeStatus resources found.")
+	// Fetch BGPNodeStatuses. List errors typically mean the BGP CRDs aren't
+	// installed (a supported "BGP not enabled" configuration); detectBGPState
+	// disambiguates from pod presence.
+	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	pods, _ := listAndCategorizePureLBPods(ctx, c)
+	info := detectBGPState(bgpnsList, pods)
+	if info.state != bgpStateActive {
+		fmt.Println(info.sentence())
 		return nil
 	}
 

--- a/cmd/kubectl-purelb/bgp_state.go
+++ b/cmd/kubectl-purelb/bgp_state.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// bgpState is the cluster's BGP operational state. All three states are
+// legitimate operating modes — NotEnabled is not a failure, it just means
+// the user installed PureLB without the k8gobgp sidecar (a supported
+// configuration documented for L2/ARP-only deployments).
+type bgpState int
+
+const (
+	bgpStateNotEnabled    bgpState = iota // no k8gobgp sidecar — gobgp.enabled=false or no-bgp manifest variant
+	bgpStateNotConfigured                 // sidecar present, no BGPConfiguration applied (or sidecar still starting up)
+	bgpStateActive                        // sidecar present, BGPConfiguration applied, ≥1 neighbor configured
+)
+
+// bgpInfo summarizes the cluster's BGP state with all numbers the
+// existing renderers need (counts, established peers, import failures).
+type bgpInfo struct {
+	state            bgpState
+	nodeCount        int // number of BGPNodeStatus rows
+	peersEstablished int
+	peersTotal       int
+	importFailures   int
+}
+
+// detectBGPState classifies the cluster's BGP state from a BGPNodeStatus
+// list and a categorized pod set.
+//
+// bgpns may be nil — that's the normal case when the BGP CRDs aren't
+// installed (no-bgp manifest variant or older PureLB versions). In that
+// case we fall back to checking pod presence: no k8gobgp container means
+// NotEnabled; container present means NotConfigured (transient startup).
+//
+// Classification rules:
+//  1. peersTotal > 0 → Active (sub-stats already captured)
+//  2. bgpns has rows, peersTotal == 0 → NotConfigured (rows written, no peers)
+//  3. bgpns is nil OR empty, withK8GoBGP container present → NotConfigured (startup race)
+//  4. bgpns is nil OR empty, withK8GoBGP container absent → NotEnabled
+func detectBGPState(bgpns *unstructured.UnstructuredList, pods purelbPods) bgpInfo {
+	info := bgpInfo{}
+
+	if bgpns != nil {
+		info.nodeCount = len(bgpns.Items)
+		for _, ns := range bgpns.Items {
+			neighbors, _, _ := unstructured.NestedSlice(ns.Object, "status", "neighbors")
+			for _, nRaw := range neighbors {
+				n, ok := nRaw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				info.peersTotal++
+				state, _ := n["state"].(string)
+				if state == "Established" {
+					info.peersEstablished++
+				}
+			}
+			addrs, _, _ := unstructured.NestedSlice(ns.Object, "status", "netlinkImport", "importedAddresses")
+			for _, aRaw := range addrs {
+				a, ok := aRaw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				inRIB, _ := a["inRIB"].(bool)
+				if !inRIB {
+					info.importFailures++
+				}
+			}
+		}
+	}
+
+	switch {
+	case info.peersTotal > 0:
+		info.state = bgpStateActive
+	case info.nodeCount > 0:
+		// BGPNodeStatus rows exist but no neighbors: sidecar is running
+		// and has written status, but no BGPConfiguration applied.
+		info.state = bgpStateNotConfigured
+	case len(pods.withK8GoBGP) > 0:
+		// No rows but the sidecar container exists: either the manager
+		// hasn't written status yet (startup race), or it's running
+		// unconfigured. Either way, NotConfigured per the design.
+		info.state = bgpStateNotConfigured
+	default:
+		info.state = bgpStateNotEnabled
+	}
+
+	return info
+}
+
+// statusSummary returns the canonical short string used on the BGP line of
+// the status one-liner.
+func (i bgpInfo) statusSummary() string {
+	switch i.state {
+	case bgpStateNotEnabled:
+		return "not enabled"
+	case bgpStateNotConfigured:
+		return "not configured"
+	case bgpStateActive:
+		parts := []string{fmt.Sprintf("%d/%d peers established", i.peersEstablished, i.peersTotal)}
+		if i.importFailures > 0 {
+			parts = append(parts, fmt.Sprintf("%d import failure(s)", i.importFailures))
+		} else {
+			parts = append(parts, "netlinkImport OK")
+		}
+		return strings.Join(parts, " | ")
+	}
+	return "unknown"
+}
+
+// sentence returns the canonical longer-form sentence used by bgp sessions /
+// bgp dataplane / dashboard / inspect / gobgp / ip when reporting
+// NotEnabled or NotConfigured. Active returns an empty string — callers in
+// that case render their full table or output instead.
+func (i bgpInfo) sentence() string {
+	switch i.state {
+	case bgpStateNotEnabled:
+		return "BGP not enabled."
+	case bgpStateNotConfigured:
+		return "BGP not configured."
+	}
+	return ""
+}

--- a/cmd/kubectl-purelb/commands_test.go
+++ b/cmd/kubectl-purelb/commands_test.go
@@ -421,3 +421,253 @@ func TestRenderPools_EmptyCluster(t *testing.T) {
 	err = renderPools(snap, outputJSON, "", false)
 	assert.NoError(t, err)
 }
+
+// =============================================================================
+// pod categorization tests (install-method-agnostic)
+// =============================================================================
+
+func makePodWithContainers(name string, containerNames ...string) v1.Pod {
+	containers := make([]v1.Container, 0, len(containerNames))
+	for _, n := range containerNames {
+		containers = append(containers, v1.Container{Name: n})
+	}
+	return v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "purelb-system"},
+		Spec:       v1.PodSpec{Containers: containers},
+	}
+}
+
+func TestCategorizePureLBPods(t *testing.T) {
+	tests := []struct {
+		name        string
+		podList     *v1.PodList // nil exercises the nil-input path
+		wantAlloc   int
+		wantLBNA    int
+		wantK8GoBGP int
+	}{
+		{
+			name:    "nil PodList",
+			podList: nil,
+		},
+		{
+			name:    "empty Items",
+			podList: &v1.PodList{},
+		},
+		{
+			name: "allocator pod only",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("alloc", "allocator"),
+			}},
+			wantAlloc: 1,
+		},
+		{
+			name: "lbnodeagent with k8gobgp sidecar",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("lbna", "lbnodeagent", "k8gobgp"),
+			}},
+			wantLBNA:    1,
+			wantK8GoBGP: 1,
+		},
+		{
+			name: "lbnodeagent without sidecar (no-bgp install)",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("lbna", "lbnodeagent"),
+			}},
+			wantLBNA: 1,
+		},
+		{
+			name: "full multi-node install with BGP",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("alloc", "allocator"),
+				makePodWithContainers("lbna1", "lbnodeagent", "k8gobgp"),
+				makePodWithContainers("lbna2", "lbnodeagent", "k8gobgp"),
+			}},
+			wantAlloc:   1,
+			wantLBNA:    2,
+			wantK8GoBGP: 2,
+		},
+		{
+			name: "full install without BGP (gobgp.enabled=false / no-bgp manifest)",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("alloc", "allocator"),
+				makePodWithContainers("lbna1", "lbnodeagent"),
+				makePodWithContainers("lbna2", "lbnodeagent"),
+			}},
+			wantAlloc: 1,
+			wantLBNA:  2,
+		},
+		{
+			name: "unrelated pod in namespace is ignored",
+			podList: &v1.PodList{Items: []v1.Pod{
+				makePodWithContainers("alloc", "allocator"),
+				makePodWithContainers("other", "nginx"),
+			}},
+			wantAlloc: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cat := categorizePureLBPods(tt.podList)
+			assert.Equal(t, tt.wantAlloc, len(cat.allocator), "allocator pod count")
+			assert.Equal(t, tt.wantLBNA, len(cat.lbnodeagent), "lbnodeagent pod count")
+			assert.Equal(t, tt.wantK8GoBGP, len(cat.withK8GoBGP), "withK8GoBGP pod count")
+		})
+	}
+}
+
+// =============================================================================
+// BGP state detection + formatting tests
+// =============================================================================
+
+// makeBGPNodeStatus builds an unstructured BGPNodeStatus CR with the given
+// neighbor states and a count of failed (inRIB=false) imported addresses.
+// neighborStates may be nil to model a freshly-started sidecar with no
+// BGPConfiguration applied yet.
+func makeBGPNodeStatus(nodeName string, neighborStates []string, importFailures int) *unstructured.Unstructured {
+	bgpns := &unstructured.Unstructured{}
+	bgpns.SetGroupVersionKind(schema.GroupVersionKind{Group: "bgp.purelb.io", Version: "v1", Kind: "BGPNodeStatus"})
+	bgpns.SetName(nodeName)
+
+	neighbors := make([]interface{}, 0, len(neighborStates))
+	for i, state := range neighborStates {
+		neighbors = append(neighbors, map[string]interface{}{
+			"address": "192.0.2." + string(rune('1'+i)),
+			"state":   state,
+		})
+	}
+
+	importedAddrs := make([]interface{}, 0, importFailures)
+	for i := 0; i < importFailures; i++ {
+		importedAddrs = append(importedAddrs, map[string]interface{}{
+			"address": "198.51.100." + string(rune('1'+i)),
+			"inRIB":   false,
+		})
+	}
+
+	bgpns.Object["status"] = map[string]interface{}{
+		"nodeName":  nodeName,
+		"neighbors": neighbors,
+		"netlinkImport": map[string]interface{}{
+			"importedAddresses": importedAddrs,
+		},
+	}
+	return bgpns
+}
+
+func TestDetectBGPState(t *testing.T) {
+	tests := []struct {
+		name                 string
+		bgpns                []*unstructured.Unstructured // nil → list is nil; empty slice → list with 0 items
+		nilList              bool                         // explicit nil list (overrides bgpns)
+		podsWithK8GoBGP      int                          // pods to put in purelbPods.withK8GoBGP
+		wantState            bgpState
+		wantPeersTotal       int
+		wantPeersEstablished int
+		wantImportFailures   int
+		wantSummary          string
+		wantSentence         string
+	}{
+		{
+			name:         "nil list, no k8gobgp pods → NotEnabled",
+			nilList:      true,
+			wantState:    bgpStateNotEnabled,
+			wantSummary:  "not enabled",
+			wantSentence: "BGP not enabled.",
+		},
+		{
+			name:            "nil list, k8gobgp pods present → NotConfigured (startup race)",
+			nilList:         true,
+			podsWithK8GoBGP: 1,
+			wantState:       bgpStateNotConfigured,
+			wantSummary:     "not configured",
+			wantSentence:    "BGP not configured.",
+		},
+		{
+			name:         "empty list, no pods → NotEnabled",
+			bgpns:        []*unstructured.Unstructured{},
+			wantState:    bgpStateNotEnabled,
+			wantSummary:  "not enabled",
+			wantSentence: "BGP not enabled.",
+		},
+		{
+			name:            "empty list, sidecar present → NotConfigured",
+			bgpns:           []*unstructured.Unstructured{},
+			podsWithK8GoBGP: 2,
+			wantState:       bgpStateNotConfigured,
+			wantSummary:     "not configured",
+			wantSentence:    "BGP not configured.",
+		},
+		{
+			name:         "BGPNodeStatus row with no neighbors → NotConfigured",
+			bgpns:        []*unstructured.Unstructured{makeBGPNodeStatus("node-a", nil, 0)},
+			wantState:    bgpStateNotConfigured,
+			wantSummary:  "not configured",
+			wantSentence: "BGP not configured.",
+		},
+		{
+			name:                 "all peers Established, no import failures → Active OK",
+			bgpns:                []*unstructured.Unstructured{makeBGPNodeStatus("node-a", []string{"Established", "Established"}, 0)},
+			wantState:            bgpStateActive,
+			wantPeersTotal:       2,
+			wantPeersEstablished: 2,
+			wantSummary:          "2/2 peers established | netlinkImport OK",
+			wantSentence:         "",
+		},
+		{
+			name:                 "some peers down → Active with mixed count",
+			bgpns:                []*unstructured.Unstructured{makeBGPNodeStatus("node-a", []string{"Established", "Idle", "Active"}, 0)},
+			wantState:            bgpStateActive,
+			wantPeersTotal:       3,
+			wantPeersEstablished: 1,
+			wantSummary:          "1/3 peers established | netlinkImport OK",
+		},
+		{
+			name:                 "import failures → Active with failure count",
+			bgpns:                []*unstructured.Unstructured{makeBGPNodeStatus("node-a", []string{"Established"}, 2)},
+			wantState:            bgpStateActive,
+			wantPeersTotal:       1,
+			wantPeersEstablished: 1,
+			wantImportFailures:   2,
+			wantSummary:          "1/1 peers established | 2 import failure(s)",
+		},
+		{
+			name: "multi-node aggregates correctly",
+			bgpns: []*unstructured.Unstructured{
+				makeBGPNodeStatus("node-a", []string{"Established"}, 0),
+				makeBGPNodeStatus("node-b", []string{"Established", "Idle"}, 1),
+			},
+			wantState:            bgpStateActive,
+			wantPeersTotal:       3,
+			wantPeersEstablished: 2,
+			wantImportFailures:   1,
+			wantSummary:          "2/3 peers established | 1 import failure(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var list *unstructured.UnstructuredList
+			if !tt.nilList {
+				list = &unstructured.UnstructuredList{}
+				for _, item := range tt.bgpns {
+					list.Items = append(list.Items, *item)
+				}
+			}
+
+			pods := purelbPods{}
+			for i := 0; i < tt.podsWithK8GoBGP; i++ {
+				pods.withK8GoBGP = append(pods.withK8GoBGP, v1.Pod{})
+			}
+
+			info := detectBGPState(list, pods)
+			assert.Equal(t, tt.wantState, info.state, "state")
+			assert.Equal(t, tt.wantPeersTotal, info.peersTotal, "peersTotal")
+			assert.Equal(t, tt.wantPeersEstablished, info.peersEstablished, "peersEstablished")
+			assert.Equal(t, tt.wantImportFailures, info.importFailures, "importFailures")
+			if tt.wantSummary != "" {
+				assert.Equal(t, tt.wantSummary, info.statusSummary(), "statusSummary")
+			}
+			assert.Equal(t, tt.wantSentence, info.sentence(), "sentence")
+		})
+	}
+}

--- a/cmd/kubectl-purelb/dashboard.go
+++ b/cmd/kubectl-purelb/dashboard.go
@@ -130,7 +130,15 @@ func renderDashboard(snap *clusterSnapshot, format outputFormat, isTTY bool, gob
 	if gobgpOutput != "" {
 		fmt.Print(gobgpOutput)
 	} else {
-		fmt.Println("(no k8gobgp sidecars found)")
+		// No output — show the canonical BGP state sentence so the user
+		// understands why (not enabled / not configured).
+		info := detectBGPState(snap.bgpNodeStatuses, categorizePureLBPods(snap.pods))
+		if msg := info.sentence(); msg != "" {
+			fmt.Println(msg)
+		} else {
+			// Active state but no output (rare — likely an exec error).
+			fmt.Println("(no output from k8gobgp)")
+		}
 	}
 }
 
@@ -139,7 +147,9 @@ func renderDashboard(snap *clusterSnapshot, format outputFormat, isTTY bool, gob
 // or an empty string on error.
 func fetchGoBGPOutput(ctx context.Context, c *clients, snap *clusterSnapshot) string {
 	var buf bytes.Buffer
-	gobgpCmd := []string{"gobgp", "-u", "/var/run/gobgp/gobgp.sock", "global", "rib"}
+	// gobgp 4.x (bundled in k8gobgp 0.2.4+) replaced `-u <path>` with
+	// `--target unix://<path>`.
+	gobgpCmd := []string{"gobgp", "--target", "unix:///var/run/gobgp/gobgp.sock", "global", "rib"}
 	if err := execInK8GoBGPWithPods(ctx, c, snap.pods, "", gobgpCmd, &buf, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "gobgp: %v\n", err)
 		return ""

--- a/cmd/kubectl-purelb/exec.go
+++ b/cmd/kubectl-purelb/exec.go
@@ -56,7 +56,19 @@ func newGoBGPCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 				return err
 			}
 
-			execCmd := append([]string{"gobgp", "-u", "/var/run/gobgp/gobgp.sock"}, filteredArgs...)
+			// gobgp needs the gobgp daemon (started by k8gobgp once a
+			// BGPConfiguration is applied) — both NotEnabled and
+			// NotConfigured short-circuit with a clear message rather than
+			// letting the exec fail with "connection refused" on the unix
+			// socket.
+			if !preCheckBGP(cmd.Context(), c, true /* requireConfigured */) {
+				return nil
+			}
+
+			// gobgp 4.x (bundled in k8gobgp 0.2.4+) replaced the old `-u <path>` flag
+			// with `--target unix://<path>`. Old syntax silently fails with
+			// "name resolver error: produced zero addresses".
+			execCmd := append([]string{"gobgp", "--target", "unix:///var/run/gobgp/gobgp.sock"}, filteredArgs...)
 			return execInK8GoBGP(cmd.Context(), c, targetNode, execCmd)
 		},
 	}
@@ -94,6 +106,13 @@ func newIPCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 				return err
 			}
 
+			// ip queries the host's network namespace through the k8gobgp
+			// container, so it works whenever the container exists — NotEnabled
+			// short-circuits, but NotConfigured does not.
+			if !preCheckBGP(cmd.Context(), c, false /* container present is enough */) {
+				return nil
+			}
+
 			execCmd := append([]string{"ip"}, filteredArgs...)
 			return execInK8GoBGP(cmd.Context(), c, targetNode, execCmd)
 		},
@@ -102,6 +121,29 @@ func newIPCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	_ = node
 
 	return cmd
+}
+
+// preCheckBGP returns true when the caller should proceed with an exec into
+// the k8gobgp container. When it returns false, it has already printed the
+// canonical BGP-state sentence to stdout for the user. requireConfigured
+// controls whether NotConfigured is also a hard stop: true for `gobgp` (the
+// daemon socket only exists when a BGPConfiguration has been applied), false
+// for `ip` (the host netns is queryable regardless of BGP state).
+func preCheckBGP(ctx context.Context, c *clients, requireConfigured bool) bool {
+	bgpns, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	cat, _ := listAndCategorizePureLBPods(ctx, c)
+	info := detectBGPState(bgpns, cat)
+	switch info.state {
+	case bgpStateNotEnabled:
+		fmt.Println(info.sentence())
+		return false
+	case bgpStateNotConfigured:
+		if requireConfigured {
+			fmt.Println(info.sentence())
+			return false
+		}
+	}
+	return true
 }
 
 // extractNodeFlag pulls --node <name> from args since DisableFlagParsing
@@ -121,28 +163,16 @@ func extractNodeFlag(args []string) (filtered []string, node string) {
 // execInK8GoBGP runs a command in k8gobgp sidecar(s). If targetNode is empty,
 // runs on all nodes and labels output. If targetNode is set, runs on that node only.
 func execInK8GoBGP(ctx context.Context, c *clients, targetNode string, command []string) error {
-	pods, err := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{
-		ResourceVersion: "0",
-		LabelSelector:   "app=purelb,component=lbnodeagent",
-	})
+	cat, err := listAndCategorizePureLBPods(ctx, c)
 	if err != nil {
-		return fmt.Errorf("listing lbnodeagent pods: %w", err)
+		return err
 	}
 
-	// Collect eligible pods
+	// withK8GoBGP already filters to lbnodeagent pods that have the k8gobgp
+	// sidecar container — install-method-agnostic.
 	var targets []v1.Pod
-	for _, pod := range pods.Items {
+	for _, pod := range cat.withK8GoBGP {
 		if pod.Status.Phase != v1.PodRunning {
-			continue
-		}
-		hasK8GoBGP := false
-		for _, container := range pod.Spec.Containers {
-			if container.Name == "k8gobgp" {
-				hasK8GoBGP = true
-				break
-			}
-		}
-		if !hasK8GoBGP {
 			continue
 		}
 		if targetNode != "" && pod.Spec.NodeName != targetNode {
@@ -183,20 +213,11 @@ func execInK8GoBGPWithPods(ctx context.Context, c *clients, pods *v1.PodList, ta
 	if pods == nil {
 		return fmt.Errorf("no pod list provided")
 	}
+	cat := categorizePureLBPods(pods)
 
 	var targets []v1.Pod
-	for _, pod := range pods.Items {
+	for _, pod := range cat.withK8GoBGP {
 		if pod.Status.Phase != v1.PodRunning {
-			continue
-		}
-		hasK8GoBGP := false
-		for _, container := range pod.Spec.Containers {
-			if container.Name == "k8gobgp" {
-				hasK8GoBGP = true
-				break
-			}
-		}
-		if !hasK8GoBGP {
 			continue
 		}
 		if targetNode != "" && pod.Spec.NodeName != targetNode {

--- a/cmd/kubectl-purelb/inspect.go
+++ b/cmd/kubectl-purelb/inspect.go
@@ -42,6 +42,7 @@ type inspectResult struct {
 	Sharing      *sharingInfo       `json:"sharing,omitempty"`
 	Endpoints    endpointsInfo      `json:"endpoints"`
 	BGP          []bgpRouteCheck    `json:"bgp,omitempty"`
+	BGPNote      string             `json:"bgpNote,omitempty"` // canonical sentence when BGP state is NotEnabled / NotConfigured
 	Diagnosis    *diagnosisInfo     `json:"diagnosis,omitempty"`
 }
 
@@ -201,10 +202,18 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 			}
 		}
 
-		// Fetch BGPNodeStatus for remote pool route checks
+		// Fetch BGPNodeStatus for remote pool route checks. Also classify the
+		// BGP state up front so we can show a clear "BGP not enabled" /
+		// "BGP not configured" sentence instead of misleading per-route
+		// "Route X in RIB on (none): No" rows when there's no BGP to check.
 		var bgpStatuses *unstructured.UnstructuredList
 		if poolType == poolTypeRemote {
 			bgpStatuses, _ = c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+			bgpPods, _ := listAndCategorizePureLBPods(ctx, c)
+			bs := detectBGPState(bgpStatuses, bgpPods)
+			if bs.state != bgpStateActive {
+				result.BGPNote = bs.sentence()
+			}
 		}
 
 		for _, ingress := range ingresses {
@@ -287,8 +296,10 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 				}
 			}
 
-			// BGP route check (remote pools)
-			if poolType == poolTypeRemote && bgpStatuses != nil {
+			// BGP route check (remote pools). Skip when BGP isn't Active —
+			// result.BGPNote already carries the canonical "not enabled" /
+			// "not configured" sentence in that case.
+			if poolType == poolTypeRemote && bgpStatuses != nil && result.BGPNote == "" {
 				for _, bgpns := range bgpStatuses.Items {
 					nodeName, _, _ := unstructured.NestedString(bgpns.Object, "status", "nodeName")
 					inRIB := checkRouteInBGPNodeStatus(&bgpns, ipStr)
@@ -302,7 +313,8 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 						})
 					}
 				}
-				// If no BGP entries found, add a "not found" entry
+				// Route absent from RIB on all known nodes: not necessarily an
+				// error, but worth flagging for the user.
 				if len(result.BGP) == 0 {
 					result.BGP = append(result.BGP, bgpRouteCheck{
 						IP:    ipStr,
@@ -413,7 +425,11 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		}
 
 		// BGP
-		if len(result.BGP) > 0 {
+		if result.BGPNote != "" {
+			fmt.Println()
+			fmt.Println("BGP (remote pool):")
+			fmt.Println("  " + result.BGPNote)
+		} else if len(result.BGP) > 0 {
 			fmt.Println()
 			fmt.Println("BGP (remote pool):")
 			for _, b := range result.BGP {
@@ -532,18 +548,13 @@ func diagnosePending(ctx context.Context, c *clients, svc *v1.Service) *diagnosi
 	requestedPool := ann[annotationServiceGroup]
 	requestedIP := ann[annotationAddresses]
 
-	// Check allocator pod
-	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{
-		ResourceVersion: "0",
-		LabelSelector:   "app=purelb,component=allocator",
-	})
+	// Check allocator pod (identified by container name — install-method-agnostic).
+	cat, _ := listAndCategorizePureLBPods(ctx, c)
 	allocatorRunning := false
-	if pods != nil {
-		for _, p := range pods.Items {
-			if p.Status.Phase == v1.PodRunning {
-				allocatorRunning = true
-				break
-			}
+	for _, p := range cat.allocator {
+		if p.Status.Phase == v1.PodRunning {
+			allocatorRunning = true
+			break
 		}
 	}
 	if !allocatorRunning {

--- a/cmd/kubectl-purelb/pods.go
+++ b/cmd/kubectl-purelb/pods.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// purelbPods groups pods in the purelb-system namespace by which PureLB
+// component they implement. Identification is by container name, not by
+// label, so it works for both install methods: manifest installs label pods
+// `component=lbnodeagent`/`component=allocator` while Helm installs use
+// `app.kubernetes.io/component=…`. Container names are baked into both
+// pod templates and stay the same across install methods.
+type purelbPods struct {
+	allocator   []v1.Pod // pods with a container named "allocator"
+	lbnodeagent []v1.Pod // pods with a container named "lbnodeagent"
+	withK8GoBGP []v1.Pod // subset of lbnodeagent that also have a "k8gobgp" sidecar
+}
+
+// categorizePureLBPods scans a PodList and groups pods by container composition.
+// A nil or empty input returns the zero value (all slices nil).
+func categorizePureLBPods(pods *v1.PodList) purelbPods {
+	var out purelbPods
+	if pods == nil {
+		return out
+	}
+	for _, pod := range pods.Items {
+		var hasAllocator, hasLBNodeAgent, hasK8GoBGP bool
+		for _, c := range pod.Spec.Containers {
+			switch c.Name {
+			case "allocator":
+				hasAllocator = true
+			case "lbnodeagent":
+				hasLBNodeAgent = true
+			case "k8gobgp":
+				hasK8GoBGP = true
+			}
+		}
+		if hasAllocator {
+			out.allocator = append(out.allocator, pod)
+		}
+		if hasLBNodeAgent {
+			out.lbnodeagent = append(out.lbnodeagent, pod)
+			if hasK8GoBGP {
+				out.withK8GoBGP = append(out.withK8GoBGP, pod)
+			}
+		}
+	}
+	return out
+}
+
+// listAndCategorizePureLBPods lists all pods in the purelb-system namespace
+// and categorizes them. Used by commands that don't already have a snapshot
+// to share with other rendering code.
+func listAndCategorizePureLBPods(ctx context.Context, c *clients) (purelbPods, error) {
+	pods, err := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		return purelbPods{}, fmt.Errorf("listing pods in %s: %w", purelbNamespace, err)
+	}
+	return categorizePureLBPods(pods), nil
+}

--- a/cmd/kubectl-purelb/status.go
+++ b/cmd/kubectl-purelb/status.go
@@ -107,33 +107,31 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 	var warnings []string
 
 	// === Components ===
-	allocatorTotal, allocatorReady := 0, 0
-	nodeagentTotal, nodeagentReady := 0, 0
-	gobgpTotal, gobgpReady := 0, 0
+	// Identify pods by container composition (install-method-agnostic) instead
+	// of by the historical "component=*" label, which the Helm chart doesn't set.
+	pods := categorizePureLBPods(snap.pods)
 
-	if snap.pods != nil {
-		for _, pod := range snap.pods.Items {
-			labels := pod.Labels
-			if labels["component"] == "allocator" {
-				allocatorTotal++
-				if pod.Status.Phase == v1.PodRunning {
-					allocatorReady++
-				}
-			}
-			if labels["component"] == "lbnodeagent" {
-				nodeagentTotal++
-				for _, cs := range pod.Status.ContainerStatuses {
-					if cs.Name == "lbnodeagent" && cs.Ready {
-						nodeagentReady++
-					}
-					if cs.Name == "k8gobgp" {
-						gobgpTotal++
-						if cs.Ready {
-							gobgpReady++
-						}
-					}
-				}
-			}
+	allocatorTotal := len(pods.allocator)
+	allocatorReady := 0
+	for _, p := range pods.allocator {
+		if p.Status.Phase == v1.PodRunning {
+			allocatorReady++
+		}
+	}
+
+	nodeagentTotal := len(pods.lbnodeagent)
+	nodeagentReady := 0
+	for _, p := range pods.lbnodeagent {
+		if isPodContainerRunning(p, "lbnodeagent") {
+			nodeagentReady++
+		}
+	}
+
+	gobgpTotal := len(pods.withK8GoBGP)
+	gobgpReady := 0
+	for _, p := range pods.withK8GoBGP {
+		if isPodContainerRunning(p, "k8gobgp") {
+			gobgpReady++
 		}
 	}
 
@@ -235,49 +233,14 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 	}
 
 	// === BGP ===
-	bgpEstablished, bgpTotal := 0, 0
-	importFailures := 0
-
-	if snap.bgpNodeStatuses != nil {
-		for _, bgpns := range snap.bgpNodeStatuses.Items {
-			neighbors, _, _ := unstructured.NestedSlice(bgpns.Object, "status", "neighbors")
-			for _, nRaw := range neighbors {
-				n, ok := nRaw.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				bgpTotal++
-				state, _ := n["state"].(string)
-				if state == "Established" {
-					bgpEstablished++
-				}
-			}
-			addrs, _, _ := unstructured.NestedSlice(bgpns.Object, "status", "netlinkImport", "importedAddresses")
-			for _, aRaw := range addrs {
-				a, ok := aRaw.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				inRIB, _ := a["inRIB"].(bool)
-				if !inRIB {
-					importFailures++
-				}
-			}
+	bgp := detectBGPState(snap.bgpNodeStatuses, pods)
+	bgpSummary := bgp.statusSummary()
+	if bgp.state == bgpStateActive {
+		if bgp.importFailures > 0 {
+			warnings = append(warnings, fmt.Sprintf("%d netlinkImport failure(s)", bgp.importFailures))
 		}
-	}
-
-	bgpSummary := "not deployed"
-	if bgpTotal > 0 {
-		bgpParts := []string{fmt.Sprintf("%d/%d sessions established", bgpEstablished, bgpTotal)}
-		if importFailures > 0 {
-			bgpParts = append(bgpParts, fmt.Sprintf("%d import failure(s)", importFailures))
-			warnings = append(warnings, fmt.Sprintf("%d netlinkImport failure(s)", importFailures))
-		} else {
-			bgpParts = append(bgpParts, "netlinkImport OK")
-		}
-		bgpSummary = strings.Join(bgpParts, " | ")
-		if bgpEstablished < bgpTotal {
-			warnings = append(warnings, fmt.Sprintf("%d BGP session(s) down", bgpTotal-bgpEstablished))
+		if bgp.peersEstablished < bgp.peersTotal {
+			warnings = append(warnings, fmt.Sprintf("%d BGP peer(s) down", bgp.peersTotal-bgp.peersEstablished))
 		}
 	}
 

--- a/cmd/kubectl-purelb/version.go
+++ b/cmd/kubectl-purelb/version.go
@@ -68,39 +68,43 @@ func runVersion(ctx context.Context, c *clients, format outputFormat) error {
 		Plugin: fmt.Sprintf("%s (commit %s)", version, commit),
 	}
 
-	// Fetch pods
+	// Fetch and categorize pods by container composition (install-method-agnostic).
 	pods, _ := c.core.CoreV1().Pods(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-	if pods != nil {
-		for _, pod := range pods.Items {
-			if pod.Labels["component"] == "allocator" {
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "allocator" {
-						info.Allocator.Image = container.Image
-					}
-				}
-				info.Allocator.Pods++
-				if pod.Status.Phase == v1.PodRunning {
-					info.Allocator.Running++
-				}
+	cat := categorizePureLBPods(pods)
+
+	for _, pod := range cat.allocator {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "allocator" {
+				info.Allocator.Image = container.Image
 			}
-			if pod.Labels["component"] == "lbnodeagent" {
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "lbnodeagent" {
-						info.LBNodeAgent.Image = container.Image
-						info.LBNodeAgent.Pods++
-						if isPodContainerRunning(pod, "lbnodeagent") {
-							info.LBNodeAgent.Running++
-						}
-					}
-					if container.Name == "k8gobgp" {
-						info.K8GoBGP.Image = container.Image
-						info.K8GoBGP.Pods++
-						if isPodContainerRunning(pod, "k8gobgp") {
-							info.K8GoBGP.Running++
-						}
-					}
-				}
+		}
+		info.Allocator.Pods++
+		if pod.Status.Phase == v1.PodRunning {
+			info.Allocator.Running++
+		}
+	}
+
+	for _, pod := range cat.lbnodeagent {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "lbnodeagent" {
+				info.LBNodeAgent.Image = container.Image
 			}
+		}
+		info.LBNodeAgent.Pods++
+		if isPodContainerRunning(pod, "lbnodeagent") {
+			info.LBNodeAgent.Running++
+		}
+	}
+
+	for _, pod := range cat.withK8GoBGP {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "k8gobgp" {
+				info.K8GoBGP.Image = container.Image
+			}
+		}
+		info.K8GoBGP.Pods++
+		if isPodContainerRunning(pod, "k8gobgp") {
+			info.K8GoBGP.Running++
 		}
 	}
 


### PR DESCRIPTION
## Summary

Three coupled bugs surfaced during v0.16.5 smoke testing — fixing only one would have left the user-facing experience broken, so this PR ships them together.

- **Bug #1 — BGP state messaging.** `status` printed `BGP: not deployed` when the k8gobgp sidecar **was** deployed and writing BGPNodeStatus heartbeats; other commands phrased the same state with different (and contradictory) language. New 3-state taxonomy (`NotEnabled` / `NotConfigured` / `Active`) in [bgp_state.go](cmd/kubectl-purelb/bgp_state.go) with a single shared detection helper + two formatters used everywhere. Canonical wording: `not enabled` / `not configured` / `M/N peers established`. The wording for the no-sidecar case is intentionally neutral (`BGP not enabled`) — `gobgp.enabled=false` is a [documented supported configuration](https://purelb.io/docs/installation/helm/), not a failure.

- **Bug #2 — Helm install pod discovery.** Five sites hardcoded the manifest-install label `component=lbnodeagent` (and friends), which Helm-rendered pods don't carry. On Helm clusters: `status` showed `Allocator 0/0 \| LBNodeAgents 0/0`, `version` reported zero pods, and `gobgp`/`ip` printed "no running lbnodeagent pod with k8gobgp sidecar found" even with a healthy sidecar. New [pods.go](cmd/kubectl-purelb/pods.go) identifies pods by **container composition** (`allocator` / `lbnodeagent` / `k8gobgp` container names), which are stable across both install methods. All five sites go through the helper.

- **Bug #3 — gobgp 4.x flag change.** k8gobgp 0.2.4 (bundled in v0.16.4) ships gobgp 4.x, which renamed the unix-socket flag from `-u <path>` to `--target unix://<path>`. The plugin's exec.go and dashboard.go still passed the old flag — every `kubectl-purelb gobgp …` invocation silently failed with `rpc error: code = Unavailable desc = name resolver error: produced zero addresses` since v0.16.4 released. Two one-line fixes.

## How the three bugs are tangled

User-facing symptom: "BGP messages in the plugin are confusing and inconsistent" — but the *root cause* spans state interpretation (#1), pod discovery (#2), and a downstream CLI flag rename (#3). Just fixing the wording would have left `gobgp` returning a cryptic gRPC error on Active-state clusters; just fixing the labels would have left `status` saying `not deployed` for unconfigured sidecars; just fixing the flag wouldn't address the inconsistency. The three are inseparable from the user's perspective.

## Test plan

- [x] `go test -race -short ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] Two new table-driven tests: `TestCategorizePureLBPods` (8 cases) + `TestDetectBGPState` (9 cases)
- [x] Existing `TestRenderStatus` / `TestRenderStatus_EmptyCluster` continue to pass without modification
- [x] **NotEnabled** verified on a clean cluster (`helm install --set gobgp.enabled=false`):
  - `status` Components shows real pod counts; BGP line `not enabled`; Overall: OK
  - `bgp sessions` / `bgp dataplane` / `dashboard` / `gobgp neighbor` / `ip addr show` all print `BGP not enabled.`
  - `version` correctly omits the k8gobgp line
- [x] **NotConfigured** verified on a clean cluster (default install, no BGPConfig):
  - `status` Components shows real pod counts; BGP line `not configured`; Overall: OK
  - All BGP-touching commands print `BGP not configured.`
  - `gobgp neighbor` short-circuits without exec attempt (returns exit 0)
  - `ip addr show` still works (container exists, host netns is queryable)
- [x] **Active** verified on a 5-node configured-BGP cluster (5/5 peers Established):
  - All 13 plugin commands produce correct output
  - `gobgp neighbor` and `gobgp global rib` return real BGP data via the fixed `--target` flag
  - `dashboard` renders the full GoBGP RIB across all 5 nodes
- [ ] CI `test` job passes (verify after push)

## Files changed

**New (174 lines):**
- `cmd/kubectl-purelb/pods.go` — `purelbPods` struct + `categorizePureLBPods` + `listAndCategorizePureLBPods`
- `cmd/kubectl-purelb/bgp_state.go` — state enum + `bgpInfo` + `detectBGPState` + `statusSummary` + `sentence`

**Modified (8 files):**
- `status.go` — components via `categorizePureLBPods`; BGP via `detectBGPState` + `statusSummary`. "sessions" → "peers" wording.
- `version.go` — pod loop via `categorizePureLBPods`
- `bgp.go` (`runBGPSessions`) — state pre-check, prints canonical sentence on NotEnabled/NotConfigured
- `bgp_dataplane.go` — same pattern
- `dashboard.go` — state-aware fallback message; gobgp 4.x `--target` flag
- `inspect.go` — new `BGPNote` field, allocator pod check via `categorizePureLBPods`
- `exec.go` — pod discovery via `withK8GoBGP` set; new `preCheckBGP` helper (split treatment for `gobgp` vs `ip`); gobgp 4.x `--target` flag
- `commands_test.go` — two new table-driven tests

## Why this PR exists alongside v0.16.5

v0.16.5 fixed the *chart-side* RBAC drift (issue #59). This PR fixes the *plugin-side* visibility problems that v0.16.5's smoke test surfaced but didn't address. Specifically: the v0.16.5 smoke test on `helm-test` showed `Components: Allocator 0/0 Running | LBNodeAgents 0/0 Running` even with healthy pods — the audit flagged it as "may be a separate label-selector bug" but it was left for follow-up. This PR is that follow-up, expanded once the gobgp 4.x flag issue surfaced during cluster testing.

Closes #62