### PR TITLE
release: v0.16.6 — kubectl-purelb BGP state messaging + Helm install pod discovery + gobgp 4.x flag

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ This project uses GitHub Actions for CI/CD:
 
 - **Tests** run on all branches and pull requests
 - **Container images** are built and pushed to `ghcr.io/purelb/purelb` on main branch and tags
-- **Releases** are created automatically when a version tag (e.g., `v0.16.5`) is pushed
+- **Releases** are created automatically when a version tag (e.g., `v0.16.6`) is pushed
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ The default installation includes [k8gobgp](https://github.com/purelb/k8gobgp) a
 Install CRDs first, then apply the main install manifest:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-v0.16.6.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-v0.16.6.yaml
 ```
 
 Without BGP support:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-nobgp-v0.16.5.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-nobgp-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-nobgp-v0.16.6.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-nobgp-v0.16.6.yaml
 ```
 
 The CRDs must be applied first because the install manifest includes a default
@@ -50,7 +50,7 @@ Or using OCI registry (Helm 3.8+, `--version` required):
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.5
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.6
 ```
 
 To install without BGP support:

--- a/website/content/docs/installation/helm/_index.md
+++ b/website/content/docs/installation/helm/_index.md
@@ -30,7 +30,7 @@ helm install --create-namespace --namespace=purelb-system purelb purelb/purelb \
 
 ```sh
 helm install --create-namespace --namespace=purelb-system purelb \
-    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.5
+    oci://ghcr.io/purelb/purelb/charts/purelb --version v0.16.6
 ```
 
 ## Key Configuration Values

--- a/website/content/docs/installation/manifest/_index.md
+++ b/website/content/docs/installation/manifest/_index.md
@@ -9,8 +9,8 @@ The quickest way to install PureLB is with kubectl. Installation is a two-step p
 ## With BGP Support (Default)
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-v0.16.6.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-v0.16.6.yaml
 ```
 
 This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After installing, create a [BGPConfiguration]({{< relref "/docs/configuration/bgp" >}}) CR to configure BGP peering.
@@ -18,8 +18,8 @@ This installs PureLB with the k8gobgp sidecar for BGP route advertisement. After
 ## Without BGP Support
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-nobgp-v0.16.5.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-nobgp-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-nobgp-v0.16.6.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-nobgp-v0.16.6.yaml
 ```
 
 Use this variant if you only need local addresses (same subnet as your nodes) and do not need BGP routing.
@@ -62,8 +62,8 @@ The manifest creates:
 To upgrade, apply the new version's manifests:
 
 ```sh
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
-kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-v0.16.6.yaml
+kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-v0.16.6.yaml
 ```
 
 Existing services retain their allocated addresses during the upgrade.

--- a/website/content/docs/migration/_index.md
+++ b/website/content/docs/migration/_index.md
@@ -168,7 +168,7 @@ Previous versions required users to install and configure standalone routing sof
 
 3. **Install the v2 CRDs** (they replace the v1 CRDs):
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-crds-v0.16.5.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-crds-v0.16.6.yaml
    ```
 
 4. **Apply converted CRs:**
@@ -179,7 +179,7 @@ Previous versions required users to install and configure standalone routing sof
 
 5. **Upgrade PureLB:**
    ```sh
-   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.5/install-v0.16.5.yaml
+   kubectl apply -f https://github.com/purelb/purelb/releases/download/v0.16.6/install-v0.16.6.yaml
    ```
 
 6. **Verify:** Existing services should retain their allocated addresses. Check with:


### PR DESCRIPTION
## Summary

Patch release that ships the kubectl-purelb plugin fixes from [PR #63](https://github.com/purelb/purelb/pull/63) (already merged to main at `de546f6b`). **No chart or manifest changes** — the v0.16.6 chart and manifests are byte-identical to v0.16.5 in everything but the bundled plugin binaries and version-string surface.

Users running PureLB v0.16.5 do not need to redeploy the chart; only the plugin needs to be re-pulled from the v0.16.6 release.

## What ships in v0.16.6 (from PR #63)

- **BGP state messaging.** `status` no longer prints `BGP: not deployed` when the k8gobgp sidecar IS deployed and writing BGPNodeStatus heartbeats. New 3-state taxonomy (`NotEnabled` / `NotConfigured` / `Active`) used consistently across all BGP-touching commands. Canonical wording: `not enabled` / `not configured` / `M/N peers established`.
- **Helm install pod discovery.** Plugin no longer reports `Components: 0/0 Running` or "no running lbnodeagent pod" on Helm-installed clusters. Pod identification now uses container composition (`allocator` / `lbnodeagent` / `k8gobgp` container names) instead of the manifest-only `component=*` label.
- **gobgp 4.x flag.** Plugin's `gobgp …` and dashboard's GoBGP RIB invocations no longer fail with the cryptic "rpc error: name resolver error: produced zero addresses". k8gobgp 0.2.4 ships gobgp 4.x which renamed `-u <path>` to `--target unix://<path>`; the plugin now uses the new syntax.

Full bug-class breakdown in [PR #63](https://github.com/purelb/purelb/pull/63).

## Pre-flight gates (per RELEASING.md)

- [x] `make check` passes locally (vet + race tests + `check-deps` + `check-helm-rbac-source`)
- [x] `make check-deps` confirms bundled k8gobgp CRDs match k8gobgp v0.2.4 (no upstream release since v0.2.4 — no bump)
- [x] `make check-helm-rbac-source` confirms the Helm RBAC injection marker is intact
- [x] Dependabot triage: all 10 open dep PRs explicitly dispositioned — **deferred to v0.17.0** (PRs #30, #31, #32, #34, #40, #41, #42, #43, #48, #49). v0.16.6 is a focused patch and won't widen surface area with unrelated dep bumps.

## Pre-tag smoke tests (per RELEASING.md)

- [x] **Smoke Test A (manifest install)** on a clean `helm-test` cluster:
  - `install-crds-v0.16.6-rc1.yaml` + `install-v0.16.6-rc1.yaml` applied
  - allocator + lbnodeagent Running
  - ClusterRole `purelb:k8gobgp` grants `bgpnodestatuses` (3 occurrences)
  - sample LB allocated `172.30.255.220`
  - BGPNodeStatus row populated
  - NEW plugin shows correct `Components: 1/1 \| 1/1 \| 1/1` and `BGP: not configured` line
- [x] **Smoke Test B (Helm install from local tgz)** on a clean `helm-test` cluster:
  - `helm install ./purelb-v0.16.6-rc1.tgz`
  - ClusterRole grants `bgpnodestatuses` (2 occurrences)
  - sample LB allocated `172.30.255.225`
  - BGPNodeStatus row written
  - NEW plugin shows correct Components and `BGP: not configured` line
  - `gobgp neighbor` short-circuits cleanly with `BGP not configured.`
  - `ip addr show kube-lb0` returns real interface state (proves discovery fix on Helm install)
- [ ] CI `test` job passes (verify after push)
- [ ] Pre-tag rc1 container images cleaned up from ghcr.io — done

## Files changed

| File | Change |
|---|---|
| `README.md`, `BUILDING.md`, `website/content/docs/installation/{manifest,helm}/_index.md`, `website/content/docs/migration/_index.md` | `v0.16.5` → `v0.16.6` (15 hits). Migration doc's `v0.15.x` historical reference at line 7 intentionally preserved. |

That's the entire diff. The plugin code shipping in v0.16.6 was already merged via PR #63.

Closes #62