### PR TITLE
ci(docs): build the website from the latest release, not main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,25 +2,33 @@
 # https://github.com/actions/starter-workflows/blob/main/pages/hugo.yml
 name: Deploy Hugo site to Pages
 
+# The published site documents the LATEST RELEASE, not main. Docs content is
+# built from the latest release tag so that purelb.io never describes features
+# that are merged but unreleased (or omits features that are still shipping).
+# There is deliberately no `push` trigger: merging docs to main does not
+# publish them.
+#
 # Triggers:
-#   - push: normal commits to main / website-exp
 #   - workflow_run: fires after Update Helm Repository Index completes
-#     successfully. Needed because helm-index.yml's commit to main is made
-#     with secrets.GITHUB_TOKEN, which does NOT trigger downstream push
-#     workflows. workflow_run bypasses that restriction so the Hugo site
-#     (which serves the helm chart index) actually gets rebuilt.
-#   - workflow_dispatch: manual catchup.
+#     successfully, which itself only runs after a tag-push CI run. This is
+#     the release path. workflow_run is required because helm-index.yml's
+#     commit to main is made with secrets.GITHUB_TOKEN, which does NOT
+#     trigger downstream push workflows.
+#   - workflow_dispatch: manual catchup, and the escape hatch for publishing
+#     from an arbitrary ref (see the `ref` input). Note that an out-of-band
+#     publish is reverted by the next release build, so anything published
+#     that way must also be carried into the next release.
 on:
-  push:
-    branches:
-    - main
-    - website-exp
-
   workflow_run:
     workflows: ["Update Helm Repository Index"]
     types: [completed]
 
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to publish (branch, tag or SHA). Blank = latest release.'
+        required: false
+        default: ''
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -44,15 +52,78 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # For workflow_run triggers, only build when the upstream workflow
-    # succeeded. push and workflow_dispatch always run.
+    # succeeded. workflow_dispatch always runs.
     if: |
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Checkout
+      # The docs describe the latest release, so resolve that tag rather than
+      # building whatever ref triggered us. The releases/latest API honours
+      # the "Latest" flag and excludes drafts and prereleases, so an rc tag
+      # published as a prerelease will not take over the site.
+      - name: Resolve ref to publish
+        id: ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          if [ -n "$INPUT_REF" ]; then
+            ref="$INPUT_REF"
+            release=false
+            echo "Publishing manually requested ref: $ref"
+          else
+            ref=$(gh api "repos/${{ github.repository }}/releases/latest" -q .tag_name)
+            release=true
+            echo "Publishing latest release: $ref"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout docs content at ${{ steps.ref.outputs.ref }}
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.ref.outputs.ref }}
           submodules: recursive
+
+      # website/static/charts/index.yaml is a release artifact, not docs: it is
+      # regenerated and committed to main by helm-index.yml AFTER a tag is cut,
+      # so a tag's own tree never lists its own chart. Take the index from main
+      # (build-time only, never committed) or `helm repo add` would lose the
+      # newest release.
+      - name: Check out current Helm index from main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          sparse-checkout: website/static/charts
+          path: .index-overlay
+
+      - name: Overlay current Helm index
+        env:
+          REF: ${{ steps.ref.outputs.ref }}
+          IS_RELEASE: ${{ steps.ref.outputs.release }}
+        run: |
+          cp .index-overlay/website/static/charts/index.yaml \
+             website/static/charts/index.yaml
+          rm -rf .index-overlay
+          # Only assert on the release path: a manually dispatched ref may be a
+          # branch or SHA, which will never appear in the chart index.
+          if [ "$IS_RELEASE" != "true" ]; then
+            echo "Manual ref publish; skipping Helm index version check."
+            exit 0
+          fi
+          # The index must list the release we are publishing docs for.
+          # Compare without the leading "v" so either convention matches.
+          want="${REF#v}"
+          if grep -Eq "^[[:space:]]+version:[[:space:]]+v?${want}$" \
+              website/static/charts/index.yaml; then
+            echo "Helm index includes $REF"
+          else
+            echo "::error::Helm index from main does not list $REF." \
+                 "Has helm-index.yml run for this release?"
+            grep -E "^[[:space:]]+version:" website/static/charts/index.yaml | sort -u
+            exit 1
+          fi
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v6

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -241,6 +241,30 @@ Tag push fires:
 
 Total ~10 minutes from tag push to published index. No manual intervention.
 
