### PR TITLE
feat(election): opt-in app-affinity for Local pool VIPs (v0.17.0)

### DIFF
--- a/internal/election/election.go
+++ b/internal/election/election.go
@@ -371,6 +371,71 @@ func (e *Election) Winner(key string) string {
 	return winner
 }
 
+// WinnerWithPreference is like Winner but biases the election toward
+// candidates in the preferred set. If any preferred candidate is also a
+// valid election candidate (has the IP's subnet + healthy lease), the
+// election runs ONLY among those preferred candidates. Otherwise — or
+// when preferred is empty/nil — election runs over all candidates as
+// usual, and RecordAffinityFallback is invoked so operators can alert
+// on degraded affinity.
+//
+// Pass nil (or an empty slice) for preferred to behave identically to
+// Winner; no fallback is recorded in that case (it's opt-out, not a
+// degraded state).
+func (e *Election) WinnerWithPreference(key string, preferred []string) string {
+	// Same self-health + informer-sync + parse-IP preamble as Winner.
+	if !e.leaseHealthy.Load() {
+		return ""
+	}
+	if e.leaseInformer != nil && !e.leaseInformer.HasSynced() {
+		return ""
+	}
+	state := e.state.Load()
+	if state == nil || len(state.liveNodes) == 0 {
+		return ""
+	}
+	ip := net.ParseIP(key)
+	if ip == nil {
+		// Non-IP keys: behave like Winner — full live-nodes set, no
+		// affinity biasing (the subnet-based filtering doesn't apply).
+		candidates := make([]string, len(state.liveNodes))
+		copy(candidates, state.liveNodes)
+		return election(key, candidates)[0]
+	}
+
+	candidates := e.findCandidatesForIP(state, ip)
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	// Bias toward preferred candidates when set.
+	if len(preferred) > 0 {
+		prefSet := make(map[string]struct{}, len(preferred))
+		for _, n := range preferred {
+			prefSet[n] = struct{}{}
+		}
+		var prefCandidates []string
+		for _, c := range candidates {
+			if _, ok := prefSet[c]; ok {
+				prefCandidates = append(prefCandidates, c)
+			}
+		}
+		if len(prefCandidates) > 0 {
+			winner := election(key, prefCandidates)[0]
+			logging.Debug(e.config.Logger, "op", "election", "action", "winnerWithPreference",
+				"key", key, "preferred", len(preferred), "preferredCandidates", len(prefCandidates), "winner", winner)
+			return winner
+		}
+		// Preferred is non-empty but none intersect with candidates —
+		// silent fallback to standard election; tracked for observability.
+		RecordAffinityFallback(key)
+		logging.Debug(e.config.Logger, "op", "election", "action", "winnerWithPreference",
+			"key", key, "result", "fallback", "reason", "no preferred candidate eligible")
+	}
+
+	return election(key, candidates)[0]
+}
+
 // findCandidatesForIP returns all nodes that have a subnet containing the given IP.
 // The returned slice is deduplicated and sorted for deterministic results.
 func (e *Election) findCandidatesForIP(state *electionState, ip net.IP) []string {

--- a/internal/election/election_test.go
+++ b/internal/election/election_test.go
@@ -1209,3 +1209,109 @@ func TestOnLeaseUpdateNoChangeNoCallback(t *testing.T) {
 	// OnMemberChange should NOT have been called
 	assert.Equal(t, 0, memberChangeCount, "OnMemberChange should not fire when membership is unchanged")
 }
+
+// =================================================================
+// v0.17.0: opt-in app-affinity election (WinnerWithPreference)
+// =================================================================
+
+// TestWinnerWithPreference covers the affinity election method. Uses
+// IP-shaped keys so findCandidatesForIP can subnet-match — election's
+// non-IP-key code path is exercised separately at line 348.
+func TestWinnerWithPreference(t *testing.T) {
+	const ip = "192.168.1.100"
+
+	setup := func(t *testing.T, liveNodes []string, subnet string, subnetNodes []string) *Election {
+		t.Helper()
+		client := fake.NewSimpleClientset()
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+
+		e, err := New(Config{
+			Namespace: "purelb",
+			NodeName:  "test-node",
+			Client:    client,
+			StopCh:    stopCh,
+		})
+		require.NoError(t, err)
+		e.leaseHealthy.Store(true)
+		e.state.Store(&electionState{
+			liveNodes:     liveNodes,
+			subnetToNodes: map[string][]string{subnet: subnetNodes},
+			nodeToSubnets: make(map[string][]string),
+		})
+		return e
+	}
+
+	t.Run("preferred=nil → behaves like Winner (no fallback metric)", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		winnerStd := e.Winner(ip)
+		winnerPref := e.WinnerWithPreference(ip, nil)
+		assert.Equal(t, winnerStd, winnerPref, "nil preferred should match Winner exactly")
+	})
+
+	t.Run("preferred=[] → behaves like Winner (no fallback metric)", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		winnerStd := e.Winner(ip)
+		winnerPref := e.WinnerWithPreference(ip, []string{})
+		assert.Equal(t, winnerStd, winnerPref, "empty preferred should match Winner exactly")
+	})
+
+	t.Run("preferred all in candidates → winner ∈ preferred", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		winner := e.WinnerWithPreference(ip, []string{"a", "b"})
+		assert.Contains(t, []string{"a", "b"}, winner, "winner must be in preferred set")
+	})
+
+	t.Run("preferred determinism: same inputs → same winner", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		w1 := e.WinnerWithPreference(ip, []string{"a", "b"})
+		w2 := e.WinnerWithPreference(ip, []string{"a", "b"})
+		assert.Equal(t, w1, w2, "deterministic for identical inputs")
+	})
+
+	t.Run("preferred subset of one → winner is that one", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		winner := e.WinnerWithPreference(ip, []string{"a"})
+		assert.Equal(t, "a", winner)
+	})
+
+	t.Run("preferred contains node not in liveNodes → silently skipped", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		// "z" doesn't exist; "a" does. Winner must be "a".
+		winner := e.WinnerWithPreference(ip, []string{"z", "a"})
+		assert.Equal(t, "a", winner)
+	})
+
+	t.Run("preferred non-empty but NONE intersect candidates → fallback", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		winnerStd := e.Winner(ip)
+		// "z" and "y" aren't in candidates → fallback to standard election.
+		winner := e.WinnerWithPreference(ip, []string{"z", "y"})
+		assert.Equal(t, winnerStd, winner, "fallback should match Winner's pick")
+	})
+
+	t.Run("IPv6 key works same as IPv4", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "2001:db8::/120", []string{"a", "b", "c"})
+		const ipv6 = "2001:db8::5"
+		winnerStd := e.Winner(ipv6)
+		winnerPref := e.WinnerWithPreference(ipv6, nil)
+		assert.Equal(t, winnerStd, winnerPref, "IPv6 nil preferred should match Winner")
+
+		preferredWinner := e.WinnerWithPreference(ipv6, []string{"a"})
+		assert.Equal(t, "a", preferredWinner, "IPv6 single-preferred picks it")
+	})
+
+	t.Run("lease unhealthy → returns empty regardless of preferred", func(t *testing.T) {
+		e := setup(t, []string{"a", "b", "c"}, "192.168.1.0/24", []string{"a", "b", "c"})
+		e.leaseHealthy.Store(false)
+		assert.Equal(t, "", e.WinnerWithPreference(ip, []string{"a"}),
+			"unhealthy lease must return '' (matches Winner contract)")
+	})
+
+	t.Run("no candidates (no node has matching subnet) → returns empty", func(t *testing.T) {
+		// Live nodes exist but none have a subnet matching the IP.
+		e := setup(t, []string{"a"}, "10.0.0.0/24", []string{"a"})
+		assert.Equal(t, "", e.WinnerWithPreference(ip, []string{"a"}),
+			"no subnet match → empty (matches Winner contract)")
+	})
+}

