### PR TITLE
feat(sg-display): Issue #60 — status subresource + display columns + sync writer (v0.17.0 Part A)

### DIFF
--- a/build/helm/purelb/templates/clusterrole-allocator.yaml
+++ b/build/helm/purelb/templates/clusterrole-allocator.yaml
@@ -17,6 +17,13 @@ rules:
   - watch
   - update
 - apiGroups:
+  - purelb.io
+  resources:
+  - servicegroups/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - ''
   resources:
   - services

--- a/deployments/default/purelb.yaml
+++ b/deployments/default/purelb.yaml
@@ -33,6 +33,13 @@ rules:
   - watch
   - update
 - apiGroups:
+  - purelb.io
+  resources:
+  - servicegroups/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - ''
   resources:
   - services

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -15,13 +15,16 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/go-kit/log"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"purelb.io/internal/k8s"
 	"purelb.io/internal/logging"
@@ -41,23 +44,38 @@ type ActiveSubnetsFunc func(namespace string) ([]string, error)
 // Used to populate pool state from existing allocations.
 type ListServicesFunc func() []v1.Service
 
-// allocatorState holds the pool map that is atomically swapped by SetPools
-// (G2) and loaded per-cycle by SetBalancer/DeleteBalancer (G1). This
-// ensures G1 always sees a consistent pool snapshot within one processing
-// cycle, even if G2 swaps pools mid-cycle.
+// allocatorState holds the pool + ServiceGroup maps that are atomically
+// swapped by SetPools (G2) and loaded per-cycle by SetBalancer/DeleteBalancer
+// (G1). This ensures G1 always sees a consistent pool snapshot within one
+// processing cycle, even if G2 swaps mid-cycle.
+//
+// sgByName is parallel to pools (same keys, same lifetime) and holds
+// DeepCopies of the ServiceGroup objects from the informer cache.
+// DeepCopying is mandatory — informer-cache objects must never be mutated
+// per k8s client-go contract, and the status writer needs a stable SG
+// pointer to construct UpdateStatus requests from.
 type allocatorState struct {
-	pools map[string]Pool
+	pools    map[string]Pool
+	sgByName map[string]*purelbv2.ServiceGroup
 }
 
 // An Allocator tracks IP address pools and allocates addresses from them.
 type Allocator struct {
 	client          k8s.ServiceEvent
+	sgStatusClient  k8s.ServiceGroupStatusWriter // for status subresource writes
 	logger          log.Logger
 	state           atomic.Pointer[allocatorState]
 	populated       atomic.Bool
 	activeSubnets   ActiveSubnetsFunc
 	purelbNamespace string
 	listServices    ListServicesFunc
+
+	// lastWritten caches the most recently successfully-written status per
+	// ServiceGroup name. Used by maybeUpdateSGStatus to elide no-op API
+	// writes when the computed status equals what was last sent. Owned by
+	// G1 (queue worker) — sync.Map is safe for the rare concurrent reads
+	// from any future helper goroutines.
+	lastWritten sync.Map // map[svcGroupName]purelbv2.ServiceGroupStatus
 }
 
 // New returns an Allocator managing no pools.
@@ -65,8 +83,18 @@ func New(log log.Logger) *Allocator {
 	a := &Allocator{
 		logger: log,
 	}
-	a.state.Store(&allocatorState{pools: map[string]Pool{}})
+	a.state.Store(&allocatorState{
+		pools:    map[string]Pool{},
+		sgByName: map[string]*purelbv2.ServiceGroup{},
+	})
 	return a
+}
+
+// SetServiceGroupStatusWriter wires the ServiceGroup status-subresource
+// client used by maybeUpdateSGStatus. If unset, status writes are skipped
+// silently (allocator still runs; SG status fields stay empty).
+func (a *Allocator) SetServiceGroupStatusWriter(w k8s.ServiceGroupStatusWriter) {
+	a.sgStatusClient = w
 }
 
 // Pools returns the current pool snapshot. Call once per processing
@@ -109,19 +137,31 @@ func (a *Allocator) SetPools(groups []*purelbv2.ServiceGroup) error {
 		return fmt.Errorf("No valid pools found")
 	}
 
-	// Clean up metrics for removed pools
+	// Build sgByName parallel to pools. DeepCopy each SG — informer-cache
+	// objects must never be mutated (client-go contract), and the status
+	// writer holds onto these pointers across the atomic swap.
+	sgByName := make(map[string]*purelbv2.ServiceGroup, len(pools))
+	for _, g := range groups {
+		if _, kept := pools[g.Name]; !kept {
+			continue // group failed parse; not in pools map
+		}
+		sgByName[g.Name] = g.DeepCopy()
+	}
+
+	// Clean up metrics + lastWritten cache for removed pools
 	oldState := a.state.Load()
 	if oldState != nil {
 		for n := range oldState.pools {
 			if pools[n] == nil {
 				poolCapacity.DeleteLabelValues(n)
 				poolActive.DeleteLabelValues(n)
+				a.lastWritten.Delete(n)
 			}
 		}
 	}
 
 	// Atomic swap — after this, G1's next Pools() call sees the new map
-	a.state.Store(&allocatorState{pools: pools})
+	a.state.Store(&allocatorState{pools: pools, sgByName: sgByName})
 	a.populated.Store(false)
 
 	// Set capacity for new pools (size is static, safe from G2).