+## The website publishes the latest release, not main
+
+`build.yml` has no `push` trigger. Merging docs to main does **not** publish
+them: the site is built from the tag reported by the `releases/latest` API,
+so purelb.io always describes the newest release rather than unreleased work
+on main. Docs written alongside a feature go live when that feature ships.
+
+Two consequences worth remembering:
+
+- **Doc-only fixes wait for the next release.** The escape hatch is
+  `gh workflow run build.yml -f ref=<branch|tag|sha>`, which publishes any
+  ref immediately. It is reverted by the next release build, so anything
+  published that way must also land in the next release or it disappears.
+- **A prerelease must be flagged as one.** `releases/latest` excludes drafts
+  and prereleases. If an rc is published as a normal GitHub release it
+  becomes the live documentation.
+
+`website/static/charts/index.yaml` is exempt from the freeze. It is a release
+artifact, written to main by step 2 *after* the tag is cut, so a tag's own
+tree never lists its own chart (v0.16.6's tree stops at v0.16.5). `build.yml`
+therefore overlays main's copy of the index onto the release checkout at build
+time and fails the build if the index does not list the release being
+published — without that, `helm repo add` would lose the newest chart.
+
 ## Post-release verification
 
 - [ ] `gh release view $NEW` shows the expected assets (install manifests,


### PR DESCRIPTION
## Problem

`build.yml` triggered on `push` to `main` and `actions/checkout` defaults to the ref that triggered it, so **every merge to main immediately republished purelb.io**.

The result is live right now: the newest release is **v0.16.6**, but the published site is built from main and therefore documents the unreleased v0.17.0 sidecar external-IPAM while having *deleted* the Netbox page — a feature v0.16.6 still ships. Someone installing the current release reads docs for software they cannot get, and cannot find docs for what they do have.

## The complication

`website/static/charts/index.yaml` — the Helm classic-repo index served at `purelb.io/charts` — is not docs content. It is a release artifact that `helm-index.yml` regenerates and commits to main *after* a tag is cut, so a tag's own tree never contains its own chart entry:

```
index.yaml @ v0.16.6:  v0.14.0 … v0.16.4  v0.16.5           <- missing itself
index.yaml @ main:     v0.14.0 … v0.16.4  v0.16.5  v0.16.6
```

A naive "check out the latest tag and build" would silently regress `helm repo add purelb https://purelb.io/charts`: the newest chart would vanish from the index. The fix has to publish *docs at release state* but *the index at current state*.

## Changes

**`.github/workflows/build.yml`**
- Drop the `push` trigger entirely (both `main` and `website-exp`). This is the actual fix.
- New `Resolve ref to publish` step reads `gh api repos/{owner}/{repo}/releases/latest -q .tag_name`, which honours the "Latest" flag and excludes drafts and prereleases (so an rc published as a prerelease cannot take over the site, and stray tags like `v0.99.0-ds1` are invisible).
- Checkout pins to that tag with `submodules: recursive`.
- Sparse checkout of `main` limited to `website/static/charts`, overlaid onto the release checkout at build time (never committed), with a guarded assertion that the index lists the release being published. The assertion is skipped on the manual-ref path, where a branch or SHA will never appear in a chart index.
- `workflow_dispatch` gains an optional `ref` input as the escape hatch.

`helm-index.yml` and `ci.yml` are untouched; the existing `ci -> helm-index -> build` release chain still works and remains the only automatic publish path.

**`RELEASING.md`** — new section documenting the freeze, the escape hatch and its revert-on-next-release caveat, the prerelease-flag requirement, and why the chart index is exempt.

## Verification

Rehearsed the real build locally on a worktree of `v0.16.6` using the same Hugo the CI installs (0.160.1-extended):

```
=== hugo build ===        Pages 66, Static files 74, Total in 242 ms
published index.yaml:     version: v0.16.6              <- newest chart still served
present: docs/configuration/netbox           <- ships in v0.16.6, correctly documented
absent:  docs/configuration/external-ipam    <- unreleased, correctly withheld
```

The index-check logic was exercised against the real files in all three states:

| case | expected | result |
| --- | --- | --- |
| release `v0.16.6`, overlay applied | pass | `Helm index includes v0.16.6` |
| stale index missing `v0.16.6` | fail | `::error::` + exit 1 |
| manual branch ref | skip | `Manual ref publish; skipping Helm index version check.` |

The middle case is the exact regression the overlay prevents: the tag's own tree lists 9 versions and stops at v0.16.5.

## Notes for merging

- **Merge this before the multi-interface commits.** Until it lands, any merge to main republishes the v0.17.0 docs.
- Merging does not by itself correct what is live — the site keeps serving the current build until the next release triggers a rebuild. To fix purelb.io immediately after merge, run `gh workflow run build.yml` once with a blank ref.
- Tradeoff accepted: doc-only fixes now wait for the next release, or must be published out of band with `-f ref=...` and carried into the next release or they disappear.