--- a/internal/election/metrics.go
+++ b/internal/election/metrics.go
@@ -80,6 +80,19 @@ var (
 		Name:      "local_subnet_count",
 		Help:      "Number of subnets on this node",
 	})
+
+	// affinityFallbacks counts cases where a service had its
+	// NodeAffinityAnnotation set but no preferred candidate was
+	// eligible for the election (subnet mismatch, lease loss, etc.),
+	// triggering silent fallback to standard hash election. Sustained
+	// non-zero rate indicates a misconfiguration (pods on subnet-less
+	// nodes, all preferred nodes down, etc.).
+	affinityFallbacks = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: purelbv2.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "affinity_fallback_total",
+		Help:      "Times an opted-in service had no preferred candidate eligible and fell back to standard hash election.",
+	}, []string{"service"})
 )
 
 func init() {
@@ -90,6 +103,7 @@ func init() {
 	prometheus.MustRegister(memberCount)
 	prometheus.MustRegister(subnetCount)
 	prometheus.MustRegister(localSubnetCount)
+	prometheus.MustRegister(affinityFallbacks)
 }
 
 // RecordLeaseHealthy sets the lease health metric.
@@ -129,4 +143,13 @@ func RecordSubnetCount(count int) {
 // RecordLocalSubnetCount sets the local subnet count.
 func RecordLocalSubnetCount(count int) {
 	localSubnetCount.Set(float64(count))
+}
+
+// RecordAffinityFallback increments the per-service affinity-fallback
+// counter. Called by WinnerWithPreference when an opt-in service has
+// no preferred candidate eligible (subnet mismatch, lease loss, etc.).
+// service is the election key (typically the IP address string passed
+// to WinnerWithPreference).
+func RecordAffinityFallback(service string) {
+	affinityFallbacks.WithLabelValues(service).Inc()
 }

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -180,6 +180,13 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 	// add the address to our announcement database
 	a.svcIngresses[nsName] = svc.Status.LoadBalancer.Ingress
 
+	// Compute preferred-node set once per SetBalancer cycle (not per IP).
+	// For dual-stack services the inner loop iterates twice — without
+	// hoisting, the annotation check + endpoint iteration would run
+	// twice for identical input. Returns nil for opt-out services, in
+	// which case WinnerWithPreference behaves identically to Winner.
+	preferred := buildPreferredNodes(svc, epSlices)
+
 	for _, ingress := range svc.Status.LoadBalancer.Ingress {
 		// validate the allocated address
 		lbIP := net.ParseIP(ingress.IP)
@@ -194,7 +201,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			lbIPNet, localif, err := findLocal(a.localNameRegex, lbIP)
 			if err == nil {
 				// We found a local interface, announce the address on it
-				if err := a.announceLocal(svc, localif, lbIP, lbIPNet); err != nil {
+				if err := a.announceLocal(svc, preferred, localif, lbIP, lbIPNet); err != nil {
 					retErr = err
 				}
 			} else if a.isRemotePool(lbIP) {
@@ -220,7 +227,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			if lbIPNet, defaultif, err := checkLocal(announceInt, lbIP); err == nil {
 				// The default interface is a local interface, announce the
 				// address on it
-				if err := a.announceLocal(svc, defaultif, lbIP, lbIPNet); err != nil {
+				if err := a.announceLocal(svc, preferred, defaultif, lbIP, lbIPNet); err != nil {
 					retErr = err
 				}
 			} else if a.isRemotePool(lbIP) {
@@ -241,7 +248,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 	return retErr
 }
 
-func (a *announcer) announceLocal(svc *v1.Service, announceInt netlink.Link, lbIP net.IP, lbIPNet net.IPNet) error {
+func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceInt netlink.Link, lbIP net.IP, lbIPNet net.IPNet) error {
 	l := log.With(a.logger, "service", svc.Name)
 	nsName := svc.Namespace + "/" + svc.Name
 
@@ -268,8 +275,11 @@ func (a *announcer) announceLocal(svc *v1.Service, announceInt netlink.Link, lbI
 		}
 	}
 
-	// See if we won the announcement election
-	winner := a.election.Winner(lbIP.String())
+	// See if we won the announcement election. preferred is the set of
+	// nodes hosting Ready/Serving endpoints for this service when the
+	// caller has opted in via NodeAffinityAnnotation; nil otherwise (in
+	// which case WinnerWithPreference behaves identically to Winner).
+	winner := a.election.WinnerWithPreference(lbIP.String(), preferred)
 	if winner == "" {
 		// No nodes have a subnet containing this IP - withdraw any announcement
 		// This happens when subnet-aware election finds no eligible candidates
@@ -501,6 +511,52 @@ func (a *announcer) WithdrawAll() {
 
 func (a *announcer) SetElection(election *election.Election) {
 	a.election = election
+}
+
+// buildPreferredNodes returns the unique node names that host a Ready
+// or Serving endpoint of the given service IF the service has opted in
+// to election affinity via NodeAffinityAnnotation. Returns nil when:
+//   - the annotation is absent or has a value other than "service-endpoints"
+//   - the service is part of a shared-IP family (per-service preferred
+//     sets are incompatible with sharing semantics; aggregation across
+//     sharing services is a future enhancement)
+//
+// A nil return tells WinnerWithPreference to behave exactly like Winner
+// (no affinity biasing, no fallback metric).
+//
+// Readiness rule (Ready OR Serving) mirrors nodeHasHealthyEndpoint
+// below — terminating pods (Ready=false, Serving=true) stay in the
+// preferred set so the VIP doesn't migrate away mid-drain.
+func buildPreferredNodes(svc *v1.Service, epSlices []*discoveryv1.EndpointSlice) []string {
+	if svc.Annotations[purelbv2.NodeAffinityAnnotation] != purelbv2.NodeAffinityServiceEndpoints {
+		return nil
+	}
+	if _, shared := svc.Annotations[purelbv2.SharingAnnotation]; shared {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var preferred []string
+	for _, slice := range epSlices {
+		if slice == nil {
+			continue
+		}
+		for _, ep := range slice.Endpoints {
+			if ep.NodeName == nil {
+				continue
+			}
+			ready := ep.Conditions.Ready != nil && *ep.Conditions.Ready
+			serving := ep.Conditions.Serving != nil && *ep.Conditions.Serving
+			if !ready && !serving {
+				continue
+			}
+			if _, dup := seen[*ep.NodeName]; dup {
+				continue
+			}
+			seen[*ep.NodeName] = struct{}{}
+			preferred = append(preferred, *ep.NodeName)
+		}
+	}
+	return preferred
 }
 
 // nodeHasHealthyEndpoint returns true if node has at least one

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
@@ -565,4 +567,116 @@ func TestSkipDADFromServiceAnnotation(t *testing.T) {
 			assert.Equal(t, tt.wantSkipDAD, opts.SkipDAD)
 		})
 	}
+}
+
+// =================================================================
+// v0.17.0: opt-in app-affinity election (buildPreferredNodes)
+// =================================================================
+
+// ptrBool returns &b. Required because EndpointConditions fields are pointers.
+func ptrBool(b bool) *bool { return &b }
+func ptrStr(s string) *string { return &s }
+
+// makeSlice builds a single-slice EndpointSlice list for tests. Each
+// entry is (nodeName, ready, serving). nil nodeName encodes "no
+// NodeName" — the helper must skip those.
+func makeSlice(entries ...struct {
+	nodeName *string
+	ready    bool
+	serving  bool
+}) []*discoveryv1.EndpointSlice {
+	eps := make([]discoveryv1.Endpoint, 0, len(entries))
+	for _, e := range entries {
+		eps = append(eps, discoveryv1.Endpoint{
+			NodeName: e.nodeName,
+			Conditions: discoveryv1.EndpointConditions{
+				Ready:   ptrBool(e.ready),
+				Serving: ptrBool(e.serving),
+			},
+		})
+	}
+	return []*discoveryv1.EndpointSlice{{Endpoints: eps}}
+}
+
+func TestBuildPreferredNodes(t *testing.T) {
+	withAnnot := func(annot, sharingKey string) *v1.Service {
+		s := &v1.Service{}
+		s.Annotations = map[string]string{}
+		if annot != "" {
+			s.Annotations[purelbv2.NodeAffinityAnnotation] = annot
+		}
+		if sharingKey != "" {
+			s.Annotations[purelbv2.SharingAnnotation] = sharingKey
+		}
+		return s
+	}
+
+	type entry = struct {
+		nodeName *string
+		ready    bool
+		serving  bool
+	}
+
+	t.Run("no annotation → returns nil", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot("", ""), makeSlice(entry{ptrStr("a"), true, true}))
+		assert.Nil(t, got)
+	})
+
+	t.Run("unknown annotation value → returns nil", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot("topology-zone", ""), makeSlice(entry{ptrStr("a"), true, true}))
+		assert.Nil(t, got, "future-mode annotation values must opt out (treat as not-set)")
+	})
+
+	t.Run("annotation + shared-IP → returns nil (sharing exclusion)", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, "shared-1"),
+			makeSlice(entry{ptrStr("a"), true, true}))
+		assert.Nil(t, got, "sharing exclusion must fire even with valid annotation")
+	})
+
+	t.Run("annotation set, two Ready endpoints on different nodes → both included", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			makeSlice(entry{ptrStr("a"), true, true}, entry{ptrStr("b"), true, true}))
+		assert.ElementsMatch(t, []string{"a", "b"}, got)
+	})
+
+	t.Run("nil NodeName endpoint → skipped", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			makeSlice(entry{nil, true, true}, entry{ptrStr("b"), true, true}))
+		assert.Equal(t, []string{"b"}, got)
+	})
+
+	t.Run("Ready=false, Serving=true → INCLUDED (graceful drain)", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			makeSlice(entry{ptrStr("draining"), false, true}))
+		assert.Equal(t, []string{"draining"}, got,
+			"Serving=true endpoints (terminating but draining) must stay preferred")
+	})
+
+	t.Run("Ready=false, Serving=false → skipped", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			makeSlice(entry{ptrStr("dead"), false, false}))
+		assert.Empty(t, got)
+	})
+
+	t.Run("duplicate node across endpoints → deduplicated", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			makeSlice(entry{ptrStr("a"), true, true}, entry{ptrStr("a"), true, true}))
+		assert.Equal(t, []string{"a"}, got)
+	})
+
+	t.Run("nil slice in input list → tolerated (no panic, skipped)", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			[]*discoveryv1.EndpointSlice{nil, makeSlice(entry{ptrStr("a"), true, true})[0]})
+		assert.Equal(t, []string{"a"}, got)
+	})
+
+	t.Run("empty endpoint slice list → empty preferred (NOT nil)", func(t *testing.T) {
+		got := buildPreferredNodes(withAnnot(purelbv2.NodeAffinityServiceEndpoints, ""),
+			[]*discoveryv1.EndpointSlice{})
+		// Returns nil from append-loop never running; this is treated as
+		// "opted-in but no endpoints exist" — WinnerWithPreference handles
+		// it via the !len(preferred)>0 branch, falling through to standard
+		// election (no fallback metric since len(preferred)==0).
+		assert.Empty(t, got)
+	})
 }