@@ -165,6 +205,142 @@ func (a *Allocator) populateFromExisting(pools map[string]Pool) {
 func (a *Allocator) updateStats(pool Pool) {
 	poolCapacity.WithLabelValues(pool.String()).Set(float64(pool.Size()))
 	poolActive.WithLabelValues(pool.String()).Set(float64(pool.InUse()))
+	a.maybeUpdateSGStatus(pool)
+}
+
+// maybeUpdateSGStatus writes the ServiceGroup's .status to reflect the
+// pool's current state. Synchronous (runs from G1, the allocation
+// hot-path). The lastWritten cache elides API calls when the computed
+// status is unchanged — at steady state most updateStats invocations
+// are no-ops. Errors are logged + counted, never block allocation.
+//
+// Skipped silently if no sgStatusClient is wired (e.g., in unit tests).
+func (a *Allocator) maybeUpdateSGStatus(pool Pool) {
+	if a.sgStatusClient == nil {
+		return
+	}
+	s := a.state.Load()
+	if s == nil {
+		return
+	}
+	sg, ok := s.sgByName[pool.String()]
+	if !ok || sg == nil {
+		return
+	}
+
+	newStatus := buildStatus(pool)
+	if prev, loaded := a.lastWritten.Load(sg.Name); loaded {
+		if statusEqual(prev.(purelbv2.ServiceGroupStatus), newStatus) {
+			return // no-op
+		}
+	}
+
+	sgCopy := sg.DeepCopy()
+	sgCopy.Status = newStatus
+	updated, err := a.sgStatusClient.UpdateServiceGroupStatus(sgCopy)
+	if err != nil {
+		sgStatusWritesTotal.WithLabelValues(classifyStatusErr(err)).Inc()
+		if !a.sgStatusClient.IsShutdownError(err) {
+			logging.Info(a.logger, "op", "updateSGStatus", "error", err, "sg", sg.Name)
+		}
+		// Do NOT update lastWritten — next call retries.
+		return
+	}
+	sgStatusWritesTotal.WithLabelValues("success").Inc()
+	a.lastWritten.Store(sg.Name, newStatus)
+	// Refresh the cached SG's ResourceVersion so the next UpdateStatus
+	// call uses the latest server version and doesn't hit "object has
+	// been modified" conflicts. Safe to mutate in-place: sgByName is
+	// G1-single-writer (this code path); the SG pointer is exclusive
+	// to the allocator (DeepCopy was taken in SetPools).
+	if updated != nil {
+		sg.ResourceVersion = updated.ResourceVersion
+	}
+}
+
+// buildStatus computes the ServiceGroupStatus payload for a pool. Pure
+// reads from the Pool interface; no I/O. For SidecarPool (Part C),
+// callers must refresh the Stats cache before calling buildStatus.
+func buildStatus(pool Pool) purelbv2.ServiceGroupStatus {
+	s := purelbv2.ServiceGroupStatus{
+		Announce:      capitalize(pool.PoolType()),
+		IPAM:          pool.IPAMSource(),
+		Addresses:     pool.DisplayAddresses(),
+		AllocatedIPv4: int64(pool.InUseV4()),
+		AllocatedIPv6: int64(pool.InUseV6()),
+	}
+	if pool.HasKnownCapacity() {
+		availV4 := int64(pool.SizeV4()) - s.AllocatedIPv4
+		availV6 := int64(pool.SizeV6()) - s.AllocatedIPv6
+		s.AvailableIPv4, s.AvailableIPv6 = &availV4, &availV6
+	}
+	return s
+}
+
+// capitalize returns s with the first byte upper-cased. Pool.PoolType()
+// returns "local" / "remote" by convention; status display wants
+// "Local" / "Remote" to match user-facing capitalization.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] >= 'a' && s[0] <= 'z' {
+		return string(s[0]-32) + s[1:]
+	}
+	return s
+}
+
+// statusEqual reports whether two ServiceGroupStatus values are
+// semantically equal. Hand-written instead of reflect.DeepEqual so
+// *int64 fields are compared by dereferenced value, not by pointer
+// identity (two separate &int64 allocations holding the same value
+// must compare equal so the lastWritten cache elides redundant writes).
+func statusEqual(a, b purelbv2.ServiceGroupStatus) bool {
+	if a.Announce != b.Announce ||
+		a.IPAM != b.IPAM ||
+		a.AllocatedIPv4 != b.AllocatedIPv4 ||
+		a.AllocatedIPv6 != b.AllocatedIPv6 {
+		return false
+	}
+	if !int64PtrEqual(a.AvailableIPv4, b.AvailableIPv4) ||
+		!int64PtrEqual(a.AvailableIPv6, b.AvailableIPv6) {
+		return false
+	}
+	if len(a.Addresses) != len(b.Addresses) {
+		return false
+	}
+	for i := range a.Addresses {
+		if a.Addresses[i] != b.Addresses[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// int64PtrEqual returns true when a and b point to equal values or are
+// both nil. Distinct from `a == b` which compares pointer identity.
+func int64PtrEqual(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// classifyStatusErr categorises a status-write error for the
+// sgStatusWritesTotal counter. Conservative: anything we don't
+// recognise lands in "other".
+func classifyStatusErr(err error) string {
+	if err == nil {
+		return "success"
+	}
+	switch {
+	case apierrors.IsConflict(err):
+		return "conflict"
+	case apierrors.IsForbidden(err):
+		return "forbidden"
+	default:
+		return "other"
+	}
 }
 
 // NotifyExisting notifies the allocator of existing IP assignments,
@@ -186,7 +362,7 @@ func (a *Allocator) NotifyExisting(pools map[string]Pool, svc *v1.Service) error
 		}
 
 		// Tell the pool about the assignment
-		if err := pool.Notify(svc); err != nil {
+		if err := pool.Notify(context.Background(), svc); err != nil {
 			return err
 		}
 		a.updateStats(pool)
@@ -295,7 +471,7 @@ func (a *Allocator) allocateSpecificIP(pools map[string]Pool, svc *v1.Service) (
 		// Does the IP already have allocs? If so, needs to be the same
 		// sharing key, and have non-overlapping ports. If not, the proposed
 		// IP needs to be allowed by configuration.
-		if err := pool.Assign(ip, svc); err != nil {
+		if err := pool.Assign(context.Background(), ip, svc); err != nil {
 			return false, err
 		}
 
@@ -340,7 +516,7 @@ func (a *Allocator) allocateFromPool(pools map[string]Pool, svc *v1.Service, poo
 		}
 	}
 
-	if err := pool.AssignNext(svc); err != nil {
+	if err := pool.AssignNext(context.Background(), svc); err != nil {
 		// Woops, no IPs :( Fail.
 		return err
 	}
@@ -401,7 +577,7 @@ func (a *Allocator) allocateMultiPool(pools map[string]Pool, svc *v1.Service, po
 	logging.Info(a.logger, "op", "allocateMultiPool", "activeSubnets", strings.Join(activeSubnets, ","),
 		"svc", namespacedName(svc))
 
-	if err := pool.AssignNextPerRange(svc, activeSubnets); err != nil {
+	if err := pool.AssignNextPerRange(context.Background(), svc, activeSubnets); err != nil {
 		return err
 	}
 
@@ -447,7 +623,7 @@ func (a *Allocator) IncrementalMultiPool(pools map[string]Pool, svc *v1.Service)
 
 	existingCount := len(svc.Status.LoadBalancer.Ingress)
 
-	if err := pool.AssignNextPerRange(svc, activeSubnets); err != nil {
+	if err := pool.AssignNextPerRange(context.Background(), svc, activeSubnets); err != nil {
 		return false, err
 	}
 
@@ -478,7 +654,7 @@ func (a *Allocator) Unassign(pools map[string]Pool, svc string) error {
 	// not be a pool, e.g., in the case of a config change that moves
 	// addresses from one pool to another
 	for _, p := range pools {
-		if err = p.Release(svc); err == nil {
+		if err = p.Release(context.Background(), svc); err == nil {
 			a.updateStats(p) // This pool released the address
 		}
 	}
@@ -504,7 +680,7 @@ func (a *Allocator) ReleaseIPs(pools map[string]Pool, svc string, ips []string) 
 			continue
 		}
 
-		if err := pool.ReleaseIP(svc, ip); err != nil {
+		if err := pool.ReleaseIP(context.Background(), svc, ip); err != nil {
 			logging.Info(a.logger, "op", "releaseIPs", "error", err, "ip", ipStr)
 			// Continue releasing other IPs even if one fails
 		}

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -15,6 +15,8 @@
 package allocator
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -25,7 +27,9 @@ import (
 	ptu "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
@@ -1331,4 +1335,378 @@ func TestIncrementalMultiPoolNoOp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, added, "all ranges covered, should be no-op")
 	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress))
+}
+
+// =================================================================
+// Part A: ServiceGroup display (.status subresource) tests
+// =================================================================
+
+// fakeStatusPool implements just enough of Pool for buildStatus tests.
+// Each field is set per-case to exercise a specific buildStatus branch.
+type fakeStatusPool struct {
+	name              string
+	poolType          string
+	ipamSource        string
+	displayAddresses  []string
+	inUseV4           int
+	inUseV6           int
+	sizeV4            uint64
+	sizeV6            uint64
+	hasKnownCapacity  bool
+}
+
+func (f *fakeStatusPool) String() string                                  { return f.name }
+func (f *fakeStatusPool) PoolType() string                                { return f.poolType }
+func (f *fakeStatusPool) IPAMSource() string                              { return f.ipamSource }
+func (f *fakeStatusPool) DisplayAddresses() []string                      { return f.displayAddresses }
+func (f *fakeStatusPool) InUseV4() int                                    { return f.inUseV4 }
+func (f *fakeStatusPool) InUseV6() int                                    { return f.inUseV6 }
+func (f *fakeStatusPool) SizeV4() uint64                                  { return f.sizeV4 }
+func (f *fakeStatusPool) SizeV6() uint64                                  { return f.sizeV6 }
+func (f *fakeStatusPool) HasKnownCapacity() bool                          { return f.hasKnownCapacity }
+func (f *fakeStatusPool) InUse() int                                      { return f.inUseV4 + f.inUseV6 }
+func (f *fakeStatusPool) Size() uint64                                    { return f.sizeV4 + f.sizeV6 }
+func (f *fakeStatusPool) Notify(context.Context, *v1.Service) error       { return nil }
+func (f *fakeStatusPool) Assign(context.Context, net.IP, *v1.Service) error { return nil }
+func (f *fakeStatusPool) AssignNext(context.Context, *v1.Service) error   { return nil }
+func (f *fakeStatusPool) Release(context.Context, string) error           { return nil }
+func (f *fakeStatusPool) ReleaseIP(context.Context, string, net.IP) error { return nil }
+func (f *fakeStatusPool) AssignNextPerRange(context.Context, *v1.Service, []string) error {
+	return nil
+}
+func (f *fakeStatusPool) Overlaps(Pool) bool { return false }
+func (f *fakeStatusPool) Contains(net.IP) bool { return false }
+func (f *fakeStatusPool) SkipIPv6DAD() bool   { return false }
+func (f *fakeStatusPool) MultiPool() bool     { return false }
+func (f *fakeStatusPool) BalancePools() bool  { return false }
+
+// ptrI64 returns a pointer to v. Used for inline expected-value
+// construction in table-driven tests.
+func ptrI64(v int64) *int64 { return &v }
+
+func TestBuildStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		pool *fakeStatusPool
+		want purelbv2.ServiceGroupStatus
+	}{
+		{
+			name: "cluster-IPAM local pool, partial allocation",
+			pool: &fakeStatusPool{
+				poolType:         "local",
+				ipamSource:       "Cluster",
+				displayAddresses: []string{"192.168.1.0/24"},
+				inUseV4:          3,
+				sizeV4:           254,
+				hasKnownCapacity: true,
+			},
+			want: purelbv2.ServiceGroupStatus{
+				Announce:      "Local",
+				IPAM:          "Cluster",
+				Addresses:     []string{"192.168.1.0/24"},
+				AllocatedIPv4: 3,
+				AllocatedIPv6: 0,
+				AvailableIPv4: ptrI64(251),
+				AvailableIPv6: ptrI64(0),
+			},
+		},
+		{
+			name: "cluster-IPAM remote pool, dual-stack",
+			pool: &fakeStatusPool{
+				poolType:         "remote",
+				ipamSource:       "Cluster",
+				displayAddresses: []string{"172.16.0.0/24", "2001:db8::/120"},
+				inUseV4:          5,
+				inUseV6:          2,
+				sizeV4:           254,
+				sizeV6:           65535,
+				hasKnownCapacity: true,
+			},
+			want: purelbv2.ServiceGroupStatus{
+				Announce:      "Remote",
+				IPAM:          "Cluster",
+				Addresses:     []string{"172.16.0.0/24", "2001:db8::/120"},
+				AllocatedIPv4: 5,
+				AllocatedIPv6: 2,
+				AvailableIPv4: ptrI64(249),
+				AvailableIPv6: ptrI64(65533),
+			},
+		},
+		{
+			name: "external-IPAM (no known capacity): Available fields nil",
+			pool: &fakeStatusPool{
+				poolType:         "remote",
+				ipamSource:       "Netbox",
+				displayAddresses: nil,
+				inUseV4:          12,
+				inUseV6:          0,
+				hasKnownCapacity: false,
+			},
+			want: purelbv2.ServiceGroupStatus{
+				Announce:      "Remote",
+				IPAM:          "Netbox",
+				Addresses:     nil,
+				AllocatedIPv4: 12,
+				AllocatedIPv6: 0,
+				// AvailableIPv4 + AvailableIPv6 left nil
+			},
+		},
+		{
+			name: "empty local pool: Allocated=0, Available=full capacity",
+			pool: &fakeStatusPool{
+				poolType:         "local",
+				ipamSource:       "Cluster",
+				displayAddresses: []string{"10.0.0.0/30"},
+				sizeV4:           4,
+				hasKnownCapacity: true,
+			},
+			want: purelbv2.ServiceGroupStatus{
+				Announce:      "Local",
+				IPAM:          "Cluster",
+				Addresses:     []string{"10.0.0.0/30"},
+				AllocatedIPv4: 0,
+				AllocatedIPv6: 0,
+				AvailableIPv4: ptrI64(4),
+				AvailableIPv6: ptrI64(0),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildStatus(tc.pool)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("buildStatus mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStatusEqual(t *testing.T) {
+	base := purelbv2.ServiceGroupStatus{
+		Announce: "Local", IPAM: "Cluster",
+		Addresses:     []string{"192.168.1.0/24"},
+		AllocatedIPv4: 3, AllocatedIPv6: 0,
+		AvailableIPv4: ptrI64(251), AvailableIPv6: ptrI64(0),
+	}
+
+	cases := []struct {
+		name string
+		a, b purelbv2.ServiceGroupStatus
+		want bool
+	}{
+		{name: "identical", a: base, b: base, want: true},
+		{
+			name: "Announce differs",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.Announce = "Remote"; return c }(),
+			want: false,
+		},
+		{
+			name: "IPAM differs",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.IPAM = "Netbox"; return c }(),
+			want: false,
+		},
+		{
+			name: "AllocatedIPv4 differs",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.AllocatedIPv4 = 4; return c }(),
+			want: false,
+		},
+		{
+			name: "Available* nil vs ptr-to-equal-value differ",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.AvailableIPv4 = nil; return c }(),
+			want: false,
+		},
+		{
+			name: "Available* both nil match",
+			a:    func() purelbv2.ServiceGroupStatus { c := base; c.AvailableIPv4 = nil; c.AvailableIPv6 = nil; return c }(),
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.AvailableIPv4 = nil; c.AvailableIPv6 = nil; return c }(),
+			want: true,
+		},
+		{
+			name: "Available* separate-allocation-same-value match (this is the key cache-elision case)",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; v4, v6 := int64(251), int64(0); c.AvailableIPv4 = &v4; c.AvailableIPv6 = &v6; return c }(),
+			want: true,
+		},
+		{
+			name: "Addresses length differs",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.Addresses = []string{"192.168.1.0/24", "extra"}; return c }(),
+			want: false,
+		},
+		{
+			name: "Addresses content differs",
+			a:    base,
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.Addresses = []string{"10.0.0.0/24"}; return c }(),
+			want: false,
+		},
+		{
+			name: "Addresses both empty match",
+			a:    func() purelbv2.ServiceGroupStatus { c := base; c.Addresses = nil; return c }(),
+			b:    func() purelbv2.ServiceGroupStatus { c := base; c.Addresses = nil; return c }(),
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := statusEqual(tc.a, tc.b)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestInt64PtrEqual(t *testing.T) {
+	a, b := int64(5), int64(5)
+	c := int64(7)
+	assert.True(t, int64PtrEqual(nil, nil), "both nil should be equal")
+	assert.False(t, int64PtrEqual(&a, nil), "ptr vs nil should differ")
+	assert.False(t, int64PtrEqual(nil, &a), "nil vs ptr should differ")
+	assert.True(t, int64PtrEqual(&a, &b), "separate alloc same value should be equal")
+	assert.False(t, int64PtrEqual(&a, &c), "different values should differ")
+	assert.True(t, int64PtrEqual(&a, &a), "same pointer should be equal")
+}
+
+func TestClassifyStatusErr(t *testing.T) {
+	assert.Equal(t, "success", classifyStatusErr(nil))
+	assert.Equal(t, "conflict", classifyStatusErr(apierrors.NewConflict(
+		schema.GroupResource{Group: "purelb.io", Resource: "servicegroups"},
+		"test", nil)))
+	assert.Equal(t, "forbidden", classifyStatusErr(apierrors.NewForbidden(
+		schema.GroupResource{Group: "purelb.io", Resource: "servicegroups/status"},
+		"test", nil)))
+	// Any error not matching IsConflict / IsForbidden → "other"
+	assert.Equal(t, "other", classifyStatusErr(fmt.Errorf("some random error")))
+}
+
+func TestCapitalize(t *testing.T) {
+	assert.Equal(t, "", capitalize(""))
+	assert.Equal(t, "Local", capitalize("local"))
+	assert.Equal(t, "Remote", capitalize("remote"))
+	assert.Equal(t, "Already", capitalize("Already"), "already-capitalized should be unchanged")
+	assert.Equal(t, "A", capitalize("a"))
+}
+
+// fakeStatusWriter captures ServiceGroupStatusWriter calls for tests of
+// maybeUpdateSGStatus. The next write returns nextErr when non-nil.
+type fakeStatusWriter struct {
+	updates       []*purelbv2.ServiceGroup
+	nextErr       error
+	apiCtxCalls   int
+	shutdownCalls int
+}
+
+func (f *fakeStatusWriter) UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error) {
+	f.updates = append(f.updates, sg.DeepCopy())
+	if f.nextErr != nil {
+		err := f.nextErr
+		f.nextErr = nil
+		return nil, err
+	}
+	// Simulate API server: bump ResourceVersion to demonstrate the fake
+	// behaves like the real one. Tests that care about ResourceVersion
+	// propagation can assert on this.
+	updated := sg.DeepCopy()
+	updated.ResourceVersion = sg.ResourceVersion + "-bumped"
+	return updated, nil
+}
+func (f *fakeStatusWriter) APIContext() (context.Context, context.CancelFunc) {
+	f.apiCtxCalls++
+	return context.Background(), func() {}
+}
+func (f *fakeStatusWriter) IsShutdownError(err error) bool {
+	f.shutdownCalls++
+	return false
+}
+
+func TestMaybeUpdateSGStatus_NoopCacheElision(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	fakeWriter := &fakeStatusWriter{}
+	alloc.SetServiceGroupStatusWriter(fakeWriter)
+
+	sg := &purelbv2.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sg", Namespace: "purelb-system"},
+	}
+	pool := &fakeStatusPool{
+		name:             "test-sg",
+		poolType:         "local",
+		ipamSource:       "Cluster",
+		displayAddresses: []string{"192.168.1.0/24"},
+		inUseV4:          3,
+		sizeV4:           254,
+		hasKnownCapacity: true,
+	}
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"test-sg": pool},
+		sgByName: map[string]*purelbv2.ServiceGroup{"test-sg": sg},
+	})
+
+	// First call: writes status.
+	alloc.maybeUpdateSGStatus(pool)
+	assert.Equal(t, 1, len(fakeWriter.updates), "first call should write")
+
+	// Second call with unchanged pool state: cache-elision → no write.
+	alloc.maybeUpdateSGStatus(pool)
+	assert.Equal(t, 1, len(fakeWriter.updates), "no-op second call should NOT write")
+
+	// State change → write fires again.
+	pool.inUseV4 = 4
+	alloc.maybeUpdateSGStatus(pool)
+	assert.Equal(t, 2, len(fakeWriter.updates), "changed state should write")
+}
+
+func TestMaybeUpdateSGStatus_ErrorPath(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	fakeWriter := &fakeStatusWriter{
+		nextErr: apierrors.NewConflict(
+			schema.GroupResource{Group: "purelb.io", Resource: "servicegroups"},
+			"test", nil),
+	}
+	alloc.SetServiceGroupStatusWriter(fakeWriter)
+
+	sg := &purelbv2.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sg", Namespace: "purelb-system"},
+	}
+	pool := &fakeStatusPool{
+		name: "test-sg", poolType: "local", ipamSource: "Cluster",
+		inUseV4: 1, sizeV4: 4, hasKnownCapacity: true,
+	}
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"test-sg": pool},
+		sgByName: map[string]*purelbv2.ServiceGroup{"test-sg": sg},
+	})
+
+	// First call fails with conflict; should NOT update lastWritten cache.
+	alloc.maybeUpdateSGStatus(pool)
+	assert.Equal(t, 1, len(fakeWriter.updates), "first call attempts the write")
+	// Second call (no state change) retries because cache wasn't updated.
+	alloc.maybeUpdateSGStatus(pool)
+	assert.Equal(t, 2, len(fakeWriter.updates), "after error, next call should retry (cache not updated)")
+}
+
+func TestMaybeUpdateSGStatus_NilClient(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	// sgStatusClient NOT set — should silently skip.
+	pool := &fakeStatusPool{name: "test-sg", poolType: "local"}
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"test-sg": pool},
+		sgByName: map[string]*purelbv2.ServiceGroup{"test-sg": {ObjectMeta: metav1.ObjectMeta{Name: "test-sg"}}},
+	})
+	// No-op; just verify no panic.
+	alloc.maybeUpdateSGStatus(pool)
+}
+
+func TestMaybeUpdateSGStatus_UnknownPool(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.SetServiceGroupStatusWriter(&fakeStatusWriter{})
+	// Pool whose name isn't in sgByName — should silently skip.
+	pool := &fakeStatusPool{name: "unknown-sg", poolType: "local"}
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{},
+		sgByName: map[string]*purelbv2.ServiceGroup{},
+	})
+	// No-op; no panic.
+	alloc.maybeUpdateSGStatus(pool)
 }

--- a/internal/allocator/controller.go
+++ b/internal/allocator/controller.go
@@ -65,6 +65,7 @@ func NewController(l log.Logger, ips *Allocator) (Controller, error) {
 func (c *controller) SetClient(client *k8s.Client) {
 	c.client = client
 	c.ips.SetClient(client)
+	c.ips.SetServiceGroupStatusWriter(client)
 	c.ips.SetListServices(client.ListServices)
 
 	data, err := os.ReadFile(namespacePath)

--- a/internal/allocator/localpool.go
+++ b/internal/allocator/localpool.go
@@ -16,6 +16,7 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sort"
@@ -160,7 +161,7 @@ func NewLocalPool(name string, log log.Logger, v4Pool *purelbv2.AddressPool, v6P
 	return pool, nil
 }
 
-func (p LocalPool) Notify(service *v1.Service) error {
+func (p LocalPool) Notify(_ context.Context, service *v1.Service) error {
 	nsName := namespacedName(service)
 	sharingKey := &Key{Sharing: SharingKey(service)}
 	ports := Ports(service)
@@ -250,7 +251,7 @@ func (p LocalPool) available(ip net.IP, service *v1.Service) error {
 }
 
 // AssignNext assigns the next available IP to service.
-func (p LocalPool) AssignNext(service *v1.Service) error {
+func (p LocalPool) AssignNext(_ context.Context, service *v1.Service) error {
 	families, err := p.whichFamilies(service)
 	if err != nil {
 		return err
@@ -309,7 +310,7 @@ func (p LocalPool) assignFamily(family int, service *v1.Service) error {
 	boundIP := p.ipForSharingKey(sharingKey, family)
 
 	for pos := p.first(family); pos != nil; pos = p.next(pos) {
-		if err := p.Assign(pos, service); err == nil {
+		if err := p.Assign(context.Background(), pos, service); err == nil {
 			// we found an available address
 			return nil
 		} else {
@@ -358,7 +359,7 @@ func (p LocalPool) assignFamily(family int, service *v1.Service) error {
 }
 
 // Assign assigns a service to an IP.
-func (p LocalPool) Assign(ip net.IP, service *v1.Service) error {
+func (p LocalPool) Assign(ctx context.Context, ip net.IP, service *v1.Service) error {
 	if err := p.available(ip, service); err != nil {
 		return err
 	}
@@ -367,11 +368,11 @@ func (p LocalPool) Assign(ip net.IP, service *v1.Service) error {
 	addIngress(p.logger, service, ip)
 
 	// Update our internal allocation data structures
-	return p.Notify(service)
+	return p.Notify(ctx, service)
 }
 
 // Release releases an IP so it can be assigned again.
-func (p LocalPool) Release(service string) error {
+func (p LocalPool) Release(_ context.Context, service string) error {
 	for ipstr, allocs := range p.addressesInUse {
 		delete(allocs, service)
 		if len(allocs) == 0 {
@@ -400,7 +401,7 @@ func (p LocalPool) Release(service string) error {
 
 // ReleaseIP releases a specific IP address for a service. Used during
 // IP family transitions (e.g., DualStack → SingleStack).
-func (p LocalPool) ReleaseIP(service string, ip net.IP) error {
+func (p LocalPool) ReleaseIP(_ context.Context, service string, ip net.IP) error {
 	ipstr := ip.String()
 
 	// Check if this IP is in our pool
@@ -654,6 +655,79 @@ func (p LocalPool) BalancePools() bool {
 	return p.balancePools
 }
 
+// IPAMSource returns "Cluster" — LocalPool is authoritative for its own
+// address space; PureLB's allocator does the IPAM directly.
+func (p LocalPool) IPAMSource() string {
+	return "Cluster"
+}
+
+// InUseV4 returns the number of IPv4 addresses currently allocated.
+func (p LocalPool) InUseV4() int {
+	n := 0
+	for ipStr := range p.addressesInUse {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// InUseV6 returns the number of IPv6 addresses currently allocated.
+func (p LocalPool) InUseV6() int {
+	n := 0
+	for ipStr := range p.addressesInUse {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// SizeV4 returns the total IPv4 capacity of this pool.
+func (p LocalPool) SizeV4() (size uint64) {
+	for _, v4 := range p.v4Ranges {
+		size += v4.Size()
+	}
+	return
+}
+
+// SizeV6 returns the total IPv6 capacity of this pool.
+func (p LocalPool) SizeV6() (size uint64) {
+	for _, v6 := range p.v6Ranges {
+		size += v6.Size()
+	}
+	return
+}
+
+// HasKnownCapacity returns true — LocalPool's capacity is sum of its
+// configured ranges and is always known.
+func (p LocalPool) HasKnownCapacity() bool {
+	return true
+}
+
+// DisplayAddresses returns the original spec strings of the configured
+// ranges (CIDRs and/or from-to forms), in v4-then-v6 order. Surfaced as
+// .status.addresses so kubectl shows what the user wrote rather than the
+// parsed "(from - to)" form.
+func (p LocalPool) DisplayAddresses() []string {
+	out := make([]string, 0, len(p.v4Ranges)+len(p.v6Ranges))
+	for _, r := range p.v4Ranges {
+		out = append(out, r.Raw())
+	}
+	for _, r := range p.v6Ranges {
+		out = append(out, r.Raw())
+	}
+	return out
+}
+
 // countAllocationsPerRange counts how many IPs are currently allocated
 // in each range. Used by balanced allocation to pick the least-used range.
 func (p LocalPool) countAllocationsPerRange(ranges []*purelbv2.IPRange) []int {
@@ -722,7 +796,7 @@ func (p LocalPool) assignFamilyBalancePools(family int, service *v1.Service) err
 func (p LocalPool) assignFromRange(ipRange *purelbv2.IPRange, service *v1.Service) error {
 	var lastErr error
 	for ip := ipRange.First(); ip != nil; ip = ipRange.Next(ip) {
-		if err := p.Assign(ip, service); err == nil {
+		if err := p.Assign(context.Background(), ip, service); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -737,7 +811,7 @@ func (p LocalPool) assignFromRange(ipRange *purelbv2.IPRange, service *v1.Servic
 // AssignNextPerRange allocates one IP per address range (per family) that
 // has an active subnet. activeSubnets is the set of subnets (in CIDR notation)
 // with healthy lbnodeagents. Returns error only if NO IPs could be allocated.
-func (p LocalPool) AssignNextPerRange(svc *v1.Service, activeSubnets []string) error {
+func (p LocalPool) AssignNextPerRange(ctx context.Context, svc *v1.Service, activeSubnets []string) error {
 	activeSet := make(map[string]bool, len(activeSubnets))
 	for _, s := range activeSubnets {
 		activeSet[s] = true

--- a/internal/allocator/localpool_test.go
+++ b/internal/allocator/localpool_test.go
@@ -14,6 +14,7 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sort"
@@ -42,7 +43,7 @@ func TestEmptyPool(t *testing.T) {
 	assert.Equal(t, uint64(0), p.Size(), "incorrect pool size")
 	assert.Error(t, p.assignFamily(nl.FAMILY_V6, &svc))
 	assert.Error(t, p.assignFamily(nl.FAMILY_V4, &svc))
-	assert.Error(t, p.AssignNext(&svc))
+	assert.Error(t, p.AssignNext(context.Background(), &svc))
 }
 
 func TestNewLocalPool(t *testing.T) {
@@ -58,14 +59,14 @@ func TestNewLocalPool(t *testing.T) {
 	p, err := NewLocalPool("testpool", localPoolTestLogger, v4Pool, nil, nil, nil, purelbv2.PoolTypeLocal, false, false, false)
 	assert.NoError(t, err, "Pool instantiation failed")
 	svc = v1.Service{}
-	assert.NoError(t, p.AssignNext(&svc), "Address allocation failed")
+	assert.NoError(t, p.AssignNext(context.Background(), &svc), "Address allocation failed")
 	assert.Equal(t, ip4, svc.Status.LoadBalancer.Ingress[0].IP, "AssignNext failed")
 
 	// Test IPV4 config with V4Pool
 	p, err = NewLocalPool("v4pool", localPoolTestLogger, v4Pool, nil, nil, nil, purelbv2.PoolTypeLocal, false, false, false)
 	assert.NoError(t, err, "Pool instantiation failed")
 	svc = v1.Service{}
-	assert.NoError(t, p.AssignNext(&svc), "Address allocation failed")
+	assert.NoError(t, p.AssignNext(context.Background(), &svc), "Address allocation failed")
 	// We specified the top-level Pool and the V4Pool so the V4Pool
 	// should take precedence
 	assert.Equal(t, ip4, svc.Status.LoadBalancer.Ingress[0].IP, "AssignNext failed")
@@ -78,14 +79,14 @@ func TestNewLocalPool(t *testing.T) {
 	p, err = NewLocalPool("v6pool", localPoolTestLogger, nil, v6Pool, nil, nil, purelbv2.PoolTypeLocal, false, false, false)
 	assert.NoError(t, err, "Pool instantiation failed")
 	svc = v1.Service{}
-	assert.NoError(t, p.AssignNext(&svc), "Address allocation failed")
+	assert.NoError(t, p.AssignNext(context.Background(), &svc), "Address allocation failed")
 	assert.Equal(t, ip6, svc.Status.LoadBalancer.Ingress[0].IP, "AssignNext failed")
 
 	// Test both pools config
 	p, err = NewLocalPool("bothpools", localPoolTestLogger, v4Pool, v6Pool, nil, nil, purelbv2.PoolTypeLocal, false, false, false)
 	assert.NoError(t, err, "Pool instantiation failed")
 	svc = v1.Service{}
-	assert.NoError(t, p.AssignNext(&svc), "Address allocation failed")
+	assert.NoError(t, p.AssignNext(context.Background(), &svc), "Address allocation failed")
 	// We specified both pools so the V6Pool should take precedence
 	assert.Equal(t, ip6, svc.Status.LoadBalancer.Ingress[0].IP, "AssignNext failed")
 
@@ -145,7 +146,7 @@ func TestRemotePoolMultiPoolSkipsActiveSubnetFilter(t *testing.T) {
 
 	// activeSubnets has NEITHER of the remote pool subnets —
 	// but remote pools should ignore the filter
-	err = p.AssignNextPerRange(&svc, []string{"192.168.1.0/24"})
+	err = p.AssignNextPerRange(context.Background(), &svc, []string{"192.168.1.0/24"})
 	assert.NoError(t, err, "remote pool multi-pool should succeed even without matching active subnets")
 	assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "should get IPs from both remote ranges")
 }
@@ -164,7 +165,7 @@ func TestLocalPoolMultiPoolRespectsActiveSubnetFilter(t *testing.T) {
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 
 	// Only subnet 1 active — should get 1 IP, not 2
-	err = p.AssignNextPerRange(&svc, []string{"192.168.1.0/24"})
+	err = p.AssignNextPerRange(context.Background(), &svc, []string{"192.168.1.0/24"})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress), "should only get IP from active subnet")
 }
@@ -203,11 +204,11 @@ func TestNotify(t *testing.T) {
 
 	// Tell the pool that ip1 is in use
 	addIngress(localPoolTestLogger, &svc1, ip1)
-	assert.NoError(t, p.Notify(&svc1), "Notify failed")
+	assert.NoError(t, p.Notify(context.Background(), &svc1), "Notify failed")
 
 	// Allocate an address to svc2 - it should get ip2 since ip1 is in
 	// use by svc1
-	assert.NoError(t, p.AssignNext(&svc2), "Assigning an address failed")
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2), "Assigning an address failed")
 	assert.Equal(t, ip2.String(), svc2.Status.LoadBalancer.Ingress[0].IP, "svc2 was assigned the wrong address")
 }
 
@@ -219,17 +220,17 @@ func TestInUse(t *testing.T) {
 	svc2 := service("svc2", ports("tcp/80"), "sharing2")
 	svc3 := service("svc3", ports("tcp/25"), "sharing2")
 
-	p.Assign(ip2, &svc1)
+	p.Assign(context.Background(), ip2, &svc1)
 	assert.Equal(t, 1, p.InUse())
-	p.Assign(ip, &svc2)
+	p.Assign(context.Background(), ip, &svc2)
 	assert.Equal(t, 2, p.InUse())
-	p.Assign(ip, &svc3)
+	p.Assign(context.Background(), ip, &svc3)
 	assert.Equal(t, 2, p.InUse()) // allocating the same address doesn't change the count
-	p.Release(namespacedName(&svc2))
+	p.Release(context.Background(), namespacedName(&svc2))
 	assert.Equal(t, 2, p.InUse()) // the address isn't fully released yet
-	p.Release(namespacedName(&svc3))
+	p.Release(context.Background(), namespacedName(&svc3))
 	assert.Equal(t, 1, p.InUse()) // the address isn't fully released yet
-	p.Release(namespacedName(&svc1))
+	p.Release(context.Background(), namespacedName(&svc1))
 	assert.Equal(t, 0, p.InUse()) // all addresses are released
 }
 
@@ -239,11 +240,11 @@ func TestServicesOn(t *testing.T) {
 	svc1 := service("svc1", ports("tcp/80"), "sharing1")
 	svc2 := service("svc2", ports("tcp/25"), "sharing1")
 
-	p.Assign(ip2, &svc1)
+	p.Assign(context.Background(), ip2, &svc1)
 	assert.Equal(t, []string{namespacedName(&svc1)}, p.servicesOnIP(ip2))
-	p.Assign(ip2, &svc2)
+	p.Assign(context.Background(), ip2, &svc2)
 	sameStrings(t, []string{namespacedName(&svc1), namespacedName(&svc2)}, p.servicesOnIP(ip2))
-	p.Release(namespacedName(&svc1))
+	p.Release(context.Background(), namespacedName(&svc1))
 	assert.Equal(t, []string{namespacedName(&svc2)}, p.servicesOnIP(ip2))
 }
 
@@ -257,25 +258,25 @@ func TestSharing(t *testing.T) {
 	svc3 := service("svc3", ports("tcp/81"), key1.Sharing)
 	svc3.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}
 
-	p.Release(namespacedName(&svc3)) // releasing a not-assigned service should be OK
+	p.Release(context.Background(), namespacedName(&svc3)) // releasing a not-assigned service should be OK
 
 	// Allocate addresses to svc1 and svc2 and verify that they both
 	// have the same ones
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	assert.Equal(t, 2, len(svc1.Status.LoadBalancer.Ingress))
 	assert.Equal(t, key1, *p.sharingKeys[svc1.Status.LoadBalancer.Ingress[0].IP])
 	assert.Equal(t, key1, *p.sharingKeys[svc1.Status.LoadBalancer.Ingress[1].IP])
-	assert.NoError(t, p.AssignNext(&svc2))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2))
 	assert.EqualValues(t, svc1.Status.LoadBalancer.Ingress, svc2.Status.LoadBalancer.Ingress, "svc1 and svc2 have different addresses")
 
-	p.Release(namespacedName(&svc1))
+	p.Release(context.Background(), namespacedName(&svc1))
 	// svc2 is still using the IPs
 	assert.Equal(t, key1, *p.sharingKeys[svc2.Status.LoadBalancer.Ingress[1].IP])
-	assert.Error(t, p.Assign(ip4, &svc3)) // svc3 is blocked by svc2 (same port)
-	p.Release(namespacedName(&svc2))
+	assert.Error(t, p.Assign(context.Background(), ip4, &svc3)) // svc3 is blocked by svc2 (same port)
+	p.Release(context.Background(), namespacedName(&svc2))
 	// the IP is unused
 	assert.Nil(t, p.SharingKey(ip4))
-	assert.NoError(t, p.Assign(ip4, &svc3)) // svc2 is out of the picture so svc3 can use the address
+	assert.NoError(t, p.Assign(context.Background(), ip4, &svc3)) // svc2 is out of the picture so svc3 can use the address
 }
 
 func TestAvailable(t *testing.T) {
@@ -286,7 +287,7 @@ func TestAvailable(t *testing.T) {
 	// no assignment, should be available
 	assert.NoError(t, p.available(ip, &svc1))
 
-	p.Assign(ip, &svc1)
+	p.Assign(context.Background(), ip, &svc1)
 
 	// same service can "share" with or without the key
 	assert.NoError(t, p.available(ip, &svc1))
@@ -311,17 +312,17 @@ func TestAssignNext(t *testing.T) {
 	svc3 := service("svc3", ports("tcp/80"), "sharing2")
 
 	// The pool has two addresses; allocate both of them
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	assert.Equal(t, "192.168.1.0", svc1.Status.LoadBalancer.Ingress[0].IP, "svc1 was assigned the wrong address")
-	assert.NoError(t, p.AssignNext(&svc2))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2))
 	assert.Equal(t, "192.168.1.1", svc2.Status.LoadBalancer.Ingress[0].IP, "svc2 was assigned the wrong address")
 
 	// Same port: should fail
-	assert.Error(t, p.AssignNext(&svc3))
+	assert.Error(t, p.AssignNext(context.Background(), &svc3))
 
 	// Shared key, different ports: should succeed
 	svc3.Spec.Ports = ports("tcp/25")
-	assert.NoError(t, p.AssignNext(&svc3))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc3))
 }
 
 func TestPoolSize(t *testing.T) {
@@ -430,15 +431,15 @@ func TestSharingKeyPortConflict(t *testing.T) {
 	svc3 := service("svc3", ports("tcp/80"), "webservers")  // same port, same key - should FAIL
 
 	// svc1 gets first IP
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	assert.Equal(t, "192.168.1.0", svc1.Status.LoadBalancer.Ingress[0].IP)
 
 	// svc2 shares the IP (different port)
-	assert.NoError(t, p.AssignNext(&svc2))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2))
 	assert.Equal(t, "192.168.1.0", svc2.Status.LoadBalancer.Ingress[0].IP)
 
 	// svc3 should FAIL - same sharing key, same port
-	err := p.AssignNext(&svc3)
+	err := p.AssignNext(context.Background(), &svc3)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "port TCP/80")
 	assert.Contains(t, err.Error(), "already in use")
@@ -454,14 +455,14 @@ func TestSharingKeyReleaseCleanup(t *testing.T) {
 	ip := net.ParseIP("192.168.1.0")
 
 	svc1 := service("svc1", ports("tcp/80"), "webservers")
-	assert.NoError(t, p.Assign(ip, &svc1))
+	assert.NoError(t, p.Assign(context.Background(), ip, &svc1))
 
 	// Verify sharing key is tracked
 	assert.NotNil(t, p.ipForSharingKey("webservers", nl.FAMILY_V4))
 	assert.Equal(t, "192.168.1.0", p.ipForSharingKey("webservers", nl.FAMILY_V4).String())
 
 	// Release the service
-	p.Release(namespacedName(&svc1))
+	p.Release(context.Background(), namespacedName(&svc1))
 
 	// Verify sharing key mapping is cleaned up
 	assert.Nil(t, p.ipForSharingKey("webservers", nl.FAMILY_V4))
@@ -476,12 +477,12 @@ func TestSharingKeyBindingPreventsOtherIPs(t *testing.T) {
 	svc2 := service("svc2", ports("tcp/80"), "webservers") // same port, same key
 
 	// svc1 gets first IP, binding "webservers" to 192.168.1.0
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	assert.Equal(t, "192.168.1.0", svc1.Status.LoadBalancer.Ingress[0].IP)
 
 	// svc2 cannot get 192.168.1.1 because "webservers" is bound to .0
 	// and it cannot share .0 because of port conflict
-	err := p.AssignNext(&svc2)
+	err := p.AssignNext(context.Background(), &svc2)
 	assert.Error(t, err)
 
 	// The error should mention the port conflict (from the bound IP),
@@ -497,11 +498,11 @@ func TestDifferentSharingKeysGetDifferentIPs(t *testing.T) {
 	svc1 := service("svc1", ports("tcp/80"), "webservers")
 	svc2 := service("svc2", ports("tcp/80"), "databases") // same port, different key
 
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	assert.Equal(t, "192.168.1.0", svc1.Status.LoadBalancer.Ingress[0].IP)
 
 	// svc2 should get a different IP because it has a different sharing key
-	assert.NoError(t, p.AssignNext(&svc2))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2))
 	assert.Equal(t, "192.168.1.1", svc2.Status.LoadBalancer.Ingress[0].IP)
 }
 
@@ -542,7 +543,7 @@ func TestAssignNextPerRange(t *testing.T) {
 		svc := service("svc1", ports("tcp/80"), "")
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 
-		err := p.AssignNextPerRange(&svc, []string{"192.168.1.0/24", "192.168.2.0/24"})
+		err := p.AssignNextPerRange(context.Background(), &svc, []string{"192.168.1.0/24", "192.168.2.0/24"})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "should get 2 IPs")
 
@@ -566,7 +567,7 @@ func TestAssignNextPerRange(t *testing.T) {
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 
 		// Only subnet 1 is active
-		err := p.AssignNextPerRange(&svc, []string{"192.168.1.0/24"})
+		err := p.AssignNextPerRange(context.Background(), &svc, []string{"192.168.1.0/24"})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress), "should get 1 IP")
 		ip := svc.Status.LoadBalancer.Ingress[0].IP
@@ -582,7 +583,7 @@ func TestAssignNextPerRange(t *testing.T) {
 		svc := service("svc1", ports("tcp/80"), "")
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 
-		err := p.AssignNextPerRange(&svc, []string{})
+		err := p.AssignNextPerRange(context.Background(), &svc, []string{})
 		assert.Error(t, err, "should fail with no active subnets")
 		assert.Equal(t, 0, len(svc.Status.LoadBalancer.Ingress))
 	})
@@ -597,14 +598,14 @@ func TestAssignNextPerRange(t *testing.T) {
 		// Exhaust range 1
 		svc0 := service("svc0", ports("tcp/80"), "")
 		svc0.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		err := p.AssignNextPerRange(&svc0, []string{"192.168.1.0/24", "192.168.2.0/24"})
+		err := p.AssignNextPerRange(context.Background(), &svc0, []string{"192.168.1.0/24", "192.168.2.0/24"})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(svc0.Status.LoadBalancer.Ingress))
 
 		// Now range 1 is exhausted, svc1 should still get an IP from range 2
 		svc1 := service("svc1", ports("tcp/80"), "")
 		svc1.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		err = p.AssignNextPerRange(&svc1, []string{"192.168.1.0/24", "192.168.2.0/24"})
+		err = p.AssignNextPerRange(context.Background(), &svc1, []string{"192.168.1.0/24", "192.168.2.0/24"})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(svc1.Status.LoadBalancer.Ingress), "should get partial allocation")
 		assert.Equal(t, "192.168.2.1", svc1.Status.LoadBalancer.Ingress[0].IP)
@@ -624,7 +625,7 @@ func TestAssignNextPerRange(t *testing.T) {
 		svc := service("svc1", ports("tcp/80"), "")
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
 
-		err := p.AssignNextPerRange(&svc, []string{
+		err := p.AssignNextPerRange(context.Background(), &svc, []string{
 			"192.168.1.0/24", "192.168.2.0/24",
 			"fd00:1::/64", "fd00:2::/64",
 		})
@@ -649,9 +650,9 @@ func TestAssignNextPerRange(t *testing.T) {
 			{IP: "192.168.1.0", IPMode: &ipModeVIP},
 		}
 		// Notify the pool about the existing IP
-		assert.NoError(t, p.Notify(&svc))
+		assert.NoError(t, p.Notify(context.Background(), &svc))
 
-		err := p.AssignNextPerRange(&svc, []string{"192.168.1.0/24", "192.168.2.0/24"})
+		err := p.AssignNextPerRange(context.Background(), &svc, []string{"192.168.1.0/24", "192.168.2.0/24"})
 		assert.NoError(t, err)
 		// Should get 2 total: the existing one + 1 new from range 2
 		assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "should have 2 IPs total")
@@ -686,7 +687,7 @@ func TestBalancePoolsBasic(t *testing.T) {
 	for i := range svcs {
 		svcs[i] = service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svcs[i].Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		assert.NoError(t, p.AssignNext(&svcs[i]))
+		assert.NoError(t, p.AssignNext(context.Background(), &svcs[i]))
 		assert.Equal(t, 1, len(svcs[i].Status.LoadBalancer.Ingress))
 	}
 
@@ -720,13 +721,13 @@ func TestBalancePoolsExhaustion(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		svc := service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		assert.NoError(t, p.AssignNext(&svc), "allocation %d should succeed", i)
+		assert.NoError(t, p.AssignNext(context.Background(), &svc), "allocation %d should succeed", i)
 	}
 
 	// 7th should fail — all exhausted
 	svc := service("svc-overflow", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	assert.Error(t, p.AssignNext(&svc), "should fail when all ranges exhausted")
+	assert.Error(t, p.AssignNext(context.Background(), &svc), "should fail when all ranges exhausted")
 }
 
 func TestBalancePoolsIPv6(t *testing.T) {
@@ -741,7 +742,7 @@ func TestBalancePoolsIPv6(t *testing.T) {
 	for i := range svcs {
 		svcs[i] = service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svcs[i].Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
-		assert.NoError(t, p.AssignNext(&svcs[i]))
+		assert.NoError(t, p.AssignNext(context.Background(), &svcs[i]))
 	}
 
 	// Count per range
@@ -777,7 +778,7 @@ func TestBalancePoolsDualStack(t *testing.T) {
 	for i := range svcs {
 		svcs[i] = service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svcs[i].Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
-		assert.NoError(t, p.AssignNext(&svcs[i]))
+		assert.NoError(t, p.AssignNext(context.Background(), &svcs[i]))
 		assert.Equal(t, 2, len(svcs[i].Status.LoadBalancer.Ingress), "should get 1 v4 + 1 v6")
 	}
 
@@ -824,7 +825,7 @@ func TestBalancePoolsDisabled(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		svc := service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		assert.NoError(t, p.AssignNext(&svc))
+		assert.NoError(t, p.AssignNext(context.Background(), &svc))
 		ip := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 		_, sub0, _ := net.ParseCIDR("10.0.0.0/24")
 		assert.True(t, sub0.Contains(ip), "sequential should exhaust range 0 first, got %s", ip)
@@ -844,7 +845,7 @@ func TestBalancePoolsAfterRelease(t *testing.T) {
 	for i := range svcs {
 		svcs[i] = service(fmt.Sprintf("svc%d", i), ports("tcp/80"), "")
 		svcs[i].Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-		assert.NoError(t, p.AssignNext(&svcs[i]))
+		assert.NoError(t, p.AssignNext(context.Background(), &svcs[i]))
 	}
 
 	// Release 2 services from range 0 (svc0 and svc2 should be from range 0 due to alternation)
@@ -854,7 +855,7 @@ func TestBalancePoolsAfterRelease(t *testing.T) {
 	for i, svc := range svcs {
 		ip := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 		if sub0.Contains(ip) && released < 2 {
-			assert.NoError(t, p.Release(namespacedName(&svcs[i])))
+			assert.NoError(t, p.Release(context.Background(), namespacedName(&svcs[i])))
 			released++
 		}
 	}
@@ -862,7 +863,7 @@ func TestBalancePoolsAfterRelease(t *testing.T) {
 	// Next allocation should go to range 0 (now has fewer allocations)
 	newSvc := service("svc-new", ports("tcp/80"), "")
 	newSvc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	assert.NoError(t, p.AssignNext(&newSvc))
+	assert.NoError(t, p.AssignNext(context.Background(), &newSvc))
 	newIP := net.ParseIP(newSvc.Status.LoadBalancer.Ingress[0].IP)
 	assert.True(t, sub0.Contains(newIP), "after release, should rebalance to range 0, got %s", newIP)
 }
@@ -878,7 +879,7 @@ func TestBalancePoolsWithSharingKeyBypass(t *testing.T) {
 	// First, allocate a service with sharing key to range 0 (sequential path)
 	svc1 := service("svc1", ports("tcp/80"), "share-key")
 	svc1.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	assert.NoError(t, p.AssignNext(&svc1))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc1))
 	ip1 := net.ParseIP(svc1.Status.LoadBalancer.Ingress[0].IP)
 	_, sub0, _ := net.ParseCIDR("10.0.0.0/24")
 
@@ -888,7 +889,7 @@ func TestBalancePoolsWithSharingKeyBypass(t *testing.T) {
 	// Second service with same sharing key must get same IP (sharing key binding)
 	svc2 := service("svc2", ports("tcp/443"), "share-key")
 	svc2.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	assert.NoError(t, p.AssignNext(&svc2))
+	assert.NoError(t, p.AssignNext(context.Background(), &svc2))
 	ip2 := net.ParseIP(svc2.Status.LoadBalancer.Ingress[0].IP)
 	assert.True(t, ip1.Equal(ip2), "sharing key services must share the same IP")
 }

--- a/internal/allocator/netboxpool.go
+++ b/internal/allocator/netboxpool.go
@@ -16,6 +16,7 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -76,7 +77,7 @@ func NewNetboxPool(name string, log log.Logger, spec purelbv2.ServiceGroupNetbox
 	}, nil
 }
 
-func (p NetboxPool) Notify(service *v1.Service) error {
+func (p NetboxPool) Notify(_ context.Context, service *v1.Service) error {
 	nsName := namespacedName(service)
 
 	for _, ingress := range service.Status.LoadBalancer.Ingress {
@@ -97,7 +98,7 @@ func (p NetboxPool) Notify(service *v1.Service) error {
 }
 
 // AssignNext assigns a service to the next available IP.
-func (p NetboxPool) AssignNext(service *v1.Service) error {
+func (p NetboxPool) AssignNext(ctx context.Context, service *v1.Service) error {
 	// fetch from netbox
 	cidr, err := p.netbox.Fetch()
 	if err != nil {
@@ -107,7 +108,7 @@ func (p NetboxPool) AssignNext(service *v1.Service) error {
 	if err != nil {
 		return fmt.Errorf("error parsing CIDR %s", cidr)
 	}
-	if err := p.Assign(ip, service); err != nil {
+	if err := p.Assign(ctx, ip, service); err != nil {
 		return err
 	}
 
@@ -115,16 +116,16 @@ func (p NetboxPool) AssignNext(service *v1.Service) error {
 }
 
 // Assign assigns a service to an IP.
-func (p NetboxPool) Assign(ip net.IP, service *v1.Service) error {
+func (p NetboxPool) Assign(ctx context.Context, ip net.IP, service *v1.Service) error {
 	// we have an IP selected somehow, so program the data plane
 	addIngress(p.logger, service, ip)
 
 	// Update our internal allocation data structures
-	return p.Notify(service)
+	return p.Notify(ctx, service)
 }
 
 // Release releases an IP so it can be assigned again.
-func (p NetboxPool) Release(service string) error {
+func (p NetboxPool) Release(_ context.Context, service string) error {
 	ip, haveIp := p.services[service]
 	if !haveIp {
 		return fmt.Errorf("trying to release an IP from unknown service %s", service)
@@ -140,7 +141,7 @@ func (p NetboxPool) Release(service string) error {
 
 // ReleaseIP releases a specific IP address for a service. Used during
 // IP family transitions (e.g., DualStack → SingleStack).
-func (p NetboxPool) ReleaseIP(service string, ip net.IP) error {
+func (p NetboxPool) ReleaseIP(_ context.Context, service string, ip net.IP) error {
 	ipstr := ip.String()
 
 	// Check if this IP is tracked in our pool
@@ -233,6 +234,58 @@ func (p NetboxPool) BalancePools() bool {
 }
 
 // AssignNextPerRange is not supported for Netbox pools.
-func (p NetboxPool) AssignNextPerRange(svc *v1.Service, activeSubnets []string) error {
+func (p NetboxPool) AssignNextPerRange(_ context.Context, svc *v1.Service, activeSubnets []string) error {
 	return fmt.Errorf("multi-pool allocation is not supported for Netbox pools")
 }
+
+// IPAMSource returns "Netbox" — addresses come from an external Netbox
+// IPAM system.
+func (p NetboxPool) IPAMSource() string {
+	return "Netbox"
+}
+
+// InUseV4 returns the number of IPv4 addresses currently allocated.
+func (p NetboxPool) InUseV4() int {
+	n := 0
+	for ipStr := range p.addressesInUse {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// InUseV6 returns the number of IPv6 addresses currently allocated.
+func (p NetboxPool) InUseV6() int {
+	n := 0
+	for ipStr := range p.addressesInUse {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// SizeV4 returns 0 — Netbox pool capacity is managed externally and not
+// knowable locally without an additional Netbox API call.
+func (p NetboxPool) SizeV4() uint64 { return 0 }
+
+// SizeV6 returns 0 — see SizeV4.
+func (p NetboxPool) SizeV6() uint64 { return 0 }
+
+// HasKnownCapacity returns false — Netbox owns the address space and
+// PureLB doesn't track total capacity.
+func (p NetboxPool) HasKnownCapacity() bool { return false }
+
+// DisplayAddresses returns nil — Netbox is deprecated (will be removed
+// in Part B of this PR series) and we don't invest in pretty status
+// formatting for unsupported code.
+func (p NetboxPool) DisplayAddresses() []string { return nil }

--- a/internal/allocator/netboxpool_test.go
+++ b/internal/allocator/netboxpool_test.go
@@ -13,6 +13,7 @@
 package allocator
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -37,13 +38,13 @@ func TestNetboxContains(t *testing.T) {
 	}
 	nbp.netbox = fake.NewNetbox("base", "tenant", "token") // patch the pool with a fake Netbox client
 
-	err = nbp.AssignNext(&svc1)
+	err = nbp.AssignNext(context.Background(), &svc1)
 	assert.Nil(t, err, "Netbox pool AssignNext() failed")
 
 	assigned := net.ParseIP(svc1.Status.LoadBalancer.Ingress[0].IP)
 	assert.NotNil(t, assigned, "service was assigned an unparseable IP")
 	assert.True(t, nbp.Contains(assigned), "address should have been contained in pool but wasn't")
 
-	nbp.Release(nsName)
+	nbp.Release(context.Background(), nsName)
 	assert.False(t, nbp.Contains(assigned), "address should not have been contained in pool but was")
 }

--- a/internal/allocator/pool.go
+++ b/internal/allocator/pool.go
@@ -16,6 +16,7 @@
 package allocator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -42,17 +43,20 @@ type Key struct {
 }
 
 // Pool describes the interface to code that manages pools of
-// addresses.
+// addresses. Mutating methods take a context so that pool
+// implementations backed by network I/O (e.g. external IPAM sidecars)
+// can honor the allocator's shutdown semantics; in-memory
+// implementations may safely ignore it.
 type Pool interface {
 	// Notify notifies the pool of an existing address assignment, for
 	// example, at startup time.
-	Notify(*v1.Service) error
-	AssignNext(*v1.Service) error
-	Assign(net.IP, *v1.Service) error
-	Release(string) error
+	Notify(ctx context.Context, svc *v1.Service) error
+	AssignNext(ctx context.Context, svc *v1.Service) error
+	Assign(ctx context.Context, ip net.IP, svc *v1.Service) error
+	Release(ctx context.Context, service string) error
 	// ReleaseIP releases a specific IP address for a service. Used during
 	// IP family transitions (e.g., DualStack → SingleStack).
-	ReleaseIP(service string, ip net.IP) error
+	ReleaseIP(ctx context.Context, service string, ip net.IP) error
 	InUse() int
 	Overlaps(Pool) bool
 	Contains(net.IP) bool // FIXME: I'm not sure that we need this. It might be the case that we can always rely on the service's pool annotation to find to which pool an address belongs
@@ -64,6 +68,12 @@ type Pool interface {
 	// or "remote" for addresses that should be announced on the dummy interface
 	// (different subnet, typically for BGP/routing scenarios or external IPAM).
 	PoolType() string
+
+	// IPAMSource identifies the source of address management. Returns
+	// "Cluster" when PureLB's allocator is authoritative for the address
+	// space, or the name of an external IPAM system (e.g. a sidecar
+	// plugin's provider name) when allocation is delegated.
+	IPAMSource() string
 
 	// SkipIPv6DAD returns whether IPv6 Duplicate Address Detection should
 	// be skipped for addresses from this pool. This can speed up address
@@ -82,7 +92,36 @@ type Pool interface {
 	// AssignNextPerRange allocates one IP per address range (per family)
 	// that has an active subnet. activeSubnets is the set of subnets with
 	// healthy lbnodeagents. Returns error only if NO IPs could be allocated.
-	AssignNextPerRange(svc *v1.Service, activeSubnets []string) error
+	AssignNextPerRange(ctx context.Context, svc *v1.Service, activeSubnets []string) error
+
+	// InUseV4 returns the number of IPv4 addresses currently allocated.
+	// Must be a pure in-memory read; implementations that wrap remote
+	// state (e.g. sidecar IPAM) MUST cache and never fire RPCs from this
+	// accessor.
+	InUseV4() int
+
+	// InUseV6 returns the number of IPv6 addresses currently allocated.
+	// Same purity contract as InUseV4.
+	InUseV6() int
+
+	// SizeV4 returns the IPv4 capacity of the pool. May return 0 when
+	// capacity is not knowable locally (use HasKnownCapacity to
+	// disambiguate "0 capacity" from "unknown").
+	SizeV4() uint64
+
+	// SizeV6 returns the IPv6 capacity of the pool. Same semantics as SizeV4.
+	SizeV6() uint64
+
+	// HasKnownCapacity reports whether SizeV4/SizeV6 reflect true capacity.
+	// False for pools backed by external systems whose total size is not
+	// visible to the allocator (e.g. sidecar IPAM without a Stats reply).
+	HasKnownCapacity() bool
+
+	// DisplayAddresses returns a human-readable summary of the pool's
+	// address scope, surfaced as .status.addresses. Pool implementations
+	// choose their own format (CIDR list for local pools; external-system
+	// descriptor for sidecar-IPAM pools).
+	DisplayAddresses() []string
 }
 
 func sharingOK(existing, new *Key) error {

--- a/internal/allocator/stats.go
+++ b/internal/allocator/stats.go
@@ -66,6 +66,18 @@ var (
 		Name:      "balance_pools_allocations_total",
 		Help:      "Total balancePools allocations performed",
 	}, labelNames)
+
+	// sgStatusWritesTotal tracks ServiceGroup .status subresource write
+	// outcomes. Defends against the v0.16.4-class silent-RBAC-failure
+	// pattern: if servicegroups/status RBAC isn't granted, the
+	// "forbidden" series will tick non-zero and operators can alert on
+	// it via `rate(sg_status_writes_total{outcome!="success"}[5m]) > 0`.
+	sgStatusWritesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: purelbv2.MetricsNamespace,
+		Subsystem: "allocator",
+		Name:      "sg_status_writes_total",
+		Help:      "ServiceGroup status subresource write outcomes (success|conflict|forbidden|other).",
+	}, []string{"outcome"})
 )
 
 func init() {
@@ -75,4 +87,5 @@ func init() {
 	prometheus.MustRegister(multipoolAllocations)
 	prometheus.MustRegister(multipoolPartial)
 	prometheus.MustRegister(balancePoolsAllocations)
+	prometheus.MustRegister(sgStatusWritesTotal)
 }

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -110,6 +110,17 @@ func NewCRController(
 			controller.enqueueResource("sg", added)
 		},
 		UpdateFunc: func(old, new interface{}) {
+			// Skip status-only updates. The allocator itself writes SG
+			// .status via the status subresource (Part A display work);
+			// those writes don't bump .metadata.generation, but the watch
+			// event still fires. Without this filter, every status write
+			// triggers a full SetConfig → SetPools → forceSync cycle over
+			// all services. O(N) per status write, catastrophic at scale.
+			oldSG, _ := old.(*purelbv2.ServiceGroup)
+			newSG, _ := new.(*purelbv2.ServiceGroup)
+			if oldSG != nil && newSG != nil && oldSG.Generation == newSG.Generation {
+				return
+			}
 			controller.enqueueResource("sg", new)
 		},
 		DeleteFunc: func(deleted interface{}) {

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -55,9 +55,10 @@ const serviceNameIndexName = "serviceName"
 type Client struct {
 	logger log.Logger
 
-	client *kubernetes.Clientset
-	events record.EventRecorder
-	queue  workqueue.TypedRateLimitingInterface[queueItem]
+	client   *kubernetes.Clientset
+	crClient versioned.Interface
+	events   record.EventRecorder
+	queue    workqueue.TypedRateLimitingInterface[queueItem]
 
 	// shuttingDown is set to true when stopCh closes, signaling that
 	// API calls should use shorter timeouts to allow graceful shutdown.
@@ -85,6 +86,65 @@ type ServiceEvent interface {
 	Infof(obj runtime.Object, desc, msg string, args ...interface{})
 	Errorf(obj runtime.Object, desc, msg string, args ...interface{})
 	ForceSync()
+}
+
+// ServiceGroupStatusWriter is the surface the allocator needs from
+// *Client to write ServiceGroup .status: the write itself, a
+// timeout-bounded cancellable context, and a way to classify shutdown
+// errors as expected (silent). Kept narrow and separate from
+// ServiceEvent — different semantic concern (CRD status writes vs
+// k8s Event emission). *Client satisfies both interfaces.
+//
+// APIContext lives here, not just as a renamed public method on
+// *Client, because the allocator only holds the narrow ServiceEvent
+// interface today and has no path to *Client.apiContext(). Putting
+// APIContext on the new interface lets the allocator construct
+// cancellable contexts without needing a *Client reference.
+type ServiceGroupStatusWriter interface {
+	// UpdateServiceGroupStatus writes sg.Status via the status subresource.
+	// Returns the updated ServiceGroup (with bumped ResourceVersion) on
+	// success — callers should use this to refresh their cached SG so
+	// subsequent UpdateStatus calls don't hit "object has been modified"
+	// conflicts. nil + error on failure.
+	UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error)
+	APIContext() (context.Context, context.CancelFunc)
+	IsShutdownError(err error) bool
+}
+
+// APIContext is the public wrapper over the unexported apiContext.
+// Returns a context.Context with the standard PureLB API timeout
+// (10s normally, 500ms during shutdown). Callers MUST invoke the
+// returned CancelFunc.
+func (c *Client) APIContext() (context.Context, context.CancelFunc) {
+	return c.apiContext()
+}
+
+// IsShutdownError is the public wrapper over isShutdownError.
+// Returns true when err is a context.DeadlineExceeded or
+// context.Canceled originating from the shutdown-mode short timeout.
+func (c *Client) IsShutdownError(err error) bool {
+	return c.isShutdownError(err)
+}
+
+// UpdateServiceGroupStatus writes sg's .status subresource. Mirrors
+// maybeUpdateService's pattern: uses apiContext() for timeout-bounded
+// cancellable I/O; sets FieldManager so SSA users see PureLB's owner
+// identity correctly; classifies shutdown errors as benign.
+func (c *Client) UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error) {
+	ctx, cancel := c.apiContext()
+	defer cancel()
+	updated, err := c.crClient.PurelbV2().ServiceGroups(sg.Namespace).UpdateStatus(ctx, sg, metav1.UpdateOptions{
+		FieldManager: "purelb-allocator",
+	})
+	if err != nil {
+		if c.isShutdownError(err) {
+			c.logger.Log("op", "updateSGStatus", "msg", "skipping update during shutdown")
+			return nil, nil
+		}
+		// Caller is responsible for logging + classifying for metrics.
+		return nil, err
+	}
+	return updated, nil
 }
 
 // SyncState is the result of calling synchronization callbacks.
@@ -162,10 +222,11 @@ func New(cfg *Config) (*Client, error) {
 	queue := workqueue.NewTypedRateLimitingQueue[queueItem](workqueue.DefaultTypedControllerRateLimiter[queueItem]())
 
 	c := &Client{
-		logger: cfg.Logger,
-		client: clientset,
-		events: recorder,
-		queue:  queue,
+		logger:   cfg.Logger,
+		client:   clientset,
+		crClient: crClient,
+		events:   recorder,
+		queue:    queue,
 	}
 
 	// Custom Resource Watcher

--- a/pkg/apis/purelb/v2/iprange.go
+++ b/pkg/apis/purelb/v2/iprange.go
@@ -30,6 +30,11 @@ import (
 type IPRange struct {
 	from net.IP
 	to   net.IP
+	// raw is the original spec string (CIDR like "192.168.1.0/24" or
+	// from-to like "192.168.1.0 - 192.168.1.255"). Preserved so kubectl
+	// status display can echo the user's input rather than the parsed
+	// "(from - to)" form.
+	raw string
 }
 
 // NewIPRange parses a string representation of an IP address range
@@ -39,13 +44,30 @@ type IPRange struct {
 // 192.168.1.255". The error return value will be non-nil if the
 // representation couldn't be parsed.
 func NewIPRange(raw string) (IPRange, error) {
+	var (
+		iprange IPRange
+		err     error
+	)
 	if strings.Contains(raw, "-") {
 		// "from-to" notation
-		return parseFromTo(raw)
+		iprange, err = parseFromTo(raw)
+	} else {
+		// CIDR notation
+		iprange, err = parseCIDR(raw)
 	}
+	if err != nil {
+		return iprange, err
+	}
+	iprange.raw = raw
+	return iprange, nil
+}
 
-	// CIDR notation
-	return parseCIDR(raw)
+// Raw returns the original spec string this IPRange was parsed from
+// (e.g., "192.168.1.0/24" or "192.168.1.0-192.168.1.255"). Used by
+// status display to show the user's input verbatim rather than the
+// parsed "(from - to)" form.
+func (r IPRange) Raw() string {
+	return r.raw
 }
 
 var IPRangeComparer = cmp.Comparer(func(x, y IPRange) bool {

--- a/pkg/apis/purelb/v2/types.go
+++ b/pkg/apis/purelb/v2/types.go
@@ -33,6 +33,15 @@ import (
 // group spec and status.
 // +kubebuilder:resource:shortName=sg;sgs
 // +kubebuilder:storageversion
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Announce",type=string,JSONPath=`.status.announce`
+// +kubebuilder:printcolumn:name="IPAM",type=string,JSONPath=`.status.ipam`
+// +kubebuilder:printcolumn:name="Addresses",type=string,JSONPath=`.status.addresses`
+// +kubebuilder:printcolumn:name="Allocated-V4",type=integer,JSONPath=`.status.allocatedIPv4`,priority=1
+// +kubebuilder:printcolumn:name="Allocated-V6",type=integer,JSONPath=`.status.allocatedIPv6`,priority=1
+// +kubebuilder:printcolumn:name="Available-V4",type=integer,JSONPath=`.status.availableIPv4`,priority=1
+// +kubebuilder:printcolumn:name="Available-V6",type=integer,JSONPath=`.status.availableIPv6`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type ServiceGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -260,11 +269,52 @@ type AddressPool struct {
 	Aggregation string `json:"aggregation,omitempty"`
 }
 
-// ServiceGroupStatus contains runtime information about the ServiceGroup.
+// ServiceGroupStatus reports runtime information about the ServiceGroup,
+// populated by the allocator as services are assigned and released.
+// Values may briefly lag the spec after a config change.
 type ServiceGroupStatus struct {
-	// AllocatedCount is the number of IP addresses currently allocated from this pool.
+	// Announce is the announcement mechanism: "Local" (IP added to the
+	// node's primary interface, for directly-attached subnets) or
+	// "Remote" (IP added to the kubelb0 dummy interface and advertised
+	// via BGP for non-local subnets). Derived from Pool.PoolType().
 	// +optional
-	AllocatedCount int `json:"allocatedCount,omitempty"`
+	Announce string `json:"announce,omitempty"`
+
+	// IPAM identifies the address-management source: "Cluster" when
+	// PureLB's allocator is authoritative for the address space, or the
+	// name of an external IPAM system (e.g. a sidecar plugin's provider
+	// name) when allocation is delegated. Derived from Pool.IPAMSource().
+	// +optional
+	IPAM string `json:"ipam,omitempty"`
+
+	// Addresses is a human-readable summary of the pool's address scope,
+	// produced by the Pool implementation. For cluster-IPAM pools this
+	// is the configured CIDRs and ranges; for external-IPAM pools it is
+	// whatever descriptor the source chooses (may be empty when the
+	// source does not expose address scope locally).
+	// +optional
+	Addresses []string `json:"addresses,omitempty"`
+
+	// AllocatedIPv4 is the number of IPv4 addresses currently assigned.
+	// +kubebuilder:validation:Minimum=0
+	AllocatedIPv4 int64 `json:"allocatedIPv4"`
+
+	// AllocatedIPv6 is the number of IPv6 addresses currently assigned.
+	// +kubebuilder:validation:Minimum=0
+	AllocatedIPv6 int64 `json:"allocatedIPv6"`
+
+	// AvailableIPv4 is the number of free IPv4 addresses. Absent when
+	// pool capacity is not knowable locally (external IPAM).
+	// Distinct from the value 0, which means the pool is full.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	AvailableIPv4 *int64 `json:"availableIPv4,omitempty"`
+
+	// AvailableIPv6 is the number of free IPv6 addresses. Absent when
+	// pool capacity is not knowable locally (external IPAM).
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	AvailableIPv6 *int64 `json:"availableIPv6,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Summary

Closes Issue #60 (display piece). Adds a populated `.status` subresource on `ServiceGroup` so users running stock `kubectl` (without the `kubectl-purelb` plugin) get meaningful output from `kubectl get sg` and `kubectl describe sg`.

**Part A of the v0.17.0 series.** Part B (Netbox removal) and Part C (sidecar IPAM API) follow.

## What ships

**Display**:
- `kubectl get sg` default columns: NAME, ANNOUNCE, IPAM, ADDRESSES, AGE
- `kubectl get sg -o wide` adds: ALLOCATED-V4, ALLOCATED-V6, AVAILABLE-V4, AVAILABLE-V6
- `kubectl describe sg` shows a populated Status block

**Schema (`ServiceGroupStatus`)**:
- `Announce` — "Local" or "Remote" (announcement mechanism)
- `IPAM` — "Cluster" or external IPAM provider name
- `Addresses` — human-readable spec strings (CIDRs / from-to ranges)
- `AllocatedIPv4` / `AllocatedIPv6` — per-family in-use count
- `AvailableIPv4` / `AvailableIPv6` — per-family free count (`*int64` + omitempty; nil = unknown, distinct from 0 = full)

**Pool interface** (additive-breaking; no in-tree mocks exist per `grep var _ Pool`):
- 7 new read-only accessors: `IPAMSource`, `InUseV4/V6`, `SizeV4/V6`, `HasKnownCapacity`, `DisplayAddresses`
- `context.Context` added to 6 mutating methods (Notify, Assign, AssignNext, AssignNextPerRange, Release, ReleaseIP) — required so future Pool implementations backed by network I/O (sidecar IPAM in Part C) can honor allocator shutdown semantics
- `Contains()` keeps its no-context signature; FIXME removal deferred

**IPRange.raw** preserves the user's original spec string so `DisplayAddresses` echoes what they wrote, not the parsed `(from - to)` form.

**Sync writer with cache** (`maybeUpdateSGStatus`):
- Synchronous from `updateStats`; `lastWritten sync.Map` elides API writes when status is unchanged
- ResourceVersion propagated back into `sgByName` after successful write (prevents conflict loop)
- Errors logged + counted, never block allocation

**Generation-aware UpdateFunc filter** on `cr-controller.go` prevents the allocator's own status writes from triggering full reconcile cycles (O(N²) reconcile storms otherwise).

**RBAC**: `servicegroups/status` verb added to allocator ClusterRole in BOTH `deployments/default/purelb.yaml` AND `build/helm/purelb/templates/clusterrole-allocator.yaml` — same drift class that bit v0.16.5 for k8gobgp.

**Observability**: `purelb_allocator_sg_status_writes_total{outcome="success|conflict|forbidden|other"}` counter. Defends against v0.16.4-class silent-RBAC-failure pattern.

## Test plan
- [x] `make check` passes with `-race` + `check-deps` + `check-helm-rbac-source`
- [x] 22 new test cases (TestBuildStatus, TestStatusEqual, TestInt64PtrEqual, TestClassifyStatusErr, TestCapitalize, TestMaybeUpdateSGStatus_* x4) all PASS
- [x] All 58 existing localpool_test ctx-threading sites updated via sed; no behavior regressions
- [x] Smoke-tested end-to-end on helm-test cluster:
  - ServiceGroup applied → `get sg` shows Announce=Local, IPAM=Cluster, Addresses=[range]
  - LoadBalancer Service created → got VIP `172.30.255.210`, data plane attached
  - SG status updated: ALLOCATED-V4=1, AVAILABLE-V4=10 (decremented from 11)
  - Zero conflict/forbidden errors in allocator log
  - `can-i update servicegroups/status` returns `yes` (RBAC working)