--- a/pkg/apis/purelb/v2/annotations.go
+++ b/pkg/apis/purelb/v2/annotations.go
@@ -51,6 +51,23 @@ const (
 	// processing. Useful when subnets change without a config change.
 	ReEvaluateAnnotation string = "purelb.io/re-evaluate"
 
+	// NodeAffinityAnnotation, when set on a Service whose VIP comes from a
+	// Local pool, biases election toward nodes that host a Ready or Serving
+	// endpoint of this Service. The only supported value is
+	// "service-endpoints" (NodeAffinityServiceEndpoints); any other value
+	// is ignored. Has no effect on Remote-pool services (which already get
+	// affinity via BGP-from-endpoint-nodes when ETP=Local). Has no effect
+	// on services that share an IP via SharingAnnotation. When no preferred
+	// node is eligible, election falls back silently to standard hash
+	// selection (tracked via purelb_election_affinity_fallback_total).
+	NodeAffinityAnnotation string = "purelb.io/node-affinity"
+
+	// NodeAffinityServiceEndpoints is the only currently-supported value
+	// for NodeAffinityAnnotation. String-valued (not boolean) so future
+	// modes (e.g. topology-zone) can extend without inventing a second
+	// annotation.
+	NodeAffinityServiceEndpoints string = "service-endpoints"
+
 	// ============================================================================
 	// PureLB-set annotations (informational)
 	// ============================================================================


### PR DESCRIPTION
## Summary

Adds opt-in `purelb.io/node-affinity=service-endpoints` annotation that biases election toward nodes hosting Ready/Serving endpoints of the service. **Local pools only** — Remote pools already get this via BGP-from-endpoint-nodes when ETP=Local.

Without affinity: kube-proxy hop on every inbound packet (VIP on a random eligible node, not the pod's node). With affinity: VIP lands directly on the pod's node — zero extra hops on the local L2 segment.

**Independent of IPAM Parts A/B/C — zero file overlap.**

## Design choices (per [task-election-app-affinity.md](.claude/plans/task-election-app-affinity.md))

**Minimum-code, no machinery:**
- No cache, no debounce, no re-evaluate handling, no events
- VIP follows pod automatically via existing event flow
- Trade-off: brief ARP transition during pod reschedule (acceptable; VIP always ends up correctly on the new pod's node)
- Pin-VIP-regardless-of-pod mode is explicit out-of-scope future work

**New election method, `Winner` unchanged:**
- `(*Election).WinnerWithPreference(key, preferred)` biases standard election toward `preferred` candidates
- Empty/nil `preferred` → identical to `Winner` (no fallback metric — it's opt-out, not degraded)
- Non-empty `preferred` with no intersection → silent fallback + `RecordAffinityFallback`
- Remote-pool path completely untouched (zero behavior change for non-opted-in services)

**Announcer integration:**
- `buildPreferredNodes` helper hoisted into `SetBalancer` — computed ONCE per service-event, not per-IP (dual-stack doesn't pay twice)
- `announceLocal` gains `preferred []string` parameter; calls `WinnerWithPreference` instead of `Winner`
- Shared-IP services explicitly opted out

## Observability

`purelb_election_affinity_fallback_total{service}` counter. Recommended alert:
```promql
rate(purelb_election_affinity_fallback_total[10m]) > 0
```

## Test plan
- [x] `make check` passes with `-race`
- [x] 20 new test cases all PASS:
  - **TestWinnerWithPreference** (10 subtests): nil/empty preferred → identical to Winner; preferred subset → wins; preferred-with-no-intersection → fallback; IPv6 parity; unhealthy lease; no candidates
  - **TestBuildPreferredNodes** (10 subtests): no annotation; unknown value; sharing exclusion; multi-node dedup; nil NodeName skipped; Ready=false+Serving=true INCLUDED (graceful drain); fully-failed endpoints skipped; nil slice tolerated
- [ ] **helm-test cannot verify** (single-node — can't demonstrate VIP migration between nodes). Multi-node smoke recommended as out-of-band verification on `prox-purelb2` (5 nodes per memory) BEFORE v0.17.0 release tag. The scenario:
  1. Apply Service WITH annotation, pinned pod on node-A → VIP on node-A
  2. Repin pod to node-B → VIP follows to node-B
  3. Scale to 0 → fallback metric increments, VIP stays on hash-elected node

## Files modified

| File | Change |
|---|---|
| `pkg/apis/purelb/v2/annotations.go` | `NodeAffinityAnnotation` + `NodeAffinityServiceEndpoints` const block |
| `internal/election/election.go` | `WinnerWithPreference` method (~65 lines) |
| `internal/election/election_test.go` | `TestWinnerWithPreference` |
| `internal/election/metrics.go` | `affinity_fallback_total` counter + `RecordAffinityFallback` |
| `internal/local/announcer_local.go` | `buildPreferredNodes` + hoist into `SetBalancer` + thread `preferred` into `announceLocal` |
| `internal/local/announcer_local_test.go` | `TestBuildPreferredNodes` |