### PR TITLE
Multi-interface subnet-aware election: nodeSelector, interfaces[], IPv6 NA parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ pkg/generated
 pkg/apis/purelb/*/zz_generated.deepcopy.go
 
 # build / test / local artifacts
-kubectl-purelb
+# Root-anchored: the plugin binary is built to the repo root by `make plugin`.
+# Unanchored, this pattern also matched cmd/kubectl-purelb/, so new source
+# files in the plugin were silently untracked.
+/kubectl-purelb
 test/e2e/timing/timing-results-*.csv
 .claude/

--- a/cmd/kubectl-purelb/commands_test.go
+++ b/cmd/kubectl-purelb/commands_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -727,4 +729,249 @@ func TestDetectBGPState(t *testing.T) {
 			assert.Equal(t, tt.wantSentence, info.sentence(), "sentence")
 		})
 	}
+}
+
+// =============================================================================
+// nodeSelector / announcement-visibility tests (v0.17.0)
+// =============================================================================
+
+// captureOutput redirects stdout while fn runs so tests can assert on what the
+// command actually prints, not merely that it returned nil.
+func captureOutput(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	require.NoError(t, pipeErr)
+	os.Stdout = w
+
+	runErr := fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, readErr := io.ReadAll(r)
+	require.NoError(t, readErr)
+	return string(out), runErr
+}
+
+func makeNode(name string, labels map[string]string) *v1.Node {
+	return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func makeLBNodeAgent(name string, spec map[string]interface{}) *unstructured.Unstructured {
+	lbna := &unstructured.Unstructured{}
+	lbna.SetGroupVersionKind(schema.GroupVersionKind{Group: "purelb.io", Version: "v2", Kind: "LBNodeAgent"})
+	lbna.SetName(name)
+	lbna.SetNamespace("purelb-system")
+	lbna.Object["spec"] = spec
+	return lbna
+}
+
+// TestRenderStatus_CountsUnannouncedIPs covers the bug where `status` reported
+// "Overall: OK" while every allocated address had lost its announcer, because
+// it only counted services awaiting allocation. `services` flagged the same
+// addresses as NO ANNOUNCER at that moment.
+func TestRenderStatus_CountsUnannouncedIPs(t *testing.T) {
+	sg := makeSG("pool", "local", "10.0.0.0/28", "10.0.0.0/24")
+	// Allocated, but no announcing-* annotation: nothing is answering for it.
+	svc := makePureLBService("default", "web", "10.0.0.1", "pool", "local")
+	lease := makeLease("node-a", "10.0.0.0/24", 2)
+
+	c := newFakeClients([]runtime.Object{svc, lease}, sg)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	out, err := captureOutput(t, func() error { return renderStatus(snap, outputJSON) })
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "1 IP(s) not announced")
+	assert.Contains(t, out, "WARNING")
+	assert.NotContains(t, out, `"overall": "OK"`)
+}
+
+// The same service WITH a healthy announcer must stay clean, so the check
+// cannot be satisfied by simply always warning.
+func TestRenderStatus_AnnouncedIPIsNotAProblem(t *testing.T) {
+	sg := makeSG("pool", "local", "10.0.0.0/28", "10.0.0.0/24")
+	svc := makePureLBService("default", "web", "10.0.0.1", "pool", "local")
+	svc.Annotations[annotationAnnouncing+"-IPv4"] = "node-a,eth0,10.0.0.1"
+	lease := makeLease("node-a", "10.0.0.0/24", 2)
+
+	c := newFakeClients([]runtime.Object{svc, lease}, sg)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	out, err := captureOutput(t, func() error { return renderStatus(snap, outputJSON) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "not announced")
+}
+
+// A node with a perfectly healthy lease that no LBNodeAgent selects announces
+// nothing; lease health alone cannot express that.
+func TestRenderStatus_DeselectedNodeIsVisible(t *testing.T) {
+	lease := makeLease("node-a", "", 2)
+	node := makeNode("node-a", map[string]string{"role": "worker"})
+	lbna := makeLBNodeAgent("edge-only", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+
+	c := newFakeClients([]runtime.Object{lease, node}, lbna)
+	snap, err := fetchSnapshot(context.Background(), c)
+	require.NoError(t, err)
+
+	out, err := captureOutput(t, func() error { return renderStatus(snap, outputJSON) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "selected by no LBNodeAgent")
+	assert.Contains(t, out, "announcing nothing")
+}
+
+// TestRunElection_ConfigColumn checks the per-node config state that tells a
+// deliberately-excluded node apart from a broken one.
+func TestRunElection_ConfigColumn(t *testing.T) {
+	leaseEdge := makeLease("node-edge", "10.0.0.0/24", 2)
+	leaseWorker := makeLease("node-worker", "", 2)
+	nodeEdge := makeNode("node-edge", map[string]string{"role": "edge"})
+	nodeWorker := makeNode("node-worker", map[string]string{"role": "worker"})
+	lbna := makeLBNodeAgent("edge-only", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+
+	c := newFakeClients([]runtime.Object{leaseEdge, leaseWorker, nodeEdge, nodeWorker}, lbna)
+
+	out, err := captureOutput(t, func() error {
+		return runElection(context.Background(), c, outputTable, "", false, "")
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "CONFIG")
+	assert.Contains(t, out, configStateConfigured)
+	assert.Contains(t, out, configStateDeselected)
+	assert.Contains(t, out, "node-worker is selected by no LBNodeAgent")
+}
+
+// TestRunValidate_NodeSelectorChecks covers the LBNodeAgent nodeSelector
+// checks: a resource that selects nothing, and nodes selected by nothing.
+func TestRunValidate_NodeSelectorChecks(t *testing.T) {
+	node := makeNode("node-a", map[string]string{"role": "worker"})
+	lbna := makeLBNodeAgent("edge-only", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+
+	c := newFakeClients([]runtime.Object{node}, lbna)
+
+	out, err := captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, false)
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "nodeSelector matches 0 of 1 nodes")
+	assert.Contains(t, out, "selected by no LBNodeAgent")
+}
+
+// A specific selector overriding the catch-all is the documented
+// default-plus-override pattern. It must report which resource governs the
+// node WITHOUT warning — otherwise a correct configuration could never
+// validate clean and --strict would fail CI on it.
+func TestRunValidate_ScopedOverrideIsNotAWarning(t *testing.T) {
+	node := makeNode("node-a", map[string]string{"role": "edge"})
+	catchAll := makeLBNodeAgent("aaa-catchall", map[string]interface{}{
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+	scoped := makeLBNodeAgent("zzz-scoped", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+
+	c := newFakeClients([]runtime.Object{node}, catchAll, scoped)
+
+	out, err := captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, false)
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "using a scoped LBNodeAgent override")
+	assert.Contains(t, out, "using purelb-system/zzz-scoped")
+	assert.Contains(t, out, "over purelb-system/aaa-catchall")
+	assert.NotContains(t, out, "resolved by name order")
+	assert.Contains(t, out, "0 WARN")
+
+	// --strict must also pass: this configuration is correct.
+	_, err = captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, true)
+	})
+	assert.NoError(t, err, "--strict must not fail on the default-plus-override pattern")
+}
+
+// Two SPECIFIC selectors matching one node is genuinely ambiguous: the winner
+// is decided only by namespace/name sort, so it stays a warning.
+func TestRunValidate_ContestedNodeWarns(t *testing.T) {
+	node := makeNode("node-a", map[string]string{"role": "edge", "tier": "front"})
+	byRole := makeLBNodeAgent("aaa-by-role", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+	byTier := makeLBNodeAgent("zzz-by-tier", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"tier": "front"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})
+
+	c := newFakeClients([]runtime.Object{node}, byRole, byTier)
+
+	out, err := captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, false)
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "matched by multiple specific nodeSelectors")
+	assert.Contains(t, out, "resolved by name order")
+	assert.Contains(t, out, "using purelb-system/aaa-by-role")
+}
+
+// TestRunValidate_LocalInterfaceRegex covers the documented footgun: matching
+// is unanchored, so "eth" also selects veth interfaces.
+func TestRunValidate_LocalInterfaceRegex(t *testing.T) {
+	node := makeNode("node-a", nil)
+	lbna := makeLBNodeAgent("default", map[string]interface{}{
+		"local": map[string]interface{}{"localInterface": "eth"},
+	})
+
+	c := newFakeClients([]runtime.Object{node}, lbna)
+
+	out, err := captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "unanchored")
+	assert.Contains(t, out, "^eth$")
+}
+
+// An invalid regex is a hard failure: the agent rejects the config and the
+// selected nodes announce nothing.
+func TestRunValidate_InvalidLocalInterface(t *testing.T) {
+	node := makeNode("node-a", nil)
+	lbna := makeLBNodeAgent("default", map[string]interface{}{
+		"local": map[string]interface{}{"localInterface": "["},
+	})
+
+	c := newFakeClients([]runtime.Object{node}, lbna)
+
+	out, err := captureOutput(t, func() error {
+		return runValidate(context.Background(), c, outputTable, false)
+	})
+	assert.Error(t, err, "an invalid localInterface must fail validation")
+	assert.Contains(t, out, "not a valid regex")
 }

--- a/cmd/kubectl-purelb/election.go
+++ b/cmd/kubectl-purelb/election.go
@@ -38,6 +38,11 @@ type nodeLeaseInfo struct {
 	ExpiresIn  string   `json:"expiresIn"`
 	Healthy    bool     `json:"healthy"`
 	Announcing int      `json:"announcing"`
+	// Config reports which LBNodeAgent governs this node. A node with a
+	// healthy lease still announces nothing when no nodeSelector selects it
+	// ("deselected") or its localInterface regex is invalid ("invalid"),
+	// which lease health alone cannot express.
+	Config      nodeConfig `json:"config"`
 }
 
 type subnetCoverage struct {
@@ -130,6 +135,20 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 		return fmt.Errorf("listing leases: %w", err)
 	}
 
+	// Node labels plus LBNodeAgent resources let us resolve which
+	// configuration governs each node, using the same precedence the node
+	// agents apply. Both are best-effort: without them the CONFIG column
+	// simply reports "unknown".
+	nodeList, _ := c.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	agents := decodeLBNodeAgents(lbnaList)
+	nodeLabels := map[string]map[string]string{}
+	if nodeList != nil {
+		for i := range nodeList.Items {
+			nodeLabels[nodeList.Items[i].Name] = nodeList.Items[i].Labels
+		}
+	}
+
 	// Parse leases into node info
 	// Also build subnet -> nodes map
 	var nodes []nodeLeaseInfo
@@ -161,12 +180,18 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 			}
 		}
 
+		cfg := nodeConfig{State: "unknown"}
+		if labels, known := nodeLabels[nodeName]; known {
+			cfg = resolveNodeConfig(agents, labels)
+		}
+
 		nodes = append(nodes, nodeLeaseInfo{
 			Name:       nodeName,
 			Subnets:    subnets,
 			RenewedAgo: renewedAgo,
 			ExpiresIn:  expiresIn,
 			Healthy:    healthy,
+			Config:     cfg,
 		})
 
 		nodeSubnets[nodeName] = subnets
@@ -353,6 +378,12 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 				hasProblems = true
 			}
 		}
+		for _, n := range nodes {
+			if n.Config.State == configStateInvalid {
+				fmt.Printf("INVALID CONFIG: node %s (%s) - announces nothing\n", n.Name, n.Config.Reason)
+				hasProblems = true
+			}
+		}
 		for _, u := range uncovered {
 			fmt.Printf("UNCOVERED: %s range %s (subnet %s) - no nodes with this subnet\n",
 				u.ServiceGroup, u.Pool, u.Subnet)
@@ -367,16 +398,36 @@ func runElection(ctx context.Context, c *clients, format outputFormat, filterNod
 
 	// Full table output
 	tw := tableWriter(os.Stdout)
-	fmt.Fprintf(tw, "NODE\tSUBNETS\tRENEWED\tEXPIRES\tHEALTHY\tANNOUNCING\n")
+	fmt.Fprintf(tw, "NODE\tCONFIG\tSUBNETS\tRENEWED\tEXPIRES\tHEALTHY\tANNOUNCING\n")
 	for _, n := range nodes {
 		subnets := strings.Join(n.Subnets, ",")
 		if subnets == "" {
 			subnets = "(none)"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%v\t%d IPs\n",
-			n.Name, subnets, n.RenewedAgo, n.ExpiresIn, n.Healthy, n.Announcing)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%v\t%d IPs\n",
+			n.Name, n.Config.State, subnets, n.RenewedAgo, n.ExpiresIn, n.Healthy, n.Announcing)
 	}
 	tw.Flush()
+
+	// Nodes that are configured out of announcing deserve an explicit note:
+	// a healthy lease with no subnets looks identical to a misconfiguration.
+	for _, n := range nodes {
+		switch n.Config.State {
+		case configStateDeselected:
+			fmt.Printf("  note: %s is selected by no LBNodeAgent — announces nothing\n", n.Name)
+		case configStateInvalid:
+			fmt.Printf("  note: %s has an invalid config (%s) — announces nothing\n", n.Name, n.Config.Reason)
+		}
+		if len(n.Config.Ignored) > 0 {
+			if n.Config.Contested {
+				fmt.Printf("  note: %s matches multiple specific nodeSelectors; using %s over %s (resolved by name order)\n",
+					n.Name, n.Config.Agent, strings.Join(n.Config.Ignored, ", "))
+			} else {
+				fmt.Printf("  note: %s uses scoped override %s (over %s)\n",
+					n.Name, n.Config.Agent, strings.Join(n.Config.Ignored, ", "))
+			}
+		}
+	}
 
 	// Subnet coverage
 	fmt.Printf("\nMembers: %d, Subnets: %d unique\n", len(nodes), len(coverage))

--- a/cmd/kubectl-purelb/inspect.go
+++ b/cmd/kubectl-purelb/inspect.go
@@ -59,7 +59,14 @@ type electionInfo struct {
 	Candidates []string `json:"candidates"`
 	Subnet     string   `json:"subnet"`
 	Winner     string   `json:"winner"`
-	Matches    bool     `json:"matchesAnnouncer"`
+	// Method explains how the winner was reached: a plain hash over the
+	// candidates, or one biased by node affinity (or a documented fallback
+	// when no endpoint node can serve the address).
+	Method string `json:"method"`
+	// Preferred is the endpoint-node set affinity biases toward, empty when
+	// the service does not use node affinity.
+	Preferred []string `json:"preferredNodes,omitempty"`
+	Matches   bool     `json:"matchesAnnouncer"`
 }
 
 type announcementInfo struct {
@@ -159,6 +166,20 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		}
 	}
 
+	// Endpoints are fetched up front because the election below needs them:
+	// with the node-affinity annotation the announcer elects among the nodes
+	// hosting Ready/Serving endpoints, not among all candidates.
+	epSlices, _ := c.core.DiscoveryV1().EndpointSlices(ns).List(ctx, metav1.ListOptions{
+		ResourceVersion: "0",
+		LabelSelector:   fmt.Sprintf("kubernetes.io/service-name=%s", name),
+	})
+	var epItems []discoveryv1.EndpointSlice
+	if epSlices != nil {
+		epItems = epSlices.Items
+		result.Endpoints = countEndpoints(epItems)
+	}
+	preferred := preferredNodesForService(ann, epItems)
+
 	// Check if allocated
 	ingresses := svc.Status.LoadBalancer.Ingress
 	isAllocated := ann[annotationAllocatedBy] == brandPureLB && len(ingresses) > 0
@@ -195,12 +216,7 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		}
 
 		// Parse announcing annotations
-		announcers := map[string]announcement{}
-		for _, suffix := range []string{"-IPv4", "-IPv6"} {
-			for _, a := range parseAnnouncingAnnotation(ann[annotationAnnouncing+suffix]) {
-				announcers[a.IP] = a
-			}
-		}
+		announcers := serviceAnnouncers(ann)
 
 		// Fetch BGPNodeStatus for remote pool route checks. Also classify the
 		// BGP state up front so we can show a clear "BGP not enabled" /
@@ -255,10 +271,18 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 					}
 				}
 
-				winner := electionWinner(ipStr, candidates)
+				winner, affinityApplied, affinityFellBack := predictWinner(ipStr, candidates, preferred)
 				actualAnnouncer := ""
 				if a, ok := announcers[ipStr]; ok {
 					actualAnnouncer = a.Node
+				}
+
+				method := "SHA256 hash"
+				switch {
+				case affinityApplied:
+					method = "SHA256 hash, affinity-biased to endpoint nodes"
+				case affinityFellBack:
+					method = "SHA256 hash, affinity fell back (no endpoint node has this subnet)"
 				}
 
 				result.Elections = append(result.Elections, electionInfo{
@@ -266,6 +290,8 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 					Candidates: candidates,
 					Subnet:     matchedSubnet,
 					Winner:     winner,
+					Method:     method,
+					Preferred:  preferred,
 					Matches:    winner == actualAnnouncer || (winner != "" && actualAnnouncer == ""),
 				})
 			}
@@ -351,15 +377,6 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 		}
 	}
 
-	// Endpoints
-	epSlices, _ := c.core.DiscoveryV1().EndpointSlices(ns).List(ctx, metav1.ListOptions{
-		ResourceVersion: "0",
-		LabelSelector:   fmt.Sprintf("kubernetes.io/service-name=%s", name),
-	})
-	if epSlices != nil {
-		result.Endpoints = countEndpoints(epSlices.Items)
-	}
-
 	if format != outputTable {
 		return printStructured(format, result)
 	}
@@ -406,7 +423,10 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 				}
 				fmt.Printf("Election (%s):\n", e.IP)
 				fmt.Printf("  Candidates: %s (subnet %s)\n", strings.Join(e.Candidates, ", "), e.Subnet)
-				fmt.Printf("  Winner: %s (SHA256 hash)  [%s]\n", e.Winner, match)
+				if len(e.Preferred) > 0 {
+					fmt.Printf("  Affinity prefers: %s (nodes with Ready/Serving endpoints)\n", strings.Join(e.Preferred, ", "))
+				}
+				fmt.Printf("  Winner: %s (%s)  [%s]\n", e.Winner, e.Method, match)
 			}
 		}
 

--- a/cmd/kubectl-purelb/nodeconfig.go
+++ b/cmd/kubectl-purelb/nodeconfig.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// defaultDummyInterface is the dummy interface name assumed when no
+// LBNodeAgent sets one (matches the CRD default).
+const defaultDummyInterface = "kube-lb0"
+
+// Announcement configuration states for a node. These mirror the states the
+// node agent itself reports via purelb_lbnodeagent_selector_state, but are
+// derived from the API so the plugin needs no access to node metrics ports.
+const (
+	// configStateConfigured: an LBNodeAgent with a local spec governs this node.
+	configStateConfigured = "configured"
+	// configStateDeselected: LBNodeAgents exist but none selects this node, so
+	// it announces nothing and advertises no subnets.
+	configStateDeselected = "deselected"
+	// configStateRemote: the governing LBNodeAgent has no local spec, so this
+	// node announces remote addresses only.
+	configStateRemote = "remote"
+	// configStateInvalid: the governing localInterface is not a valid regex, so
+	// the agent rejects the config and announces nothing.
+	configStateInvalid = "invalid"
+	// configStateNoConfig: no LBNodeAgent resources exist at all.
+	configStateNoConfig = "no-config"
+)
+
+// decodeLBNodeAgents converts dynamic-client objects into typed LBNodeAgents
+// so the plugin can call purelbv2.AgentsForNode — the very function the node
+// agents use to pick their configuration — instead of reimplementing selector
+// precedence here, where it could drift. Objects that fail to decode are
+// skipped rather than failing the whole command.
+func decodeLBNodeAgents(list *unstructured.UnstructuredList) []*purelbv2.LBNodeAgent {
+	if list == nil {
+		return nil
+	}
+	agents := make([]*purelbv2.LBNodeAgent, 0, len(list.Items))
+	for i := range list.Items {
+		agent := &purelbv2.LBNodeAgent{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, agent); err != nil {
+			continue
+		}
+		agents = append(agents, agent)
+	}
+	return agents
+}
+
+// agentName renders an LBNodeAgent's namespace/name for display.
+func agentName(a *purelbv2.LBNodeAgent) string {
+	if a == nil {
+		return ""
+	}
+	if a.Namespace == "" {
+		return a.Name
+	}
+	return a.Namespace + "/" + a.Name
+}
+
+// nodeConfig describes which LBNodeAgent governs a node, and what that means
+// for announcement.
+type nodeConfig struct {
+	State string `json:"state"`
+	// Agent is the resource providing the local spec (or the
+	// highest-precedence match when none has one).
+	Agent string `json:"agent,omitempty"`
+	// Ignored lists lower-precedence matches, which the agent logs and events.
+	Ignored []string `json:"ignored,omitempty"`
+	// Contested is true when more than one *specific* selector matched, so
+	// precedence fell through to namespace/name order — arbitrary from an
+	// operator's point of view and worth a warning. A specific selector
+	// overriding a catch-all is NOT contested: that is the documented
+	// default-plus-override pattern and resolves unambiguously.
+	Contested bool   `json:"contested,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// announces reports whether a node in this state announces local addresses.
+func (c nodeConfig) announces() bool {
+	return c.State == configStateConfigured
+}
+
+// resolveNodeConfig determines the announcement configuration for one node,
+// mirroring the node agent's own resolution: filter by nodeSelector with
+// AgentsForNode (specific selectors beat catch-alls, then namespace/name
+// order), then take the first match carrying a local spec.
+func resolveNodeConfig(agents []*purelbv2.LBNodeAgent, nodeLabels map[string]string) nodeConfig {
+	if len(agents) == 0 {
+		return nodeConfig{State: configStateNoConfig, Reason: "no LBNodeAgent resources exist"}
+	}
+
+	matched := purelbv2.AgentsForNode(agents, nodeLabels)
+	if len(matched) == 0 {
+		return nodeConfig{
+			State:  configStateDeselected,
+			Reason: "no LBNodeAgent nodeSelector matches this node",
+		}
+	}
+
+	cfg := nodeConfig{}
+	for _, extra := range matched[1:] {
+		cfg.Ignored = append(cfg.Ignored, agentName(extra))
+	}
+
+	// Classify selectors exactly as AgentsForNode does, so "contested" means
+	// the same thing here as the precedence rule it describes.
+	specific := 0
+	for _, m := range matched {
+		if !purelbv2.IsCatchAll(m.Spec.NodeSelector) {
+			specific++
+		}
+	}
+	cfg.Contested = specific > 1
+
+	local := purelbv2.FirstLocalAgent(matched)
+	if local == nil {
+		cfg.State = configStateRemote
+		cfg.Agent = agentName(matched[0])
+		cfg.Reason = "matching LBNodeAgent has no local spec"
+		return cfg
+	}
+
+	cfg.Agent = agentName(local)
+	if invalid, _ := localInterfaceIssues(local.Spec.Local.LocalInterface); invalid {
+		cfg.State = configStateInvalid
+		cfg.Reason = fmt.Sprintf("localInterface %q is not a valid regex", local.Spec.Local.LocalInterface)
+		return cfg
+	}
+
+	cfg.State = configStateConfigured
+	return cfg
+}
+
+// localInterfaceIssues classifies a localInterface value. "default" (and the
+// empty value, which the agent treats as "default") selects the default-route
+// interface. Anything else is a regex which both the announcer and the
+// election match UNANCHORED, so "eth" also matches "veth1a2b3c" and would pull
+// pod interfaces into subnet detection.
+func localInterfaceIssues(pattern string) (invalid, unanchored bool) {
+	if pattern == "" || pattern == "default" {
+		return false, false
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return true, false
+	}
+	if !strings.HasPrefix(pattern, "^") || !strings.HasSuffix(pattern, "$") {
+		return false, true
+	}
+	return false, false
+}
+
+// dummyInterfaces returns the distinct dummy interface names configured across
+// the given agents, in deterministic order. Callers previously read item [0]
+// of the LBNodeAgent list, which is arbitrary once more than one resource
+// exists.
+func dummyInterfaces(agents []*purelbv2.LBNodeAgent) []string {
+	seen := map[string]bool{}
+	names := []string{}
+	for _, a := range agents {
+		if a.Spec.Local == nil {
+			continue
+		}
+		name := a.Spec.Local.DummyInterface
+		if name == "" {
+			name = defaultDummyInterface
+		}
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return []string{defaultDummyInterface}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// dummyInterfaceForNode returns the dummy interface that applies to one node,
+// resolved with the same precedence the node agent uses.
+func dummyInterfaceForNode(agents []*purelbv2.LBNodeAgent, nodeLabels map[string]string) string {
+	if local := purelbv2.FirstLocalAgent(purelbv2.AgentsForNode(agents, nodeLabels)); local != nil {
+		if name := local.Spec.Local.DummyInterface; name != "" {
+			return name
+		}
+	}
+	return defaultDummyInterface
+}
+
+// matchesNode reports whether a single agent's nodeSelector selects a node.
+func matchesNode(agent *purelbv2.LBNodeAgent, nodeLabels map[string]string) bool {
+	return len(purelbv2.AgentsForNode([]*purelbv2.LBNodeAgent{agent}, nodeLabels)) > 0
+}
+
+// preferredNodesForService returns the nodes the announcer biases toward for
+// this service, mirroring buildPreferredNodes in internal/local: only when the
+// node-affinity annotation asks for it, never for shared IPs (where one
+// address serves several services with different endpoints), and counting an
+// endpoint whose node is known and which is Ready or Serving. Returns nil when
+// affinity does not apply, which makes the caller's election plain.
+func preferredNodesForService(ann map[string]string, slices []discoveryv1.EndpointSlice) []string {
+	if ann[annotationNodeAffinity] != nodeAffinityServiceEndpoints {
+		return nil
+	}
+	if _, shared := ann[annotationSharing]; shared {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var preferred []string
+	for i := range slices {
+		for _, ep := range slices[i].Endpoints {
+			if ep.NodeName == nil {
+				continue
+			}
+			ready := ep.Conditions.Ready != nil && *ep.Conditions.Ready
+			serving := ep.Conditions.Serving != nil && *ep.Conditions.Serving
+			if !ready && !serving {
+				continue
+			}
+			if _, dup := seen[*ep.NodeName]; dup {
+				continue
+			}
+			seen[*ep.NodeName] = struct{}{}
+			preferred = append(preferred, *ep.NodeName)
+		}
+	}
+	return preferred
+}
+
+// predictWinner reproduces the announcer's election for one address:
+// WinnerWithPreference narrows the candidates to the preferred set when that
+// intersection is non-empty, otherwise it falls back to the full set. Ignoring
+// affinity here made the plugin predict the wrong winner for every
+// affinity-enabled service and report a false split-brain.
+func predictWinner(ip string, candidates, preferred []string) (winner string, affinityApplied, affinityFellBack bool) {
+	if len(candidates) == 0 {
+		return "", false, false
+	}
+	if len(preferred) > 0 {
+		prefSet := make(map[string]struct{}, len(preferred))
+		for _, n := range preferred {
+			prefSet[n] = struct{}{}
+		}
+		var narrowed []string
+		for _, c := range candidates {
+			if _, ok := prefSet[c]; ok {
+				narrowed = append(narrowed, c)
+			}
+		}
+		if len(narrowed) > 0 {
+			return electionWinner(ip, narrowed), true, false
+		}
+		// Preferred nodes exist but none can serve this address.
+		return electionWinner(ip, candidates), false, true
+	}
+	return electionWinner(ip, candidates), false, false
+}

--- a/cmd/kubectl-purelb/nodeconfig_test.go
+++ b/cmd/kubectl-purelb/nodeconfig_test.go
@@ -1,0 +1,411 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/utils/ptr"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// makeLBNA builds an unstructured LBNodeAgent the way the API server returns
+// one, so the decode path is exercised rather than bypassed.
+func makeLBNA(name string, spec map[string]interface{}) *unstructured.Unstructured {
+	lbna := &unstructured.Unstructured{}
+	lbna.SetGroupVersionKind(schema.GroupVersionKind{Group: "purelb.io", Version: "v2", Kind: "LBNodeAgent"})
+	lbna.SetName(name)
+	lbna.SetNamespace("purelb-system")
+	lbna.Object["spec"] = spec
+	return lbna
+}
+
+func localSpec(localInterface string) map[string]interface{} {
+	return map[string]interface{}{
+		"local": map[string]interface{}{
+			"localInterface": localInterface,
+			"dummyInterface": "kube-lb0",
+		},
+	}
+}
+
+func lbnaListOf(items ...*unstructured.Unstructured) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	for _, i := range items {
+		list.Items = append(list.Items, *i)
+	}
+	return list
+}
+
+func TestDecodeLBNodeAgents(t *testing.T) {
+	list := lbnaListOf(
+		makeLBNA("default", localSpec("default")),
+		makeLBNA("scoped", map[string]interface{}{
+			"nodeSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"role": "edge"},
+			},
+			"local": map[string]interface{}{"localInterface": "^eth1$"},
+		}),
+	)
+
+	agents := decodeLBNodeAgents(list)
+	if len(agents) != 2 {
+		t.Fatalf("decoded %d agents, want 2", len(agents))
+	}
+	if agents[0].Name != "default" || agents[0].Spec.Local == nil {
+		t.Errorf("first agent decoded wrong: %+v", agents[0])
+	}
+	if agents[1].Spec.NodeSelector == nil || agents[1].Spec.NodeSelector.MatchLabels["role"] != "edge" {
+		t.Errorf("nodeSelector did not decode: %+v", agents[1].Spec.NodeSelector)
+	}
+	if got := agentName(agents[1]); got != "purelb-system/scoped" {
+		t.Errorf("agentName = %q, want purelb-system/scoped", got)
+	}
+
+	if agents := decodeLBNodeAgents(nil); agents != nil {
+		t.Errorf("nil list should decode to nil, got %v", agents)
+	}
+}
+
+func TestResolveNodeConfig(t *testing.T) {
+	catchAll := decodeLBNodeAgents(lbnaListOf(makeLBNA("default", localSpec("default"))))
+	scoped := decodeLBNodeAgents(lbnaListOf(makeLBNA("edge", map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{"role": "edge"},
+		},
+		"local": map[string]interface{}{"localInterface": "default"},
+	})))
+	remoteOnly := decodeLBNodeAgents(lbnaListOf(makeLBNA("remote", map[string]interface{}{})))
+	badRegex := decodeLBNodeAgents(lbnaListOf(makeLBNA("broken", localSpec("["))))
+
+	tests := []struct {
+		name      string
+		agents    []*purelbv2.LBNodeAgent
+		labels    map[string]string
+		wantState string
+	}{
+		{"no resources at all", nil, nil, configStateNoConfig},
+		{"catch-all selects every node", catchAll, map[string]string{"any": "value"}, configStateConfigured},
+		{"scoped selects a matching node", scoped, map[string]string{"role": "edge"}, configStateConfigured},
+		{"scoped deselects a non-matching node", scoped, map[string]string{"role": "worker"}, configStateDeselected},
+		{"resource without local spec", remoteOnly, nil, configStateRemote},
+		{"invalid localInterface regex", badRegex, nil, configStateInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveNodeConfig(tt.agents, tt.labels).State; got != tt.wantState {
+				t.Errorf("state = %q, want %q", got, tt.wantState)
+			}
+		})
+	}
+}
+
+// TestResolveNodeConfigPrecedence pins that the plugin reports the same
+// winner the node agent uses: a specific selector beats a catch-all
+// regardless of name order, and the losers are listed as ignored.
+func TestResolveNodeConfigPrecedence(t *testing.T) {
+	agents := decodeLBNodeAgents(lbnaListOf(
+		makeLBNA("aaa-catchall", localSpec("default")),
+		makeLBNA("zzz-scoped", map[string]interface{}{
+			"nodeSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"role": "edge"},
+			},
+			"local": map[string]interface{}{"localInterface": "^eth1$"},
+		}),
+	))
+
+	cfg := resolveNodeConfig(agents, map[string]string{"role": "edge"})
+	if cfg.Agent != "purelb-system/zzz-scoped" {
+		t.Errorf("governing agent = %q, want the specific selector to win", cfg.Agent)
+	}
+	if len(cfg.Ignored) != 1 || cfg.Ignored[0] != "purelb-system/aaa-catchall" {
+		t.Errorf("ignored = %v, want the catch-all listed", cfg.Ignored)
+	}
+
+	// A node the specific selector does not match falls back to the catch-all
+	// with nothing ignored.
+	cfg = resolveNodeConfig(agents, map[string]string{"role": "worker"})
+	if cfg.Agent != "purelb-system/aaa-catchall" || len(cfg.Ignored) != 0 {
+		t.Errorf("non-matching node: agent=%q ignored=%v", cfg.Agent, cfg.Ignored)
+	}
+}
+
+func TestLocalInterfaceIssues(t *testing.T) {
+	tests := []struct {
+		pattern    string
+		invalid    bool
+		unanchored bool
+	}{
+		{"default", false, false},
+		{"", false, false}, // agent treats empty as "default"
+		{"^eth1$", false, false},
+		{"^(eth0|eth1)$", false, false},
+		{"eth", false, true},   // matches veth1a2b3c too
+		{"^eth1", false, true}, // half-anchored
+		{"eth1$", false, true}, // half-anchored
+		{"[", true, false},     // does not compile
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			invalid, unanchored := localInterfaceIssues(tt.pattern)
+			if invalid != tt.invalid || unanchored != tt.unanchored {
+				t.Errorf("localInterfaceIssues(%q) = (%v,%v), want (%v,%v)",
+					tt.pattern, invalid, unanchored, tt.invalid, tt.unanchored)
+			}
+		})
+	}
+}
+
+// TestDummyInterfacesDeterministic covers the bug where callers read list
+// item [0]: with several resources the answer depended on list order, and a
+// second distinct name was invisible.
+func TestDummyInterfacesDeterministic(t *testing.T) {
+	withDummy := func(name, dummy string) *unstructured.Unstructured {
+		return makeLBNA(name, map[string]interface{}{
+			"local": map[string]interface{}{"localInterface": "default", "dummyInterface": dummy},
+		})
+	}
+
+	agents := decodeLBNodeAgents(lbnaListOf(withDummy("b", "kube-lb1"), withDummy("a", "kube-lb0")))
+	got := dummyInterfaces(agents)
+	if len(got) != 2 || got[0] != "kube-lb0" || got[1] != "kube-lb1" {
+		t.Errorf("dummyInterfaces = %v, want sorted [kube-lb0 kube-lb1]", got)
+	}
+
+	// Reversed input order must give the same answer.
+	reversed := decodeLBNodeAgents(lbnaListOf(withDummy("a", "kube-lb0"), withDummy("b", "kube-lb1")))
+	if got2 := dummyInterfaces(reversed); got2[0] != got[0] || got2[1] != got[1] {
+		t.Errorf("order-dependent result: %v vs %v", got, got2)
+	}
+
+	if got := dummyInterfaces(nil); len(got) != 1 || got[0] != defaultDummyInterface {
+		t.Errorf("no agents should default to %q, got %v", defaultDummyInterface, got)
+	}
+}
+
+func TestDummyInterfaceForNode(t *testing.T) {
+	agents := decodeLBNodeAgents(lbnaListOf(
+		makeLBNA("default", map[string]interface{}{
+			"local": map[string]interface{}{"localInterface": "default", "dummyInterface": "kube-lb0"},
+		}),
+		makeLBNA("edge", map[string]interface{}{
+			"nodeSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"role": "edge"},
+			},
+			"local": map[string]interface{}{"localInterface": "default", "dummyInterface": "edge-lb0"},
+		}),
+	))
+
+	if got := dummyInterfaceForNode(agents, map[string]string{"role": "edge"}); got != "edge-lb0" {
+		t.Errorf("edge node dummy = %q, want edge-lb0", got)
+	}
+	if got := dummyInterfaceForNode(agents, map[string]string{"role": "worker"}); got != "kube-lb0" {
+		t.Errorf("worker node dummy = %q, want kube-lb0", got)
+	}
+}
+
+func TestAnnounceState(t *testing.T) {
+	healthy := map[string]bool{"node-a": true}
+	announcers := map[string]announcement{
+		"10.0.0.1": {Node: "node-a", Interface: "eth0", IP: "10.0.0.1"},
+		"10.0.0.2": {Node: "node-dead", Interface: "eth0", IP: "10.0.0.2"},
+	}
+
+	tests := []struct {
+		name     string
+		ip       string
+		poolType string
+		want     string
+	}{
+		{"announced by a healthy node", "10.0.0.1", poolTypeLocal, svcStatusOK},
+		{"announced by a dead node", "10.0.0.2", poolTypeLocal, svcStatusAnnouncerUnhealthy},
+		{"local pool with no announcer", "10.0.0.3", poolTypeLocal, svcStatusNoAnnouncer},
+		{"remote pool needs no annotation", "10.0.0.3", poolTypeRemote, svcStatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := announceState(announcers, tt.ip, tt.poolType, healthy); got != tt.want {
+				t.Errorf("announceState = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveNodeConfigContested separates the two multi-match cases: a
+// specific selector beating a catch-all resolves unambiguously, while two
+// specific selectors are decided only by namespace/name order.
+func TestResolveNodeConfigContested(t *testing.T) {
+	specific := func(name, key, value string) *unstructured.Unstructured {
+		return makeLBNA(name, map[string]interface{}{
+			"nodeSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{key: value},
+			},
+			"local": map[string]interface{}{"localInterface": "default"},
+		})
+	}
+
+	labels := map[string]string{"role": "edge", "tier": "front"}
+
+	override := decodeLBNodeAgents(lbnaListOf(
+		makeLBNA("catchall", localSpec("default")),
+		specific("scoped", "role", "edge"),
+	))
+	cfg := resolveNodeConfig(override, labels)
+	if cfg.Contested {
+		t.Errorf("specific-over-catch-all must not be contested: %+v", cfg)
+	}
+	if len(cfg.Ignored) != 1 {
+		t.Errorf("expected the catch-all to be listed as overridden, got %v", cfg.Ignored)
+	}
+
+	collision := decodeLBNodeAgents(lbnaListOf(
+		specific("aaa-by-role", "role", "edge"),
+		specific("zzz-by-tier", "tier", "front"),
+	))
+	cfg = resolveNodeConfig(collision, labels)
+	if !cfg.Contested {
+		t.Errorf("two specific selectors must be contested: %+v", cfg)
+	}
+	if cfg.Agent != "purelb-system/aaa-by-role" {
+		t.Errorf("winner = %q, want the name-sorted first", cfg.Agent)
+	}
+
+	// An empty selector is a catch-all, so it must not make a node contested.
+	withEmpty := decodeLBNodeAgents(lbnaListOf(
+		makeLBNA("empty-selector", map[string]interface{}{
+			"nodeSelector": map[string]interface{}{},
+			"local":        map[string]interface{}{"localInterface": "default"},
+		}),
+		specific("scoped", "role", "edge"),
+	))
+	if cfg := resolveNodeConfig(withEmpty, labels); cfg.Contested {
+		t.Errorf("empty selector is a catch-all, must not contest: %+v", cfg)
+	}
+}
+
+func epSlice(svcName string, entries ...struct {
+	node          string
+	ready         bool
+	serving       bool
+	nodeNameIsNil bool
+}) discoveryv1.EndpointSlice {
+	slice := discoveryv1.EndpointSlice{}
+	slice.Labels = map[string]string{"kubernetes.io/service-name": svcName}
+	for _, e := range entries {
+		ep := discoveryv1.Endpoint{
+			Conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(e.ready),
+				Serving: ptr.To(e.serving),
+			},
+		}
+		if !e.nodeNameIsNil {
+			node := e.node
+			ep.NodeName = &node
+		}
+		slice.Endpoints = append(slice.Endpoints, ep)
+	}
+	return slice
+}
+
+type epEntry = struct {
+	node          string
+	ready         bool
+	serving       bool
+	nodeNameIsNil bool
+}
+
+func TestPreferredNodesForService(t *testing.T) {
+	slices := []discoveryv1.EndpointSlice{
+		epSlice("web",
+			epEntry{node: "node-a", ready: true, serving: true},
+			epEntry{node: "node-b", ready: false, serving: false}, // neither: skipped
+			epEntry{node: "node-c", ready: false, serving: true},  // serving only: kept
+			epEntry{node: "node-a", ready: true, serving: true},   // duplicate node
+			epEntry{nodeNameIsNil: true, ready: true, serving: true},
+		),
+	}
+
+	t.Run("no annotation means no affinity", func(t *testing.T) {
+		if got := preferredNodesForService(map[string]string{}, slices); got != nil {
+			t.Errorf("expected nil without the annotation, got %v", got)
+		}
+	})
+
+	t.Run("ready or serving, deduplicated, nil node skipped", func(t *testing.T) {
+		got := preferredNodesForService(
+			map[string]string{annotationNodeAffinity: nodeAffinityServiceEndpoints}, slices)
+		if len(got) != 2 || got[0] != "node-a" || got[1] != "node-c" {
+			t.Errorf("preferred = %v, want [node-a node-c]", got)
+		}
+	})
+
+	t.Run("shared IPs opt out", func(t *testing.T) {
+		got := preferredNodesForService(map[string]string{
+			annotationNodeAffinity: nodeAffinityServiceEndpoints,
+			annotationSharing:      "shared-key",
+		}, slices)
+		if got != nil {
+			t.Errorf("shared services must not use affinity, got %v", got)
+		}
+	})
+}
+
+// TestPredictWinner covers the bug where inspect predicted the plain-hash
+// winner for affinity services and then reported a false
+// "DOES NOT MATCH ANNOUNCER".
+func TestPredictWinner(t *testing.T) {
+	candidates := []string{"node-a", "node-b", "node-c"}
+
+	t.Run("no affinity uses the plain hash", func(t *testing.T) {
+		got, applied, fellBack := predictWinner("10.0.0.1", candidates, nil)
+		if got != electionWinner("10.0.0.1", candidates) {
+			t.Errorf("winner = %q, want the plain-hash winner", got)
+		}
+		if applied || fellBack {
+			t.Errorf("flags = (%v,%v), want (false,false)", applied, fellBack)
+		}
+	})
+
+	t.Run("affinity narrows the candidate set", func(t *testing.T) {
+		got, applied, fellBack := predictWinner("10.0.0.1", candidates, []string{"node-c"})
+		if got != "node-c" {
+			t.Errorf("winner = %q, want node-c (the only preferred candidate)", got)
+		}
+		if !applied || fellBack {
+			t.Errorf("flags = (%v,%v), want (true,false)", applied, fellBack)
+		}
+	})
+
+	t.Run("preferred node that cannot serve the subnet falls back", func(t *testing.T) {
+		got, applied, fellBack := predictWinner("10.0.0.1", candidates, []string{"node-z"})
+		if got != electionWinner("10.0.0.1", candidates) {
+			t.Errorf("winner = %q, want the plain-hash winner on fallback", got)
+		}
+		if applied || !fellBack {
+			t.Errorf("flags = (%v,%v), want (false,true)", applied, fellBack)
+		}
+	})
+
+	t.Run("no candidates", func(t *testing.T) {
+		if got, _, _ := predictWinner("10.0.0.1", nil, []string{"node-a"}); got != "" {
+			t.Errorf("winner = %q, want empty", got)
+		}
+	})
+}

--- a/cmd/kubectl-purelb/services.go
+++ b/cmd/kubectl-purelb/services.go
@@ -136,7 +136,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 					Name:      svc.Name,
 					IP:        "<pending>",
 					Pool:      ann[annotationServiceGroup],
-					Status:    "PENDING",
+					Status:    svcStatusPending,
 				}
 				if filterPool == "" || row.Pool == filterPool {
 					rows = append(rows, row)
@@ -151,12 +151,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 
 		// Parse announcing annotations for both families (local pools only;
 		// remote pools derive the interface from the LBNodeAgent CR).
-		announcers := map[string]announcement{} // ip -> announcement
-		for _, suffix := range []string{"-IPv4", "-IPv6"} {
-			for _, a := range parseAnnouncingAnnotation(ann[annotationAnnouncing+suffix]) {
-				announcers[a.IP] = a
-			}
-		}
+		announcers := serviceAnnouncers(ann)
 
 		// Build port string for sharing display
 		portStrs := []string{}
@@ -175,7 +170,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 				Pool:       poolName,
 				PoolType:   poolType,
 				SharingKey: sharingKey,
-				Status:     "PENDING",
+				Status:     svcStatusPending,
 			}
 			rows = append(rows, row)
 			continue
@@ -187,22 +182,18 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 				continue
 			}
 
-			// Determine announcer and status
+			// Determine announcer and status. announceState is shared with
+			// `status` so the per-IP verdict is defined in exactly one place.
 			announcing := ""
-			status := "OK"
+			status := announceState(announcers, ipStr, poolType, healthyNodes)
 
 			if a, ok := announcers[ipStr]; ok {
 				announcing = a.Node + "/" + a.Interface
-				if !healthyNodes[a.Node] {
-					status = "ANNOUNCER UNHEALTHY"
-				}
 			} else if poolType == poolTypeRemote {
 				// Remote pools: all nodes announce on the dummy interface.
 				// Derive the name from the LBNodeAgent CR instead of an
 				// annotation to avoid a write storm from multiple agents.
 				announcing = dummyIface
-			} else {
-				status = "NO ANNOUNCER"
 			}
 
 			row := svcRow{
@@ -226,7 +217,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 			if filterIP != "" && ipStr != filterIP {
 				continue
 			}
-			if problemsOnly && status == "OK" {
+			if problemsOnly && status == svcStatusOK {
 				continue
 			}
 
@@ -312,7 +303,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 		}
 
 		statusMarker := r.Status
-		if r.Status != "OK" && r.Status != "PENDING" {
+		if r.Status != svcStatusOK && r.Status != svcStatusPending {
 			statusMarker = r.Status + "  ***"
 		}
 

--- a/cmd/kubectl-purelb/snapshot.go
+++ b/cmd/kubectl-purelb/snapshot.go
@@ -36,6 +36,9 @@ type clusterSnapshot struct {
 	leases          *coordinationv1.LeaseList
 	bgpNodeStatuses *unstructured.UnstructuredList
 	lbNodeAgents    *unstructured.UnstructuredList
+	// nodes carries node labels, needed to resolve which LBNodeAgent
+	// (if any) selects each node.
+	nodes *v1.NodeList
 }
 
 // fetchSnapshot fetches all resources needed by the dashboard in parallel.
@@ -99,6 +102,15 @@ func fetchSnapshot(ctx context.Context, c *clients) (*clusterSnapshot, error) {
 		snap.lbNodeAgents, err = c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("listing LBNodeAgents: %w", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		var err error
+		snap.nodes, err = c.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		if err != nil {
+			return fmt.Errorf("listing nodes: %w", err)
 		}
 		return nil
 	})

--- a/cmd/kubectl-purelb/status.go
+++ b/cmd/kubectl-purelb/status.go
@@ -90,6 +90,8 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
 	leaseList, _ := c.core.CoordinationV1().Leases(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	bgpnsList, _ := c.dynamic.Resource(gvrBGPNodeStatuses).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	nodeList, _ := c.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 	snap := &clusterSnapshot{
 		pods:            pods,
@@ -97,6 +99,8 @@ func runStatus(ctx context.Context, c *clients, format outputFormat) error {
 		serviceGroups:   sgList,
 		leases:          leaseList,
 		bgpNodeStatuses: bgpnsList,
+		lbNodeAgents:    lbnaList,
+		nodes:           nodeList,
 	}
 	return renderStatus(snap, format)
 }
@@ -232,6 +236,33 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 		warnings = append(warnings, fmt.Sprintf("%d node(s) unhealthy", totalNodes-healthyCount))
 	}
 
+	// A node can hold a perfectly healthy lease and still announce nothing,
+	// because no LBNodeAgent nodeSelector selects it or because its
+	// localInterface regex is invalid. Counting only lease health would
+	// report such a cluster as fully operational.
+	agents := decodeLBNodeAgents(snap.lbNodeAgents)
+	deselected, invalidCfg := 0, 0
+	if snap.nodes != nil {
+		for i := range snap.nodes.Items {
+			switch resolveNodeConfig(agents, snap.nodes.Items[i].Labels).State {
+			case configStateDeselected:
+				deselected++
+			case configStateInvalid:
+				invalidCfg++
+			}
+		}
+	}
+	if deselected > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d node(s) selected by no LBNodeAgent", deselected))
+	}
+	if invalidCfg > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d node(s) with invalid localInterface", invalidCfg))
+	}
+	electionSummaryStr := fmt.Sprintf("%d/%d nodes healthy | %d subnets covered", healthyCount, totalNodes, len(subnetSet))
+	if deselected > 0 || invalidCfg > 0 {
+		electionSummaryStr += fmt.Sprintf(" | %d node(s) announcing nothing", deselected+invalidCfg)
+	}
+
 	// === BGP ===
 	bgp := detectBGPState(snap.bgpNodeStatuses, pods)
 	bgpSummary := bgp.statusSummary()
@@ -245,30 +276,53 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 	}
 
 	// === Services ===
+	// Two distinct problems are counted here: services awaiting allocation,
+	// and allocated addresses that nothing is announcing. The second used to
+	// be invisible, so a cluster where every VIP had lost its announcer still
+	// reported "Overall: OK" while `services` reported the same addresses as
+	// NO ANNOUNCER. announceState is now the shared verdict for both views.
 	totalSvcs := 0
 	totalIPs := 0
-	svcProblems := 0
+	pendingSvcs := 0
+	unannouncedIPs := 0
+
+	var healthyNodes map[string]bool
+	if snap.leases != nil {
+		healthyNodes = buildHealthyNodeSet(snap.leases.Items)
+	} else {
+		healthyNodes = map[string]bool{}
+	}
 
 	if snap.services != nil {
 		for _, svc := range snap.services.Items {
 			ann := svc.Annotations
 			if ann == nil || ann[annotationAllocatedBy] != brandPureLB {
+				if svc.Spec.Type == v1.ServiceTypeLoadBalancer && ann != nil && ann[annotationServiceGroup] != "" {
+					pendingSvcs++
+				}
 				continue
 			}
 			totalSvcs++
 			totalIPs += len(svc.Status.LoadBalancer.Ingress)
-		}
-		for _, svc := range snap.services.Items {
-			if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-				ann := svc.Annotations
-				if ann != nil && ann[annotationServiceGroup] != "" && ann[annotationAllocatedBy] != brandPureLB {
-					svcProblems++
+
+			announcers := serviceAnnouncers(ann)
+			poolType := ann[annotationPoolType]
+			for _, ingress := range svc.Status.LoadBalancer.Ingress {
+				if ingress.IP == "" {
+					continue
+				}
+				if announceState(announcers, ingress.IP, poolType, healthyNodes) != svcStatusOK {
+					unannouncedIPs++
 				}
 			}
 		}
 	}
-	if svcProblems > 0 {
-		warnings = append(warnings, fmt.Sprintf("%d service(s) pending", svcProblems))
+	svcProblems := pendingSvcs + unannouncedIPs
+	if pendingSvcs > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d service(s) pending", pendingSvcs))
+	}
+	if unannouncedIPs > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d IP(s) not announced", unannouncedIPs))
 	}
 
 	// === Overall ===
@@ -280,7 +334,7 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 	overview := statusOverview{
 		Components: comp,
 		Pools:      poolStatus{Summary: strings.Join(poolParts, " | ")},
-		Election:   electionStatus{Summary: fmt.Sprintf("%d/%d nodes healthy | %d subnets covered", healthyCount, totalNodes, len(subnetSet))},
+		Election:   electionStatus{Summary: electionSummaryStr},
 		BGP:        bgpStatus{Summary: bgpSummary},
 		Services:   svcStatus{Summary: fmt.Sprintf("%d services, %d IPs | %d problem(s)", totalSvcs, totalIPs, svcProblems)},
 		Overall:    overall,

--- a/cmd/kubectl-purelb/util.go
+++ b/cmd/kubectl-purelb/util.go
@@ -43,6 +43,12 @@ const (
 	annotationMultiPool     = "purelb.io/multi-pool"
 	annotationReEvaluate    = "purelb.io/re-evaluate"
 	annotationAllowLocal    = "purelb.io/allow-local"
+	annotationNodeAffinity  = "purelb.io/node-affinity"
+
+	// nodeAffinityServiceEndpoints is the only supported value of the
+	// node-affinity annotation: bias each address's election toward nodes
+	// hosting Ready/Serving endpoints.
+	nodeAffinityServiceEndpoints = "service-endpoints"
 
 	brandPureLB = "PureLB"
 
@@ -69,30 +75,59 @@ const (
 	familyV6 = 10
 )
 
-// dummyInterfaceName returns the dummy interface name from the LBNodeAgent CR,
-// defaulting to "kube-lb0" if not configured or not found.
+// dummyInterfaceName returns the dummy interface name configured by the
+// LBNodeAgent resources, defaulting to "kube-lb0". When several resources
+// configure different names it returns them comma-joined rather than picking
+// one arbitrarily — with nodeSelector-scoped resources the name is per-node,
+// so callers without a node in hand cannot resolve a single answer.
 func dummyInterfaceName(ctx context.Context, c *clients) string {
 	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
-	if lbnaList != nil && len(lbnaList.Items) > 0 {
-		di, _, _ := unstructured.NestedString(lbnaList.Items[0].Object, "spec", "local", "dummyInterface")
-		if di != "" {
-			return di
-		}
-	}
-	return "kube-lb0"
+	return strings.Join(dummyInterfaces(decodeLBNodeAgents(lbnaList)), ",")
 }
 
-// resolveDummyInterface extracts the dummy interface name from a pre-fetched
-// LBNodeAgent list, defaulting to "kube-lb0". Use this when the list is already
-// available (e.g., from a clusterSnapshot) to avoid an extra API call.
+// resolveDummyInterface extracts the dummy interface name(s) from a
+// pre-fetched LBNodeAgent list. Use this when the list is already available
+// (e.g., from a clusterSnapshot) to avoid an extra API call.
 func resolveDummyInterface(lbnaList *unstructured.UnstructuredList) string {
-	if lbnaList != nil && len(lbnaList.Items) > 0 {
-		di, _, _ := unstructured.NestedString(lbnaList.Items[0].Object, "spec", "local", "dummyInterface")
-		if di != "" {
-			return di
+	return strings.Join(dummyInterfaces(decodeLBNodeAgents(lbnaList)), ",")
+}
+
+// Per-IP announcement status values, shared by the `services` table and the
+// `status` problem count so the two views cannot disagree.
+const (
+	svcStatusOK                 = "OK"
+	svcStatusPending            = "PENDING"
+	svcStatusNoAnnouncer        = "NO ANNOUNCER"
+	svcStatusAnnouncerUnhealthy = "ANNOUNCER UNHEALTHY"
+)
+
+// serviceAnnouncers builds an ip -> announcement map from a service's
+// announcing-IPv4/-IPv6 annotations.
+func serviceAnnouncers(ann map[string]string) map[string]announcement {
+	announcers := map[string]announcement{}
+	for _, suffix := range []string{"-IPv4", "-IPv6"} {
+		for _, a := range parseAnnouncingAnnotation(ann[annotationAnnouncing+suffix]) {
+			announcers[a.IP] = a
 		}
 	}
-	return "kube-lb0"
+	return announcers
+}
+
+// announceState classifies one allocated service IP. Remote-pool addresses
+// live on every node's dummy interface and carry no per-node annotation, so
+// their absence is normal; for a local pool it means nothing is answering ARP
+// or ND for that address.
+func announceState(announcers map[string]announcement, ip, poolType string, healthyNodes map[string]bool) string {
+	if a, ok := announcers[ip]; ok {
+		if !healthyNodes[a.Node] {
+			return svcStatusAnnouncerUnhealthy
+		}
+		return svcStatusOK
+	}
+	if poolType == poolTypeRemote {
+		return svcStatusOK
+	}
+	return svcStatusNoAnnouncer
 }
 
 // addrFamily returns the address family of an IP address.

--- a/cmd/kubectl-purelb/validate.go
+++ b/cmd/kubectl-purelb/validate.go
@@ -22,8 +22,11 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -104,13 +107,12 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 		}
 	}
 
-	// Get dummy interface name from LBNodeAgent (using already-fetched lbnaList)
-	dummyInterface := "kube-lb0"
-	if len(lbnaList.Items) > 0 {
-		if di, _, _ := unstructured.NestedString(lbnaList.Items[0].Object, "spec", "local", "dummyInterface"); di != "" {
-			dummyInterface = di
-		}
-	}
+	// Dummy interface names configured across all LBNodeAgents. With
+	// nodeSelector-scoped resources different nodes can use different names,
+	// so BGP netlinkImport has to cover every one of them; reading only the
+	// first resource in list order would check an arbitrary node's name.
+	agents := decodeLBNodeAgents(lbnaList)
+	dummyInterfaceNames := dummyInterfaces(agents)
 
 	// ========== Pool checks ==========
 	hasRemotePool := false
@@ -244,11 +246,92 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 	}
 
 	// ========== LBNodeAgent checks ==========
-	if len(lbnaList.Items) == 0 {
+	if len(agents) == 0 {
 		checks = append(checks, checkResult{"WARN", "No LBNodeAgent configured"})
 	} else {
-		for _, lbna := range lbnaList.Items {
-			checks = append(checks, checkResult{"PASS", fmt.Sprintf("LBNodeAgent %q: configured", lbna.GetName())})
+		for _, agent := range agents {
+			name := agentName(agent)
+
+			// A nodeSelector that matches nothing is dead configuration:
+			// the resource exists but governs no node.
+			matchCount := 0
+			if nodeList != nil {
+				for i := range nodeList.Items {
+					if matchesNode(agent, nodeList.Items[i].Labels) {
+						matchCount++
+					}
+				}
+			}
+			switch {
+			case nodeList == nil:
+				checks = append(checks, checkResult{"PASS", fmt.Sprintf("LBNodeAgent %q: configured", name)})
+			case matchCount == 0:
+				checks = append(checks, checkResult{"WARN", fmt.Sprintf(
+					"LBNodeAgent %q: nodeSelector matches 0 of %d nodes (configuration has no effect)", name, len(nodeList.Items))})
+			default:
+				scope := "all nodes"
+				if agent.Spec.NodeSelector != nil {
+					scope = fmt.Sprintf("%d of %d nodes", matchCount, len(nodeList.Items))
+				}
+				checks = append(checks, checkResult{"PASS", fmt.Sprintf("LBNodeAgent %q: configured, selects %s", name, scope)})
+			}
+
+			// localInterface is a regex unless it is "default", and both the
+			// announcer and the election match it UNANCHORED.
+			if agent.Spec.Local != nil {
+				pattern := agent.Spec.Local.LocalInterface
+				invalid, unanchored := localInterfaceIssues(pattern)
+				switch {
+				case invalid:
+					checks = append(checks, checkResult{"FAIL", fmt.Sprintf(
+						"LBNodeAgent %q: localInterface %q is not a valid regex — selected nodes announce nothing", name, pattern)})
+				case unanchored:
+					checks = append(checks, checkResult{"WARN", fmt.Sprintf(
+						"LBNodeAgent %q: localInterface %q is unanchored — it matches any interface name containing %q, including pod veth interfaces; anchor it as %q",
+						name, pattern, pattern, "^"+pattern+"$")})
+				}
+			}
+		}
+
+		// Nodes that no LBNodeAgent selects announce nothing at all. This is
+		// legitimate (deliberately excluding a node) but silent otherwise.
+		if nodeList != nil {
+			var orphans, overridden, contested []string
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				cfg := resolveNodeConfig(agents, node.Labels)
+				if cfg.State == configStateDeselected {
+					orphans = append(orphans, node.Name)
+				}
+				if len(cfg.Ignored) == 0 {
+					continue
+				}
+				detail := fmt.Sprintf("%s (using %s, over %s)", node.Name, cfg.Agent, strings.Join(cfg.Ignored, ", "))
+				if cfg.Contested {
+					contested = append(contested, detail)
+				} else {
+					overridden = append(overridden, detail)
+				}
+			}
+			if len(orphans) > 0 {
+				checks = append(checks, checkResult{"WARN", fmt.Sprintf(
+					"%d node(s) selected by no LBNodeAgent, announcing nothing: %s", len(orphans), strings.Join(orphans, ", "))})
+			}
+			// A specific selector beating a catch-all is the documented
+			// default-plus-override pattern: report which resource governs,
+			// but do not warn — otherwise a correct configuration could never
+			// validate clean, and --strict would fail CI on it.
+			if len(overridden) > 0 {
+				checks = append(checks, checkResult{"PASS", fmt.Sprintf(
+					"%d node(s) using a scoped LBNodeAgent override: %s", len(overridden), strings.Join(overridden, "; "))})
+			}
+			// Two specific selectors matching one node is genuinely ambiguous:
+			// the winner is decided only by namespace/name sort order.
+			if len(contested) > 0 {
+				checks = append(checks, checkResult{"WARN", fmt.Sprintf(
+					"%d node(s) matched by multiple specific nodeSelectors, resolved by name order: %s",
+					len(contested), strings.Join(contested, "; "))})
+			}
 		}
 	}
 
@@ -264,18 +347,23 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 			if !importEnabled {
 				checks = append(checks, checkResult{"WARN", fmt.Sprintf("BGPConfiguration %q: netlinkImport disabled (k8gobgp will advertise NO routes)", cfgName)})
 			} else {
-				// Check interface match
-				found := false
+				// Every dummy interface in use must be watched, not just one:
+				// nodeSelector-scoped LBNodeAgents may configure different
+				// names on different nodes.
+				watched := map[string]bool{}
 				for _, iface := range importInterfaces {
-					if iface == dummyInterface {
-						found = true
-						break
+					watched[iface] = true
+				}
+				var missing []string
+				for _, name := range dummyInterfaceNames {
+					if !watched[name] {
+						missing = append(missing, name)
 					}
 				}
-				if found {
-					checks = append(checks, checkResult{"PASS", fmt.Sprintf("BGPConfiguration %q: netlinkImport enabled, watching %v (matches LBNodeAgent dummyInterface %q)", cfgName, importInterfaces, dummyInterface)})
+				if len(missing) == 0 {
+					checks = append(checks, checkResult{"PASS", fmt.Sprintf("BGPConfiguration %q: netlinkImport enabled, watching %v (covers LBNodeAgent dummyInterface(s) %v)", cfgName, importInterfaces, dummyInterfaceNames)})
 				} else {
-					checks = append(checks, checkResult{"FAIL", fmt.Sprintf("BGPConfiguration %q: netlinkImport interfaces %v do not include LBNodeAgent dummyInterface %q", cfgName, importInterfaces, dummyInterface)})
+					checks = append(checks, checkResult{"FAIL", fmt.Sprintf("BGPConfiguration %q: netlinkImport interfaces %v do not include LBNodeAgent dummyInterface(s) %v", cfgName, importInterfaces, missing)})
 				}
 			}
 
@@ -293,22 +381,17 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 				addr, _ := config["neighborAddress"].(string)
 				peerASN, _ := config["peerAsn"].(int64)
 
-				// Check if nodeSelector matches any nodes
+				// Check if nodeSelector matches any nodes. Full label-selector
+				// semantics: the previous matchLabels-only comparison silently
+				// treated a matchExpressions-based selector as matching
+				// everything, hiding a neighbor that reaches no node.
 				selectorRaw, hasSelector := n["nodeSelector"]
 				if hasSelector && selectorRaw != nil && nodeList != nil {
-					matchCount := 0
-					selector, ok := selectorRaw.(map[string]interface{})
-					if ok {
-						matchLabels, _ := selector["matchLabels"].(map[string]interface{})
-						if matchLabels != nil {
-							for _, node := range nodeList.Items {
-								if labelsMatch(node.Labels, matchLabels) {
-									matchCount++
-								}
-							}
-						}
-					}
-					if matchCount == 0 {
+					count, err := countMatchingNodes(selectorRaw, nodeList.Items)
+					switch {
+					case err != nil:
+						checks = append(checks, checkResult{"FAIL", fmt.Sprintf("BGPConfiguration %q: neighbor %s (AS %d) has an invalid nodeSelector: %v", cfgName, addr, peerASN, err)})
+					case count == 0:
 						checks = append(checks, checkResult{"FAIL", fmt.Sprintf("BGPConfiguration %q: neighbor %s (AS %d) nodeSelector matches 0 nodes", cfgName, addr, peerASN)})
 					}
 				}
@@ -363,12 +446,28 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 }
 
 // labelsMatch checks if a node's labels contain all the required matchLabels.
-func labelsMatch(nodeLabels map[string]string, matchLabels map[string]interface{}) bool {
-	for k, v := range matchLabels {
-		expected, _ := v.(string)
-		if nodeLabels[k] != expected {
-			return false
+// countMatchingNodes evaluates an unstructured label selector against the
+// given nodes with full Kubernetes semantics (matchLabels AND
+// matchExpressions), so selectors the plugin cannot interpret surface as an
+// error rather than silently matching everything.
+func countMatchingNodes(selectorRaw interface{}, nodes []v1.Node) (int, error) {
+	raw, ok := selectorRaw.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("nodeSelector is not an object")
+	}
+	labelSelector := &metav1.LabelSelector{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, labelSelector); err != nil {
+		return 0, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for i := range nodes {
+		if selector.Matches(labels.Set(nodes[i].Labels)) {
+			count++
 		}
 	}
-	return true
+	return count, nil
 }

--- a/cmd/lbnodeagent/main.go
+++ b/cmd/lbnodeagent/main.go
@@ -16,16 +16,49 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"purelb.io/internal/election"
 	"purelb.io/internal/k8s"
 	"purelb.io/internal/logging"
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
+
+// selectorState reports which interface-selector state this node is
+// in: 1 for the active state, 0 for the others. The four states are
+// otherwise indistinguishable from the outside (config_loaded_bool
+// keeps reporting the previous good config during an invalid-config
+// outage).
+var selectorState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: purelbv2.MetricsNamespace,
+	Subsystem: "lbnodeagent",
+	Name:      "selector_state",
+	Help:      "Interface selector state (1 = active): default, configured, deselected, invalid",
+}, []string{"state"})
+
+func init() {
+	prometheus.MustRegister(selectorState)
+}
+
+func recordSelectorState(active string) {
+	for _, state := range []string{"default", "configured", "deselected", "invalid"} {
+		value := 0.0
+		if state == active {
+			value = 1.0
+		}
+		selectorState.WithLabelValues(state).Set(value)
+	}
+}
 
 // parseDurationEnv parses a duration from an environment variable, returning
 // the default if the env var is not set or cannot be parsed.
@@ -88,7 +121,108 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := k8s.New(&k8s.Config{
+	// selector bridges config delivery (CR-controller goroutine, via
+	// configChanged below) to the election's renewLoop goroutine, which
+	// reads it through the GetLocalSubnets closure. It is the only
+	// shared state in this file; everything else is per-delivery locals.
+	// nil means "no config yet / remote-only": the election falls back
+	// to default-interface detection, today's behavior. An empty
+	// selector means "advertise nothing".
+	var selector atomic.Pointer[election.InterfaceSelector]
+
+	// client is captured by configChanged before it is assigned. That is
+	// safe because the k8s client only invokes callbacks from inside
+	// client.Run(), which happens-after the assignment below.
+	var client *k8s.Client
+
+	// configChanged wraps ctrl.SetConfig with nodeSelector evaluation
+	// and keeps the election selector coherent with the announcer: the
+	// lease must never advertise a subnet the announcer cannot announce
+	// on. Convergence after a config change is two-wave: wave 1
+	// reprocesses services against the stale lease subnets; wave 2
+	// follows the next lease renewal (≤2.5s) plus informer propagation.
+	configChanged := func(cfg *purelbv2.Config) k8s.SyncState {
+		// Fetch our Node's labels fresh per delivery — no stored label
+		// state. Like a Pod's nodeSelector, label changes take effect
+		// when config is next delivered (CR event, informer resync, or
+		// pod restart), not continuously.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		node, err := client.Clientset().CoreV1().Nodes().Get(ctx, *myNode, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			// SyncStateError makes the CR controller requeue this
+			// delivery with backoff; config is not applied.
+			logging.Info(logger, "op", "configChanged", "error", err,
+				"msg", "failed to get node for nodeSelector evaluation, delivery will be retried")
+			return k8s.SyncStateError
+		}
+
+		for _, agent := range cfg.Agents {
+			logging.Debug(logger, "op", "configChanged", "agent", agent.Namespace+"/"+agent.Name,
+				"hasNodeSelector", fmt.Sprintf("%t", agent.Spec.NodeSelector != nil))
+		}
+
+		preFilter := len(cfg.Agents)
+		cfg.Agents = purelbv2.AgentsForNode(cfg.Agents, node.Labels)
+		if len(cfg.Agents) > 1 {
+			winner := cfg.Agents[0]
+			for _, ignored := range cfg.Agents[1:] {
+				logging.Info(logger, "op", "configChanged", "msg", "multiple LBNodeAgents match this node, using highest precedence",
+					"node", *myNode, "using", winner.Namespace+"/"+winner.Name, "ignoring", ignored.Namespace+"/"+ignored.Name)
+				client.Errorf(ignored, "ConfigIgnored",
+					"LBNodeAgent %s/%s takes precedence on node %s", winner.Namespace, winner.Name, *myNode)
+			}
+		}
+
+		// Announcer first: the selector is stored only after we know
+		// whether the announcer accepted the config, so the lease can
+		// never advertise what the announcer failed to configure.
+		ret := ctrl.SetConfig(cfg)
+
+		state := "default"
+		switch {
+		case ret == k8s.SyncStateError:
+			// Invalid regex, dummy-interface failure, any announcer
+			// config failure: the announcer announces nothing, so the
+			// lease must advertise nothing.
+			selector.Store(&election.InterfaceSelector{})
+			state = "invalid"
+			if offending := purelbv2.FirstLocalAgent(cfg.Agents); offending != nil {
+				client.Errorf(offending, "ConfigError",
+					"invalid configuration: node %s is announcing nothing until this is fixed", *myNode)
+			}
+		case preFilter > 0 && len(cfg.Agents) == 0:
+			// Every CR's nodeSelector deselected this node: the
+			// announcer is unconfigured, so advertise nothing. (A
+			// default fallback here would win elections it cannot
+			// serve — a blackhole.)
+			selector.Store(&election.InterfaceSelector{})
+			state = "deselected"
+		default:
+			sel, selErr := election.SelectorFromConfig(cfg)
+			if selErr != nil {
+				// Cannot happen when SetConfig succeeded (same regex,
+				// same agent), but stay coherent if it ever does.
+				selector.Store(&election.InterfaceSelector{})
+				state = "invalid"
+			} else {
+				// sel is nil for remote-only clusters (no Local spec):
+				// keep the default-detection lease, today's behavior.
+				selector.Store(sel)
+				if sel != nil {
+					state = "configured"
+				}
+			}
+		}
+		recordSelectorState(state)
+		logging.Info(logger, "op", "configChanged", "selectorState", state,
+			"node", *myNode, "matchingAgents", fmt.Sprintf("%d", len(cfg.Agents)),
+			"msg", "config delivery evaluated")
+
+		return ret
+	}
+
+	client, err = k8s.New(&k8s.Config{
 		ProcessName:        "purelb-lbnodeagent",
 		NodeName:           *myNode,
 		Logger:             logger,
@@ -97,7 +231,7 @@ func main() {
 
 		ServiceChanged: ctrl.ServiceChanged,
 		ServiceDeleted: ctrl.DeleteBalancer,
-		ConfigChanged:  ctrl.SetConfig,
+		ConfigChanged:  configChanged,
 		// Note: Shutdown is handled explicitly in main() after client.Run() returns
 		// to ensure proper ordering: mark unhealthy -> withdraw -> delete lease -> cleanup
 	})
@@ -121,9 +255,11 @@ func main() {
 		StopCh:         stopCh,
 		OnMemberChange: client.ForceSync,
 		GetLocalSubnets: func() ([]string, error) {
-			// TODO: This will be populated from LBNodeAgent config in Milestone 4
-			// For now, use default interface detection
-			return election.GetLocalSubnets([]string{}, true, logger)
+			// Runs on the election's renewLoop goroutine every
+			// LeaseDuration/2. Before the first config delivery the
+			// selector is nil and this is default-interface detection,
+			// identical to the historical behavior.
+			return election.GetSelectedSubnets(selector.Load(), logger)
 		},
 	})
 	if err != nil {

--- a/docs/SUBNET_AWARE_ELECTION_PLAN.md
+++ b/docs/SUBNET_AWARE_ELECTION_PLAN.md
@@ -1,5 +1,13 @@
 # Plan: Subnet-Aware Election via K8s Leases
 
+> **Status note (multi-interface work, post-v0.17.0):** "Milestone 4" —
+> config-driven subnet detection — is implemented: the election honors
+> `localInterface` (default or regex) and `interfaces[]`, on both the
+> election and announcer sides. The `localInterface: "none"` value
+> sketched below was **NOT implemented**; the supported values are
+> `default` and a regex. Deselecting a node entirely is done with
+> `spec.nodeSelector` on the LBNodeAgent resource instead.
+
 ## Summary
 
 Replace HashiCorp memberlist with Kubernetes Leases that include subnet annotations. This enables **subnet-aware election**: only nodes with a matching local subnet participate in the election for a given IP. No more kubelb0 fallback when any node has the subnet locally.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118
+	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9 h1:LxldC/UdEeJ+j3i/g5
 github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9/go.mod h1:kfOoFJuHWp76v1RgZCb9/gVUc7XdY877S2uVYbNliGc=
 github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 h1:2oDp6OOhLxQ9JBoUuysVz9UZ9uI6oLUbvAZu0x8o+vE=
 github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118/go.mod h1:ZFUnHIVchZ9lJoWoEGUg8Q3M4U8aNNWA3CVSUTkW4og=
+github.com/mdlayher/ndp v1.1.0 h1:QylGKGVtH60sKZUE88+IW5ila1Z/M9/OXhWdsVKuscs=
+github.com/mdlayher/ndp v1.1.0/go.mod h1:FmgESgemgjl38vuOIyAHWUUL6vQKA/pQNkvXdWsdQFM=
 github.com/mdlayher/packet v1.0.0 h1:InhZJbdShQYt6XV2GPj5XHxChzOfhJJOMbvnGAmOfQ8=
 github.com/mdlayher/packet v1.0.0/go.mod h1:eE7/ctqDhoiRhQ44ko5JZU2zxB88g+JH/6jmnjzPjOU=
 github.com/mdlayher/socket v0.2.1 h1:F2aaOwb53VsBE+ebRS9bLd7yPOfYUMC8lOODdCBDY6w=

--- a/internal/election/election.go
+++ b/internal/election/election.go
@@ -563,8 +563,10 @@ func (e *Election) DeleteOurLease() error {
 func (e *Election) createOrUpdateLease() error {
 	ctx := e.ctx
 
-	// Get subnets for annotation
+	// Get subnets for annotation. The same slice feeds both the
+	// annotation and the subnet-count gauge so they can never disagree.
 	var subnetsAnnotation string
+	subnetCount := -1
 	if e.config.GetLocalSubnets != nil {
 		subnets, err := e.config.GetLocalSubnets()
 		if err != nil {
@@ -572,6 +574,7 @@ func (e *Election) createOrUpdateLease() error {
 				"error", err, "msg", "failed to get local subnets, continuing without")
 		} else {
 			subnetsAnnotation = FormatSubnetsAnnotation(subnets)
+			subnetCount = len(subnets)
 		}
 	}
 
@@ -622,10 +625,8 @@ func (e *Election) createOrUpdateLease() error {
 		e.leaseHealthy.Store(true)
 		e.renewFailures.Store(0)
 		RecordLeaseHealthy(true)
-		if e.config.GetLocalSubnets != nil {
-			if subnets, err := e.config.GetLocalSubnets(); err == nil {
-				RecordLocalSubnetCount(len(subnets))
-			}
+		if subnetCount >= 0 {
+			RecordLocalSubnetCount(subnetCount)
 		}
 		return nil
 	}
@@ -655,10 +656,8 @@ func (e *Election) createOrUpdateLease() error {
 	e.leaseHealthy.Store(true)
 	e.renewFailures.Store(0)
 	RecordLeaseHealthy(true)
-	if e.config.GetLocalSubnets != nil {
-		if subnets, err := e.config.GetLocalSubnets(); err == nil {
-			RecordLocalSubnetCount(len(subnets))
-		}
+	if subnetCount >= 0 {
+		RecordLocalSubnetCount(subnetCount)
 	}
 	return nil
 }
@@ -694,6 +693,7 @@ func (e *Election) renewLease() error {
 			newAnnotation := FormatSubnetsAnnotation(subnets)
 			if lease.Annotations[SubnetsAnnotation] != newAnnotation {
 				lease.Annotations[SubnetsAnnotation] = newAnnotation
+				RecordLocalSubnetCount(len(subnets))
 				logging.Info(e.config.Logger, "op", "election", "action", "subnetsChanged",
 					"lease", e.leaseName, "subnets", newAnnotation)
 			}

--- a/internal/election/selector.go
+++ b/internal/election/selector.go
@@ -1,0 +1,188 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"sort"
+
+	"github.com/go-kit/log"
+
+	"purelb.io/internal/logging"
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// lastSelectedInterfaces tracks the previously selected interface
+// names so we can log at info level on first selection or change,
+// debug on repeats. Like lastSubnets, it is safe only because the
+// election closure is the single caller (Start happens-before the
+// renewLoop goroutine).
+var lastSelectedInterfaces string
+
+// InterfaceSelector describes which interfaces feed the election's
+// subnet detection. It is derived from the same LBNodeAgent Local spec
+// the announcer uses, so the lease advertises exactly the subnets the
+// announcer can announce on (the coherence invariant).
+//
+// The zero value (&InterfaceSelector{}) selects nothing: the node
+// advertises no subnets and is a candidate for nothing. This is
+// distinct from a nil *InterfaceSelector, which means "no
+// configuration" and falls back to default-interface detection.
+type InterfaceSelector struct {
+	// UseDefault includes the default-route interface(s), i.e.
+	// localInterface "default" (or "", which is treated as "default").
+	UseDefault bool
+
+	// Regex is the compiled localInterface pattern when it is not
+	// "default". Matching is UNANCHORED, identical to the announcer's
+	// findLocal: "eth" matches "veth0".
+	Regex *regexp.Regexp
+
+	// Interfaces are additional exact interface names (spec.interfaces),
+	// tried in addition to whatever UseDefault/Regex select.
+	Interfaces []string
+
+	// ExcludeName is the dummy interface name (e.g. "kube-lb0"). It
+	// carries remote VIPs whose subnets must not enter the election.
+	ExcludeName string
+}
+
+// SelectorFromConfig derives an InterfaceSelector from cfg using the
+// same agent the announcer picks (FirstLocalAgent). Returns (nil, nil)
+// when no agent has a Local spec — remote-only clusters keep today's
+// default-interface lease behavior. Returns an error when the
+// localInterface regex does not compile; the announcer fails its
+// SetConfig on the same input, so the caller must store an empty
+// selector to stay coherent with an announcer that announces nothing.
+func SelectorFromConfig(cfg *purelbv2.Config) (*InterfaceSelector, error) {
+	agent := purelbv2.FirstLocalAgent(cfg.Agents)
+	if agent == nil {
+		return nil, nil
+	}
+	spec := agent.Spec.Local
+
+	sel := &InterfaceSelector{
+		Interfaces:  spec.Interfaces,
+		ExcludeName: spec.DummyInterface,
+	}
+
+	// "" can only appear when an object bypassed kubebuilder defaulting;
+	// treat it as "default" (the announcer does the same) rather than
+	// compiling it into a match-everything regex.
+	if spec.LocalInterface == "default" || spec.LocalInterface == "" {
+		sel.UseDefault = true
+		return sel, nil
+	}
+
+	regex, err := regexp.Compile(spec.LocalInterface)
+	if err != nil {
+		return nil, fmt.Errorf("error compiling regex %q: %w", spec.LocalInterface, err)
+	}
+	sel.Regex = regex
+	return sel, nil
+}
+
+// GetSelectedSubnets returns the subnets the election should advertise
+// for sel. nil sel falls back to default-interface detection
+// (byte-identical to the pre-config behavior); an empty sel selects
+// nothing. Everything funnels through GetLocalSubnets so
+// deduplication, sorting, IPv6 bad-flag filtering, missing-interface
+// tolerance and log throttling are shared with the historical path.
+func GetSelectedSubnets(sel *InterfaceSelector, logger log.Logger) ([]string, error) {
+	if sel == nil {
+		return GetLocalSubnets(nil, true, logger)
+	}
+	if !sel.UseDefault && sel.Regex == nil && len(sel.Interfaces) == 0 {
+		return []string{}, nil
+	}
+
+	names := selectedInterfaceNames(sel)
+
+	// Log the selected names (not just the resulting subnets) so an
+	// under-anchored regex that catches veth/bridge interfaces is
+	// visible at info level.
+	if logger != nil {
+		formatted := fmt.Sprintf("%v(useDefault=%t)", names, sel.UseDefault)
+		if formatted != lastSelectedInterfaces {
+			lastSelectedInterfaces = formatted
+			logging.Info(logger, "op", "getSelectedSubnets", "interfaces", formatted,
+				"msg", "interface selection changed")
+		} else {
+			logging.Debug(logger, "op", "getSelectedSubnets", "interfaces", formatted,
+				"msg", "interface selection unchanged")
+		}
+	}
+
+	return GetLocalSubnets(names, sel.UseDefault, logger)
+}
+
+// selectedInterfaceNames computes the explicit interface-name set for
+// sel: the exact names from Interfaces (minus ExcludeName) plus the
+// regex matches over the system's interfaces (minus ExcludeName and
+// loopback — loopback is excluded from regex enumeration only, so an
+// explicit "lo" entry still works, which keeps CI tests viable). The
+// result is deduplicated and sorted: ifindex enumeration order is
+// boot-dependent, and deterministic order keeps logs and scans stable
+// across reboots.
+func selectedInterfaceNames(sel *InterfaceSelector) []string {
+	nameSet := make(map[string]struct{})
+
+	for _, name := range sel.Interfaces {
+		if name == "" || name == sel.ExcludeName {
+			continue
+		}
+		nameSet[name] = struct{}{}
+	}
+
+	if sel.Regex != nil {
+		if interfaces, err := net.Interfaces(); err == nil {
+			candidates := make([]string, 0, len(interfaces))
+			for _, intf := range interfaces {
+				if intf.Flags&net.FlagLoopback != 0 {
+					continue
+				}
+				candidates = append(candidates, intf.Name)
+			}
+			for _, name := range matchInterfaceNames(sel.Regex, sel.ExcludeName, candidates) {
+				nameSet[name] = struct{}{}
+			}
+		}
+	}
+
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// matchInterfaceNames returns the names matching regex, excluding
+// exclude. Matching is unanchored (regexp.Match), identical to the
+// announcer's findLocal semantics.
+func matchInterfaceNames(regex *regexp.Regexp, exclude string, names []string) []string {
+	matched := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == exclude {
+			continue
+		}
+		if regex.Match([]byte(name)) {
+			matched = append(matched, name)
+		}
+	}
+	return matched
+}

--- a/internal/election/selector_test.go
+++ b/internal/election/selector_test.go
@@ -1,0 +1,238 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"net"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+func localAgent(name string, spec *purelbv2.LBNodeAgentLocalSpec) *purelbv2.LBNodeAgent {
+	return &purelbv2.LBNodeAgent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "purelb", Name: name},
+		Spec:       purelbv2.LBNodeAgentSpec{Local: spec},
+	}
+}
+
+// loHasIPv6 reports whether the loopback interface carries ::1 —
+// some CI runners disable IPv6 entirely.
+func loHasIPv6(t *testing.T) bool {
+	t.Helper()
+	lo, err := net.InterfaceByName("lo")
+	if err != nil {
+		return false
+	}
+	addrs, err := lo.Addrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() == nil && ipnet.IP.IsLoopback() {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSelectorFromConfig(t *testing.T) {
+	t.Run("no local agent returns nil", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{})
+		assert.NoError(t, err)
+		assert.Nil(t, sel)
+
+		sel, err = SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{localAgent("remote-only", nil)},
+		})
+		assert.NoError(t, err)
+		assert.Nil(t, sel)
+	})
+
+	t.Run("default", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{localAgent("default", &purelbv2.LBNodeAgentLocalSpec{
+				LocalInterface: "default", DummyInterface: "kube-lb0",
+			})},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sel)
+		assert.True(t, sel.UseDefault)
+		assert.Nil(t, sel.Regex)
+		assert.Equal(t, "kube-lb0", sel.ExcludeName)
+	})
+
+	t.Run("empty localInterface treated as default", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{localAgent("blank", &purelbv2.LBNodeAgentLocalSpec{})},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sel)
+		assert.True(t, sel.UseDefault)
+		assert.Nil(t, sel.Regex)
+	})
+
+	t.Run("regex with field carry-through", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{localAgent("regex", &purelbv2.LBNodeAgentLocalSpec{
+				LocalInterface: "^(eth1|eth2)$",
+				DummyInterface: "kube-lb0",
+				Interfaces:     []string{"eth3"},
+			})},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sel)
+		assert.False(t, sel.UseDefault)
+		require.NotNil(t, sel.Regex)
+		assert.True(t, sel.Regex.MatchString("eth1"))
+		assert.False(t, sel.Regex.MatchString("eth10"))
+		assert.Equal(t, []string{"eth3"}, sel.Interfaces)
+		assert.Equal(t, "kube-lb0", sel.ExcludeName)
+	})
+
+	t.Run("invalid regex errors", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{localAgent("broken", &purelbv2.LBNodeAgentLocalSpec{
+				LocalInterface: "[",
+			})},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, sel)
+	})
+
+	t.Run("first local agent wins", func(t *testing.T) {
+		sel, err := SelectorFromConfig(&purelbv2.Config{
+			Agents: []*purelbv2.LBNodeAgent{
+				localAgent("remote-only", nil),
+				localAgent("first", &purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^eth1$"}),
+				localAgent("second", &purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^eth2$"}),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sel)
+		assert.True(t, sel.Regex.MatchString("eth1"))
+		assert.False(t, sel.Regex.MatchString("eth2"))
+	})
+}
+
+func TestGetSelectedSubnets(t *testing.T) {
+	t.Run("nil selector identical to default detection", func(t *testing.T) {
+		fromDefault, errDefault := GetLocalSubnets([]string{}, true, nil)
+		fromNil, errNil := GetSelectedSubnets(nil, nil)
+		assert.Equal(t, errDefault == nil, errNil == nil)
+		assert.Equal(t, fromDefault, fromNil)
+	})
+
+	t.Run("empty selector selects nothing", func(t *testing.T) {
+		subnets, err := GetSelectedSubnets(&InterfaceSelector{}, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, subnets)
+	})
+
+	t.Run("explicit lo", func(t *testing.T) {
+		subnets, err := GetSelectedSubnets(&InterfaceSelector{Interfaces: []string{"lo"}}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, subnets, "127.0.0.0/8")
+		if loHasIPv6(t) {
+			assert.Contains(t, subnets, "::1/128")
+		}
+	})
+
+	t.Run("regex enumeration excludes loopback", func(t *testing.T) {
+		subnets, err := GetSelectedSubnets(&InterfaceSelector{Regex: regexp.MustCompile("^lo$")}, nil)
+		require.NoError(t, err)
+		assert.NotContains(t, subnets, "127.0.0.0/8")
+	})
+
+	t.Run("explicit name beats ExcludeName only for non-dummy", func(t *testing.T) {
+		// lo listed explicitly but also excluded: contributes nothing.
+		subnets, err := GetSelectedSubnets(&InterfaceSelector{
+			Interfaces: []string{"lo"}, ExcludeName: "lo",
+		}, nil)
+		require.NoError(t, err)
+		assert.NotContains(t, subnets, "127.0.0.0/8")
+	})
+
+	t.Run("missing interface skipped", func(t *testing.T) {
+		subnets, err := GetSelectedSubnets(&InterfaceSelector{
+			Interfaces: []string{"purelb-does-not-exist0"},
+		}, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, subnets)
+	})
+
+	t.Run("union and dedup", func(t *testing.T) {
+		fromSingle, err := GetSelectedSubnets(&InterfaceSelector{Interfaces: []string{"lo"}}, nil)
+		require.NoError(t, err)
+		fromDuplicated, err := GetSelectedSubnets(&InterfaceSelector{Interfaces: []string{"lo", "lo"}}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, fromSingle, fromDuplicated)
+	})
+}
+
+func TestSelectedInterfaceNames(t *testing.T) {
+	t.Run("sorted deterministic order", func(t *testing.T) {
+		names := selectedInterfaceNames(&InterfaceSelector{
+			Interfaces: []string{"zzz0", "aaa0", "mmm0"},
+		})
+		assert.Equal(t, []string{"aaa0", "mmm0", "zzz0"}, names)
+	})
+
+	t.Run("empty names dropped", func(t *testing.T) {
+		names := selectedInterfaceNames(&InterfaceSelector{Interfaces: []string{"", "eth1"}})
+		assert.Equal(t, []string{"eth1"}, names)
+	})
+}
+
+func TestMatchInterfaceNames(t *testing.T) {
+	names := []string{"eth1", "eth2", "veth0abc", "kube-lb0", "docker0"}
+
+	t.Run("unanchored regex matches substrings", func(t *testing.T) {
+		matched := matchInterfaceNames(regexp.MustCompile("eth"), "", names)
+		assert.Equal(t, []string{"eth1", "eth2", "veth0abc"}, matched)
+	})
+
+	t.Run("anchored regex is exact", func(t *testing.T) {
+		matched := matchInterfaceNames(regexp.MustCompile("^(eth1|eth2)$"), "", names)
+		assert.Equal(t, []string{"eth1", "eth2"}, matched)
+	})
+
+	t.Run("exclude removes match", func(t *testing.T) {
+		matched := matchInterfaceNames(regexp.MustCompile("."), "kube-lb0", names)
+		assert.NotContains(t, matched, "kube-lb0")
+		assert.Contains(t, matched, "eth1")
+	})
+}
+
+func TestParseSubnetsAnnotationHardening(t *testing.T) {
+	t.Run("invalid entries dropped, originals kept verbatim", func(t *testing.T) {
+		parsed := ParseSubnetsAnnotation("192.168.1.0/24,not-a-cidr,fd53:9ef0:8683::/64,,300.1.1.0/24")
+		assert.Equal(t, []string{"192.168.1.0/24", "fd53:9ef0:8683::/64"}, parsed)
+	})
+
+	t.Run("capped at maxAnnotationSubnets", func(t *testing.T) {
+		entries := make([]string, maxAnnotationSubnets+10)
+		for i := range entries {
+			entries[i] = "10.0.0.0/8"
+		}
+		assert.Len(t, ParseSubnetsAnnotation(strings.Join(entries, ",")), maxAnnotationSubnets)
+	})
+}

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -222,13 +222,33 @@ func FormatSubnetsAnnotation(subnets []string) string {
 	return strings.Join(subnets, ",")
 }
 
+// maxAnnotationSubnets caps how many subnet entries we accept from a
+// single lease annotation. Peer leases are written by other nodes; a
+// buggy writer must not be able to bloat every node's election maps.
+const maxAnnotationSubnets = 256
+
 // ParseSubnetsAnnotation parses the annotation value back into a slice
-// of subnet strings. Returns an empty slice for empty input.
+// of subnet strings. Returns an empty slice for empty input. Entries
+// that are not valid CIDRs are dropped, and at most
+// maxAnnotationSubnets entries are returned. Valid entries keep their
+// original spelling — downstream consumers match them as exact strings
+// against ServiceGroup subnet specs.
 func ParseSubnetsAnnotation(annotation string) []string {
 	if annotation == "" {
 		return []string{}
 	}
-	return strings.Split(annotation, ",")
+	entries := strings.Split(annotation, ",")
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if _, _, err := net.ParseCIDR(entry); err != nil {
+			continue
+		}
+		result = append(result, entry)
+		if len(result) == maxAnnotationSubnets {
+			break
+		}
+	}
+	return result
 }
 
 // SubnetContainsIP checks if any of the given subnets contains the IP address.

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -229,7 +229,16 @@ func (c *Controller) syncHandler() error {
 	case SyncStateSuccess:
 		configLoaded.Set(1)
 	case SyncStateError:
+		// Count the error AND return non-nil so processNextWorkItem
+		// requeues this delivery with rate-limited backoff. Without the
+		// requeue a transient failure inside the callback (e.g. a Node
+		// GET during config delivery) would silently leave the consumer
+		// on stale config until the next CR event. Retrying a permanent
+		// config error is bounded (the rate limiter caps backoff and
+		// Forget resets it on the next success) and both consumers'
+		// callbacks are idempotent. forceSync is deliberately not called.
 		updateErrors.Inc()
+		return fmt.Errorf("config rejected by consumer, requeuing")
 	case SyncStateReprocessAll:
 		configLoaded.Set(1)
 		c.forceSync()

--- a/internal/k8s/cr-controller_test.go
+++ b/internal/k8s/cr-controller_test.go
@@ -16,10 +16,16 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
+	ptu "github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+	purelbfake "purelb.io/pkg/generated/clientset/versioned/fake"
+	"purelb.io/pkg/generated/informers/externalversions"
 )
 
 func newServiceGroup(name string) *purelbv2.ServiceGroup {
@@ -75,5 +81,60 @@ func TestSGUpdateNeedsReconcile(t *testing.T) {
 				t.Errorf("sgUpdateNeedsReconcile = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSyncHandlerRequeuesOnConfigError pins the SyncStateError
+// contract: the delivery is retried with rate-limited backoff (a
+// transient failure inside the callback must not leave the consumer on
+// stale config until the next CR event), the error metric still
+// increments, and forceSync is not called.
+func TestSyncHandlerRequeuesOnConfigError(t *testing.T) {
+	purelbClient := purelbfake.NewSimpleClientset()
+	factory := externalversions.NewSharedInformerFactory(purelbClient, 0)
+
+	state := SyncStateError
+	calls := 0
+	c := &Controller{
+		logger:     log.NewNopLogger(),
+		configCB:   func(*purelbv2.Config) SyncState { calls++; return state },
+		forceSync:  func() { t.Error("forceSync must not be called on SyncStateError") },
+		sgLister:   factory.Purelb().V2().ServiceGroups().Lister(),
+		lbnaLister: factory.Purelb().V2().LBNodeAgents().Lister(),
+		workqueue:  workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"}),
+	}
+	defer c.workqueue.ShutDown()
+
+	errorsBefore := ptu.ToFloat64(updateErrors)
+
+	c.workqueue.Add("lbna/default/test")
+	if !c.processNextWorkItem() {
+		t.Fatal("processNextWorkItem returned shutdown")
+	}
+	if calls != 1 {
+		t.Fatalf("configCB calls = %d, want 1", calls)
+	}
+	if got := ptu.ToFloat64(updateErrors); got != errorsBefore+1 {
+		t.Errorf("updateErrors = %v, want %v", got, errorsBefore+1)
+	}
+
+	// The rate limiter re-adds after its base delay; poll for the requeue.
+	deadline := time.Now().Add(5 * time.Second)
+	for c.workqueue.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c.workqueue.Len() != 1 {
+		t.Fatal("item was not requeued after SyncStateError")
+	}
+
+	// A subsequent success consumes the requeued item and Forgets it —
+	// no further retries.
+	state = SyncStateSuccess
+	if !c.processNextWorkItem() {
+		t.Fatal("processNextWorkItem returned shutdown")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if c.workqueue.Len() != 0 {
+		t.Errorf("queue length after success = %d, want 0", c.workqueue.Len())
 	}
 }

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -237,7 +237,13 @@ func New(cfg *Config) (*Client, error) {
 
 	// Custom Resource Watcher
 
-	c.crInformerFactory = externalversions.NewSharedInformerFactory(crClient, time.Second*0)
+	// The 10-minute resync replays the cached CRs through the update
+	// handlers (no apiserver load). ServiceGroup replays are filtered by
+	// the generation check, but LBNodeAgent replays re-deliver config:
+	// that bounds how long a node-label-only change can go unnoticed by
+	// nodeSelector evaluation and gives config delivery a self-healing
+	// floor if a delivery was lost.
+	c.crInformerFactory = externalversions.NewSharedInformerFactory(crClient, time.Minute*10)
 	c.crController = *NewCRController(c.logger, cfg.ConfigChanged, c.ForceSync, clientset, crClient, c.crInformerFactory)
 
 	// Service Watcher

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -453,13 +453,13 @@ func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceI
 		"ip":      lbIP.String(),
 	}).Set(1)
 
-	// Send GARP if configured. IPv4 only: gratuitous ARP has no IPv6
-	// equivalent (arp.NewPacket rejects non-4-byte addresses), so an IPv6
-	// address would only spin up the sequence goroutine to fail on every
-	// packet. IPv6 neighbours learn the new location from the kernel.
-	if lbIP.To4() != nil {
-		a.sendGARPSequence(lbIP, announceInt.Attrs().Name)
-	}
+	// Send gratuitous announcements if configured: GARP for IPv4,
+	// unsolicited Neighbor Advertisements for IPv6. The kernel does NOT
+	// notify IPv6 neighbours when an address is added — it only runs
+	// DAD, whose probes are sourced from :: and update no neighbor
+	// caches (and the skip-DAD annotation suppresses even those) — so
+	// without the NA a moved IPv6 VIP converges only via NUD timeouts.
+	a.sendGARPSequence(lbIP, announceInt.Attrs().Name)
 
 	return nil
 }
@@ -1041,8 +1041,11 @@ func (a *announcer) getLocalAddressOptions() AddressOptions {
 	return opts
 }
 
-// sendGARPSequence sends GARP packets according to the GARPConfig.
-// The GARP sequence runs in a goroutine to avoid blocking the main announcement.
+// sendGARPSequence sends gratuitous announcement packets according to
+// the GARPConfig: GARP for IPv4 addresses, unsolicited Neighbor
+// Advertisements for IPv6 (its protocol counterpart — same config
+// gate, delay, count, interval and verify-before-send semantics).
+// The sequence runs in a goroutine to avoid blocking the main announcement.
 func (a *announcer) sendGARPSequence(lbIP net.IP, ifName string) {
 	if a.config == nil || a.config.GARPConfig == nil {
 		return // GARP not configured
@@ -1094,7 +1097,18 @@ func (a *announcer) sendGARPSequence(lbIP net.IP, ifName string) {
 		verifyBeforeSend = *cfg.VerifyBeforeSend
 	}
 
-	// Run GARP sequence in a goroutine to avoid blocking
+	// Pick the family-appropriate packet. The sequence semantics are
+	// identical; only the wire format differs.
+	op := "sendGARP"
+	send := func() error { return sendGARP(ifName, lbIP) }
+	recordSent, recordError := RecordGARPSent, RecordGARPError
+	if lbIP.To4() == nil {
+		op = "sendUnsolicitedNA"
+		send = func() error { return sendUnsolicitedNA(ifName, lbIP) }
+		recordSent, recordError = RecordNASent, RecordNAError
+	}
+
+	// Run the sequence in a goroutine to avoid blocking
 	go func() {
 		ipStr := lbIP.String()
 
@@ -1113,21 +1127,20 @@ func (a *announcer) sendGARPSequence(lbIP net.IP, ifName string) {
 			if verifyBeforeSend && a.election != nil {
 				winner := a.election.Winner(ipStr)
 				if winner != a.myNode {
-					logging.Debug(a.logger, "op", "sendGARP", "ip", ipStr, "packet", i+1, "of", count,
-						"msg", "skipping GARP, no longer winner", "winner", winner)
+					logging.Debug(a.logger, "op", op, "ip", ipStr, "packet", i+1, "of", count,
+						"msg", "skipping announcement, no longer winner", "winner", winner)
 					return // Stop the sequence, we lost ownership
 				}
 			}
 
-			// Send GARP
-			if err := sendGARP(ifName, lbIP); err != nil {
-				RecordGARPError()
-				logging.Info(a.logger, "op", "sendGARP", "ip", ipStr, "interface", ifName,
+			if err := send(); err != nil {
+				recordError()
+				logging.Info(a.logger, "op", op, "ip", ipStr, "interface", ifName,
 					"packet", i+1, "of", count, "error", err)
 				// Continue sending remaining packets even on error
 			} else {
-				RecordGARPSent()
-				logging.Debug(a.logger, "op", "sendGARP", "ip", ipStr, "interface", ifName,
+				recordSent()
+				logging.Debug(a.logger, "op", op, "ip", ipStr, "interface", ifName,
 					"packet", i+1, "of", count, "msg", "sent")
 			}
 		}

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -15,6 +15,7 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -117,57 +118,61 @@ func (a *announcer) SetConfig(cfg *purelbv2.Config) error {
 	// the default is nil which means that we don't announce
 	a.config = nil
 
-	// if there's a "Local" agent config then we'll announce
-	for _, agent := range cfg.Agents {
-		if spec := agent.Spec.Local; spec != nil {
-			logging.Info(a.logger, "op", "setConfig", "spec", spec, "name", agent.Namespace+"/"+agent.Name)
+	// The election selector uses the same helper, so both sides always
+	// choose the same agent (the coherence invariant).
+	agent := purelbv2.FirstLocalAgent(cfg.Agents)
+	if agent == nil {
+		logging.Info(a.logger, "event", "noConfig")
+		return nil
+	}
+	spec := agent.Spec.Local
+	logging.Info(a.logger, "op", "setConfig", "spec", spec, "name", agent.Namespace+"/"+agent.Name)
 
-			// stash the local ServiceGroup configs
-			a.groups = map[string]*purelbv2.ServiceGroupLocalSpec{}
-			a.remoteGroups = map[string]*purelbv2.ServiceGroupRemoteSpec{}
-			for _, group := range cfg.Groups {
-				if group.Spec.Local != nil {
-					a.groups[group.ObjectMeta.Name] = group.Spec.Local
-				}
-				if group.Spec.Remote != nil {
-					a.remoteGroups[group.ObjectMeta.Name] = group.Spec.Remote
-				}
-			}
-
-			// if the user specified an interface regex then we'll compile
-			// that now, and use it (when we get an address) to find a local
-			// interface
-			if spec.LocalInterface != "default" {
-				if regex, err := regexp.Compile(spec.LocalInterface); err != nil {
-					return fmt.Errorf("error compiling regex \"%s\": %s", spec.LocalInterface, err.Error())
-				} else {
-					a.localNameRegex = regex
-				}
-			} else {
-				a.localNameRegex = nil
-
-			}
-
-			// now that we've got a config we can create the dummy interface
-			var err error
-			if a.dummyInt, err = addDummyInterface(spec.DummyInterface); err != nil {
-				return fmt.Errorf("error adding interface \"%s\": %s", spec.DummyInterface, err.Error())
-			}
-
-			// The dummy interface is set up so we can set the config which
-			// will allow announcements to happen.
-			a.config = spec
-
-			// we've got our marching orders so we don't need to continue
-			// scanning
-			return nil
+	// stash the local ServiceGroup configs
+	a.groups = map[string]*purelbv2.ServiceGroupLocalSpec{}
+	a.remoteGroups = map[string]*purelbv2.ServiceGroupRemoteSpec{}
+	for _, group := range cfg.Groups {
+		if group.Spec.Local != nil {
+			a.groups[group.ObjectMeta.Name] = group.Spec.Local
+		}
+		if group.Spec.Remote != nil {
+			a.remoteGroups[group.ObjectMeta.Name] = group.Spec.Remote
 		}
 	}
 
-	if a.config == nil {
-		logging.Info(a.logger, "event", "noConfig")
+	if err := a.applyLocalSpec(spec); err != nil {
+		return err
 	}
 
+	// now that we've got a config we can create the dummy interface
+	var err error
+	if a.dummyInt, err = addDummyInterface(spec.DummyInterface); err != nil {
+		return fmt.Errorf("error adding interface \"%s\": %s", spec.DummyInterface, err.Error())
+	}
+
+	// The dummy interface is set up so we can set the config which
+	// will allow announcements to happen.
+	a.config = spec
+
+	return nil
+}
+
+// applyLocalSpec applies the netlink-free part of a Local spec: regex
+// compilation. Extracted from SetConfig so it can be unit-tested
+// without CAP_NET_ADMIN. An empty LocalInterface is treated as
+// "default" — kubebuilder defaulting can be bypassed by programmatic
+// clients, and compiling "" would yield a match-everything regex. The
+// election's SelectorFromConfig applies the identical rule.
+func (a *announcer) applyLocalSpec(spec *purelbv2.LBNodeAgentLocalSpec) error {
+	if spec.LocalInterface == "default" || spec.LocalInterface == "" {
+		a.localNameRegex = nil
+		return nil
+	}
+	regex, err := regexp.Compile(spec.LocalInterface)
+	if err != nil {
+		return fmt.Errorf("error compiling regex \"%s\": %s", spec.LocalInterface, err.Error())
+	}
+	a.localNameRegex = regex
 	return nil
 }
 
@@ -186,14 +191,21 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 	// if we haven't been configured then we won't announce
 	if a.config == nil {
 		logging.Info(l, "event", "noConfig")
-		// We are not announcing anything, so drop any slot that still names
-		// us (e.g. the local config was removed after we had won).
+		// We are not announcing anything: withdraw any address we may
+		// still hold and drop any slot that still names us. nodeSelector
+		// deselection and config removal land here — the slot alone is
+		// not enough, because a previously-announced VIP would stay on
+		// the NIC with a live renewal timer re-adding it while another
+		// node wins the election (duplicate ARP responders).
 		for _, ingress := range svc.Status.LoadBalancer.Ingress {
 			if lbIP := net.ParseIP(ingress.IP); lbIP != nil {
+				if err := a.deleteAddress(nsName, "noConfig", lbIP); err != nil {
+					retErr = err
+				}
 				a.clearOwnAnnounceSlot(svc, lbIP)
 			}
 		}
-		return nil
+		return retErr
 	}
 
 	// add the address to our announcement database
@@ -217,7 +229,16 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 		if a.localNameRegex != nil {
 			// The user specified an announcement interface regex so use it to
 			// try to find a local interface
-			lbIPNet, localif, err := findLocal(a.localNameRegex, lbIP)
+			lbIPNet, localif, err := findLocal(a.localNameRegex, a.config.DummyInterface, lbIP)
+			if err != nil {
+				// The regex didn't resolve; try the explicitly-configured
+				// extra interfaces (spec.interfaces) before falling through.
+				if xNet, xIf, xErr := a.tryExtraInterfaces(lbIP); xErr == nil {
+					lbIPNet, localif, err = xNet, xIf, nil
+				} else if errors.Is(xErr, errIndeterminate) {
+					err = xErr
+				}
+			}
 			if err == nil {
 				// We found a local interface, announce the address on it
 				if err := a.announceLocal(svc, preferred, localif, lbIP, lbIPNet); err != nil {
@@ -228,11 +249,21 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 				if err := a.announceRemote(svc, epSlices, a.dummyInt, lbIP); err != nil {
 					retErr = err
 				}
+			} else if errors.Is(err, errIndeterminate) {
+				// A partial netlink dump made resolution uncertain. Do not
+				// withdraw on uncertain evidence — the next SetBalancer
+				// cycle re-checks.
+				logging.Info(l, "event", "resolutionIndeterminate", "ip", lbIP,
+					"msg", "interface resolution indeterminate this cycle, skipping withdrawal")
 			} else {
 				// lbIP is from a local pool but no local interface matches.
-				// Do NOT announce - subnet-aware election will handle this.
-				// This node is healthy (its lease is valid) but not
-				// announcing, so nothing else will clear a stale slot for us.
+				// Withdraw any stale announcement: the annotation slot alone
+				// is not enough — a previously-announced VIP would stay on
+				// the NIC with a live renewal timer re-adding it while
+				// another node wins the election (duplicate ARP responders).
+				if err := a.deleteAddress(nsName, "noLocalInterface", lbIP); err != nil {
+					retErr = err
+				}
 				a.clearOwnAnnounceSlot(svc, lbIP)
 				logging.Info(l, "event", "noLocalInterface", "ip", lbIP,
 					"msg", "local pool IP has no matching local interface, not announcing")
@@ -240,16 +271,33 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 
 		} else {
 			// The user wants us to determine the "default" interface
+			var lbIPNet net.IPNet
+			var localif netlink.Link
 			announceInt, err := netutil.DefaultInterface(purelbv2.AddrFamily(lbIP))
 			if err != nil {
-				logging.Info(l, "event", "announceError", "err", err)
-				retErr = err
-				continue
+				if len(a.config.Interfaces) == 0 {
+					// No fallback interfaces configured: keep the historical
+					// hard-error path.
+					logging.Info(l, "event", "announceError", "err", err)
+					retErr = err
+					continue
+				}
+			} else {
+				lbIPNet, localif, err = checkLocal(announceInt, lbIP)
 			}
-			if lbIPNet, defaultif, err := checkLocal(announceInt, lbIP); err == nil {
-				// The default interface is a local interface, announce the
-				// address on it
-				if err := a.announceLocal(svc, preferred, defaultif, lbIP, lbIPNet); err != nil {
+			if err != nil {
+				// The default interface didn't resolve; try the
+				// explicitly-configured extra interfaces (spec.interfaces)
+				// before falling through.
+				if xNet, xIf, xErr := a.tryExtraInterfaces(lbIP); xErr == nil {
+					lbIPNet, localif, err = xNet, xIf, nil
+				} else if errors.Is(xErr, errIndeterminate) {
+					err = xErr
+				}
+			}
+			if err == nil {
+				// We found a local interface, announce the address on it
+				if err := a.announceLocal(svc, preferred, localif, lbIP, lbIPNet); err != nil {
 					retErr = err
 				}
 			} else if a.isRemotePool(lbIP) {
@@ -257,11 +305,22 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 				if err := a.announceRemote(svc, epSlices, a.dummyInt, lbIP); err != nil {
 					retErr = err
 				}
+			} else if errors.Is(err, errIndeterminate) {
+				// A partial netlink dump made resolution uncertain. Do not
+				// withdraw on uncertain evidence — the next SetBalancer
+				// cycle re-checks.
+				logging.Info(l, "event", "resolutionIndeterminate", "ip", lbIP,
+					"msg", "interface resolution indeterminate this cycle, skipping withdrawal")
 			} else {
-				// lbIP is from a local pool but doesn't match the default interface.
-				// Do NOT announce - subnet-aware election will handle this.
-				// This node is healthy but not announcing, so nothing else
-				// will clear a stale slot for us.
+				// lbIP is from a local pool but doesn't match the default
+				// interface or any extra interface. Withdraw any stale
+				// announcement: the annotation slot alone is not enough — a
+				// previously-announced VIP would stay on the NIC with a live
+				// renewal timer re-adding it while another node wins the
+				// election (duplicate ARP responders).
+				if err := a.deleteAddress(nsName, "noLocalInterface", lbIP); err != nil {
+					retErr = err
+				}
 				a.clearOwnAnnounceSlot(svc, lbIP)
 				logging.Info(l, "event", "noLocalInterface", "ip", lbIP,
 					"msg", "local pool IP has no matching local interface, not announcing")
@@ -271,6 +330,40 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 
 	// Return the most recent error
 	return retErr
+}
+
+// tryExtraInterfaces tries to resolve lbIP on the interfaces listed in
+// the Local spec's Interfaces field, in listed order (the documented
+// contract); the first interface whose addresses contain lbIP wins.
+// Missing interfaces are skipped without error — the CR is
+// cluster-wide, so heterogeneous nodes are expected. Returns
+// errIndeterminate when a candidate's address dump was partial and
+// none succeeded, so the caller can avoid withdrawing on uncertain
+// evidence.
+func (a *announcer) tryExtraInterfaces(lbIP net.IP) (net.IPNet, netlink.Link, error) {
+	indeterminate := false
+	for _, name := range a.config.Interfaces {
+		if name == "" || name == a.config.DummyInterface {
+			continue
+		}
+		nlIntf, err := netlink.LinkByName(name)
+		if err != nil {
+			logging.Debug(a.logger, "op", "tryExtraInterfaces", "interface", name,
+				"msg", "interface not found, skipping")
+			continue
+		}
+		ipnet, link, err := checkLocal(nlIntf, lbIP)
+		if err == nil {
+			return ipnet, link, nil
+		}
+		if errors.Is(err, errIndeterminate) {
+			indeterminate = true
+		}
+	}
+	if indeterminate {
+		return net.IPNet{}, nil, errIndeterminate
+	}
+	return net.IPNet{}, nil, fmt.Errorf("no extra interface matched")
 }
 
 func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceInt netlink.Link, lbIP net.IP, lbIPNet net.IPNet) error {

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -17,12 +17,14 @@ package local
 import (
 	"errors"
 	"net"
+	"net/netip"
 	"regexp"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/mdlayher/ndp"
 	ptu "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -1070,4 +1072,44 @@ func TestWithdrawalSharedIPRefcount(t *testing.T) {
 	assert.False(t, bAnnounced)
 	_, bTimer = a.addressRenewals.Load(renewalKey("default/svc-b", "192.0.2.1"))
 	assert.False(t, bTimer)
+}
+
+// TestBuildUnsolicitedNA pins the wire-level shape of the IPv6
+// failover announcement without needing a raw socket: Override set
+// (neighbors must replace the moved VIP's cache entry), Solicited and
+// Router clear, target = the VIP, with a target link-layer address
+// option. ndp.MarshalMessage round-trips through the real wire format.
+func TestBuildUnsolicitedNA(t *testing.T) {
+	hw := net.HardwareAddr{0x02, 0x00, 0x5e, 0x10, 0x00, 0x01}
+	target := netip.MustParseAddr("2001:db8::10")
+
+	na := buildUnsolicitedNA(target, hw)
+	assert.True(t, na.Override)
+	assert.False(t, na.Solicited)
+	assert.False(t, na.Router)
+	assert.Equal(t, target, na.TargetAddress)
+
+	raw, err := ndp.MarshalMessage(na)
+	assert.NoError(t, err)
+	assert.Equal(t, byte(136), raw[0], "ICMPv6 type must be Neighbor Advertisement")
+
+	parsed, err := ndp.ParseMessage(raw)
+	assert.NoError(t, err)
+	round, ok := parsed.(*ndp.NeighborAdvertisement)
+	if assert.True(t, ok) {
+		assert.Equal(t, target, round.TargetAddress)
+		assert.True(t, round.Override)
+		assert.False(t, round.Solicited)
+		if assert.Len(t, round.Options, 1) {
+			lla, ok := round.Options[0].(*ndp.LinkLayerAddress)
+			if assert.True(t, ok) {
+				assert.Equal(t, ndp.Target, lla.Direction)
+				assert.Equal(t, hw, lla.Addr)
+			}
+		}
+	}
+}
+
+func TestSendUnsolicitedNARejectsIPv4(t *testing.T) {
+	assert.Error(t, sendUnsolicitedNA("lo", net.ParseIP("192.0.2.1")))
 }

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -15,7 +15,9 @@
 package local
 
 import (
+	"errors"
 	"net"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -869,4 +871,203 @@ func TestBuildPreferredNodes(t *testing.T) {
 		// election (no fallback metric since len(preferred)==0).
 		assert.Empty(t, got)
 	})
+}
+
+func TestApplyLocalSpec(t *testing.T) {
+	t.Run("default clears regex", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(), localNameRegex: regexp.MustCompile("stale")}
+		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "default"}))
+		assert.Nil(t, a.localNameRegex)
+	})
+
+	t.Run("empty treated as default", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(), localNameRegex: regexp.MustCompile("stale")}
+		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: ""}))
+		assert.Nil(t, a.localNameRegex)
+	})
+
+	t.Run("regex compiled", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger()}
+		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^(eth1|eth2)$"}))
+		if assert.NotNil(t, a.localNameRegex) {
+			assert.True(t, a.localNameRegex.MatchString("eth1"))
+			assert.False(t, a.localNameRegex.MatchString("eth10"))
+		}
+	})
+
+	t.Run("invalid regex errors", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger()}
+		assert.Error(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "["}))
+		assert.Nil(t, a.localNameRegex)
+	})
+}
+
+func TestFindLocal(t *testing.T) {
+	t.Run("resolves loopback address", func(t *testing.T) {
+		ipnet, link, err := findLocal(regexp.MustCompile("^lo$"), "", net.ParseIP("127.0.0.1"))
+		assert.NoError(t, err)
+		assert.Equal(t, "lo", link.Attrs().Name)
+		assert.Equal(t, "127.0.0.1/8", ipnet.String())
+	})
+
+	t.Run("exclude removes the only match", func(t *testing.T) {
+		_, _, err := findLocal(regexp.MustCompile("^lo$"), "lo", net.ParseIP("127.0.0.1"))
+		assert.Error(t, err)
+	})
+
+	t.Run("no matching interface", func(t *testing.T) {
+		_, _, err := findLocal(regexp.MustCompile("^purelb-nomatch$"), "", net.ParseIP("127.0.0.1"))
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, errIndeterminate))
+	})
+}
+
+func TestTryExtraInterfaces(t *testing.T) {
+	loV6 := func() bool {
+		lo, err := net.InterfaceByName("lo")
+		if err != nil {
+			return false
+		}
+		addrs, _ := lo.Addrs()
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() == nil && ipnet.IP.IsLoopback() {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("resolves IPv4 on explicit interface", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(),
+			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}}
+		ipnet, link, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		assert.NoError(t, err)
+		assert.Equal(t, "lo", link.Attrs().Name)
+		assert.Equal(t, "127.0.0.1/8", ipnet.String())
+	})
+
+	t.Run("resolves IPv6 on explicit interface", func(t *testing.T) {
+		if !loV6() {
+			t.Skip("loopback has no IPv6 address")
+		}
+		a := &announcer{logger: log.NewNopLogger(),
+			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}}
+		_, link, err := a.tryExtraInterfaces(net.ParseIP("::1"))
+		assert.NoError(t, err)
+		assert.Equal(t, "lo", link.Attrs().Name)
+	})
+
+	t.Run("dummy interface name skipped", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(),
+			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}, DummyInterface: "lo"}}
+		_, _, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		assert.Error(t, err)
+	})
+
+	t.Run("missing interface skipped without error abort", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(),
+			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0", "lo"}}}
+		_, link, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		assert.NoError(t, err)
+		assert.Equal(t, "lo", link.Attrs().Name)
+	})
+
+	t.Run("no candidate matches", func(t *testing.T) {
+		a := &announcer{logger: log.NewNopLogger(),
+			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0"}}}
+		_, _, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, errIndeterminate))
+	})
+}
+
+// withdrawalTestAnnouncer builds an announcer that has "announced"
+// TEST-NET addresses (192.0.2.0/24 is never on a real interface, so
+// deleteAddr's scan is read-only and removes nothing) with a live
+// renewal timer, ready to be driven into a withdrawal path.
+func withdrawalTestAnnouncer(config *purelbv2.LBNodeAgentLocalSpec) *announcer {
+	a := &announcer{
+		logger:       log.NewNopLogger(),
+		myNode:       "node-a",
+		client:       nopServiceEvent{},
+		config:       config,
+		groups:       map[string]*purelbv2.ServiceGroupLocalSpec{},
+		remoteGroups: map[string]*purelbv2.ServiceGroupRemoteSpec{},
+		svcIngresses: map[string][]v1.LoadBalancerIngress{},
+	}
+	return a
+}
+
+// announceForTest simulates a prior successful announcement of ip for
+// nsName: an announced-set entry plus a scheduled renewal timer.
+func announceForTest(a *announcer, nsName, ip string) {
+	a.announced.Store(renewalKey(nsName, ip), struct{}{})
+	lbIP := net.ParseIP(ip)
+	a.scheduleRenewal(nsName, net.IPNet{IP: lbIP, Mask: net.CIDRMask(24, 32)}, nil,
+		AddressOptions{ValidLft: 300, PreferedLft: 300})
+}
+
+func TestSetBalancerWithdrawsOnNoLocalInterface(t *testing.T) {
+	const slotKey = "purelb.io/announcing-IPv4"
+	a := withdrawalTestAnnouncer(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^purelb-nomatch$"})
+	a.localNameRegex = regexp.MustCompile("^purelb-nomatch$")
+
+	svc := lbSvc("192.0.2.1")
+	svc.Namespace = "default"
+	svc.Name = "test-svc"
+	svc.Annotations = map[string]string{slotKey: "node-a,eth0,192.0.2.1"}
+	announceForTest(a, "default/test-svc", "192.0.2.1")
+
+	assert.NoError(t, a.SetBalancer(svc, nil))
+
+	key := renewalKey("default/test-svc", "192.0.2.1")
+	_, announced := a.announced.Load(key)
+	assert.False(t, announced, "announced entry must be removed")
+	_, timerAlive := a.addressRenewals.Load(key)
+	assert.False(t, timerAlive, "renewal timer must be cancelled")
+	assert.Empty(t, svc.Annotations[slotKey], "announce slot must be cleared")
+}
+
+func TestSetBalancerWithdrawsOnNoConfig(t *testing.T) {
+	const slotKey = "purelb.io/announcing-IPv4"
+	a := withdrawalTestAnnouncer(nil) // nodeSelector deselection / config removal
+
+	svc := lbSvc("192.0.2.1")
+	svc.Namespace = "default"
+	svc.Name = "test-svc"
+	svc.Annotations = map[string]string{slotKey: "node-a,eth0,192.0.2.1"}
+	announceForTest(a, "default/test-svc", "192.0.2.1")
+
+	assert.NoError(t, a.SetBalancer(svc, nil))
+
+	key := renewalKey("default/test-svc", "192.0.2.1")
+	_, announced := a.announced.Load(key)
+	assert.False(t, announced, "announced entry must be removed")
+	_, timerAlive := a.addressRenewals.Load(key)
+	assert.False(t, timerAlive, "renewal timer must be cancelled")
+	assert.Empty(t, svc.Annotations[slotKey], "announce slot must be cleared")
+}
+
+func TestWithdrawalSharedIPRefcount(t *testing.T) {
+	a := withdrawalTestAnnouncer(nil)
+
+	announceForTest(a, "default/svc-a", "192.0.2.1")
+	announceForTest(a, "default/svc-b", "192.0.2.1")
+
+	// Withdrawing one service leaves the other's state intact — the
+	// shared address must not be removed while another announcer holds it.
+	assert.NoError(t, a.deleteAddress("default/svc-a", "test", net.ParseIP("192.0.2.1")))
+	_, aAnnounced := a.announced.Load(renewalKey("default/svc-a", "192.0.2.1"))
+	assert.False(t, aAnnounced)
+	_, bAnnounced := a.announced.Load(renewalKey("default/svc-b", "192.0.2.1"))
+	assert.True(t, bAnnounced, "second service's announced entry must survive")
+	_, bTimer := a.addressRenewals.Load(renewalKey("default/svc-b", "192.0.2.1"))
+	assert.True(t, bTimer, "second service's renewal timer must survive")
+
+	// Withdrawing the second reference releases the address.
+	assert.NoError(t, a.deleteAddress("default/svc-b", "test", net.ParseIP("192.0.2.1")))
+	_, bAnnounced = a.announced.Load(renewalKey("default/svc-b", "192.0.2.1"))
+	assert.False(t, bAnnounced)
+	_, bTimer = a.addressRenewals.Load(renewalKey("default/svc-b", "192.0.2.1"))
+	assert.False(t, bTimer)
 }

--- a/internal/local/metrics.go
+++ b/internal/local/metrics.go
@@ -71,6 +71,23 @@ var (
 		Help:      "Total number of addresses withdrawn from interfaces",
 	})
 
+	// naSent counts unsolicited IPv6 Neighbor Advertisements sent —
+	// the IPv6 counterpart of garpSent.
+	naSent = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: purelbv2.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "na_sent_total",
+		Help:      "Total number of unsolicited IPv6 Neighbor Advertisements sent",
+	})
+
+	// naErrors counts unsolicited NA send failures.
+	naErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: purelbv2.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "na_errors_total",
+		Help:      "Total number of unsolicited IPv6 Neighbor Advertisement send errors",
+	})
+
 	// electionWins counts how many times this node won an election.
 	electionWins = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: purelbv2.MetricsNamespace,
@@ -102,6 +119,8 @@ var (
 func init() {
 	prometheus.MustRegister(garpSent)
 	prometheus.MustRegister(garpErrors)
+	prometheus.MustRegister(naSent)
+	prometheus.MustRegister(naErrors)
 	prometheus.MustRegister(addressRenewalCount)
 	prometheus.MustRegister(addressRenewalErrors)
 	prometheus.MustRegister(addressAdditions)
@@ -119,6 +138,16 @@ func RecordGARPSent() {
 // RecordGARPError increments the GARP error counter.
 func RecordGARPError() {
 	garpErrors.Inc()
+}
+
+// RecordNASent increments the unsolicited-NA sent counter.
+func RecordNASent() {
+	naSent.Inc()
+}
+
+// RecordNAError increments the unsolicited-NA error counter.
+func RecordNAError() {
+	naErrors.Inc()
 }
 
 // RecordAddressRenewal increments the address renewal counter.

--- a/internal/local/network.go
+++ b/internal/local/network.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sort"
 	"syscall"
 
 	"github.com/mdlayher/arp"
@@ -30,48 +31,81 @@ import (
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
 
+// errIndeterminate means interface resolution could not be decided
+// this cycle (e.g. a partial netlink dump). Callers must not treat it
+// as "non-local": withdrawing an announcement on uncertain evidence
+// would turn transient kernel-dump races into VIP flaps.
+var errIndeterminate = errors.New("interface resolution indeterminate")
+
 // findLocal tries to find a "local" network interface based on the
 // name of the interface and the IP addresses that are assigned to it.
 // A network interface is considered local if its name matches the
-// configuration regex and lbIP is within the same network as the
-// interface.  If both are true, then the netlink.Link return value
-// will be the default interface and error will be nil.  If error is
-// non-nil then no local interface was found.
-func findLocal(regex *regexp.Regexp, lbIP net.IP) (net.IPNet, netlink.Link, error) {
+// configuration regex (excluding the interface named exclude) and lbIP
+// is within the same network as the interface.  If both are true, then
+// the netlink.Link return value will be that interface and error will
+// be nil.  If error is non-nil then no local interface was found;
+// errIndeterminate means resolution was uncertain this cycle.
+func findLocal(regex *regexp.Regexp, exclude string, lbIP net.IP) (net.IPNet, netlink.Link, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return net.IPNet{}, nil, err
 	}
 
+	// Collect the matching names, then sort: enumeration is in ifindex
+	// order which is boot-dependent, and when one subnet spans two
+	// matching interfaces the announce interface must not change
+	// across reboots.
+	matched := []string{}
 	for _, intf := range interfaces {
+		if intf.Name == exclude {
+			continue
+		}
 		if regex.Match([]byte(intf.Name)) {
-			// The interface name matches the local regex so check if the
-			// addresses also match
-			nlIntf, err := netlink.LinkByName(intf.Name)
-			if err != nil {
-				return net.IPNet{}, nil, err
-			}
-			if ipnet, link, err := checkLocal(nlIntf, lbIP); err == nil {
-				// The addresses match so this is a local interface
-				return ipnet, link, nil
-			}
+			matched = append(matched, intf.Name)
+		}
+	}
+	sort.Strings(matched)
+
+	indeterminate := false
+	for _, name := range matched {
+		nlIntf, err := netlink.LinkByName(name)
+		if err != nil {
+			// The interface disappeared between enumeration and lookup —
+			// routine veth churn on pod-dense nodes. Skip it; aborting
+			// the whole scan would fail resolution for every other
+			// matching interface.
+			continue
+		}
+		ipnet, link, err := checkLocal(nlIntf, lbIP)
+		if err == nil {
+			// The addresses match so this is a local interface
+			return ipnet, link, nil
+		}
+		if errors.Is(err, errIndeterminate) {
+			indeterminate = true
 		}
 	}
 
+	if indeterminate {
+		return net.IPNet{}, nil, errIndeterminate
+	}
 	return net.IPNet{}, nil, fmt.Errorf("No local interface found")
 }
 
 // checkLocal determines whether lbIP belongs to the same network as
 // intf.  If so, then the netlink.Link return value will be the
 // default interface and error will be nil.  If error is non-nil then
-// the address is non-local.
+// the address is non-local; errIndeterminate means the address dump
+// was partial and no containing address was seen, so "non-local"
+// cannot be concluded this cycle.
 func checkLocal(intf netlink.Link, lbIP net.IP) (net.IPNet, netlink.Link, error) {
 	var lbIPNet net.IPNet = net.IPNet{IP: lbIP}
 
 	family := purelbv2.AddrFamily(lbIP)
 
 	defaddrs, err := netlink.AddrList(intf, family)
-	if err != nil && !errors.Is(err, netlink.ErrDumpInterrupted) {
+	partialDump := errors.Is(err, netlink.ErrDumpInterrupted)
+	if err != nil && !partialDump {
 		return lbIPNet, intf, err
 	}
 
@@ -97,6 +131,11 @@ func checkLocal(intf netlink.Link, lbIP net.IP) (net.IPNet, netlink.Link, error)
 	}
 
 	if lbIPNet.Mask == nil {
+		if partialDump {
+			// The dump was interrupted and we saw no containing address:
+			// it may simply have been missing from the partial results.
+			return lbIPNet, intf, errIndeterminate
+		}
 		return lbIPNet, intf, fmt.Errorf("non-local address")
 	}
 

--- a/internal/local/network.go
+++ b/internal/local/network.go
@@ -18,12 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"regexp"
 	"sort"
 	"syscall"
 
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ethernet"
+	"github.com/mdlayher/ndp"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 
@@ -360,6 +362,53 @@ func sendGARP(ifName string, ip net.IP) error {
 		if err = client.WriteTo(pkt, ethernet.Broadcast); err != nil {
 			return fmt.Errorf("writing %q gratuitous packet for %q: %w", op, ip, err)
 		}
+	}
+	return nil
+}
+
+// buildUnsolicitedNA assembles the unsolicited Neighbor Advertisement
+// for target announced from hwAddr: Override set so neighbors replace
+// an existing cache entry for the moved VIP, Solicited clear (nobody
+// asked), Router clear (the VIP is a host address, not a router).
+func buildUnsolicitedNA(target netip.Addr, hwAddr net.HardwareAddr) *ndp.NeighborAdvertisement {
+	return &ndp.NeighborAdvertisement{
+		Override:      true,
+		TargetAddress: target,
+		Options: []ndp.Option{
+			&ndp.LinkLayerAddress{Direction: ndp.Target, Addr: hwAddr},
+		},
+	}
+}
+
+// sendUnsolicitedNA sends an unsolicited Neighbor Advertisement for ip
+// on ifName — the IPv6 counterpart of sendGARP. The kernel does not do
+// this for us: adding an address only triggers DAD, whose probes are
+// sourced from :: and update no neighbor caches, so without this a
+// moved IPv6 VIP converges only via NUD timeouts.
+func sendUnsolicitedNA(ifName string, ip net.IP) error {
+	if ip.To4() != nil {
+		return fmt.Errorf("not an IPv6 address: %s", ip)
+	}
+	target, ok := netip.AddrFromSlice(ip.To16())
+	if !ok {
+		return fmt.Errorf("invalid IPv6 address: %s", ip)
+	}
+
+	ifi, err := net.InterfaceByName(ifName)
+	if err != nil {
+		return fmt.Errorf("finding interface named %s: %w", ifName, err)
+	}
+
+	c, _, err := ndp.Listen(ifi, ndp.LinkLocal)
+	if err != nil {
+		return fmt.Errorf("creating NDP responder for %s: %w", ifName, err)
+	}
+	defer c.Close()
+
+	// RFC 4861 §7.2.6: unsolicited advertisements go to the all-nodes
+	// multicast address.
+	if err := c.WriteTo(buildUnsolicitedNA(target, ifi.HardwareAddr), nil, netip.AddrFrom16([16]byte{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01})); err != nil {
+		return fmt.Errorf("writing unsolicited NA for %q: %w", ip, err)
 	}
 	return nil
 }

--- a/pkg/apis/purelb/v2/nodeselect.go
+++ b/pkg/apis/purelb/v2/nodeselect.go
@@ -38,7 +38,7 @@ func AgentsForNode(agents []*LBNodeAgent, nodeLabels map[string]string) []*LBNod
 		if agent == nil {
 			continue
 		}
-		if isCatchAll(agent.Spec.NodeSelector) {
+		if IsCatchAll(agent.Spec.NodeSelector) {
 			catchAll = append(catchAll, agent)
 			continue
 		}
@@ -69,9 +69,13 @@ func FirstLocalAgent(agents []*LBNodeAgent) *LBNodeAgent {
 	return nil
 }
 
-// isCatchAll reports whether the selector matches all nodes: nil, or
-// empty (no matchLabels and no matchExpressions).
-func isCatchAll(sel *metav1.LabelSelector) bool {
+// IsCatchAll reports whether the selector matches all nodes: nil, or
+// empty (no matchLabels and no matchExpressions). It is exported because
+// it defines the precedence classes used by AgentsForNode, and callers
+// that explain a resolution — such as the kubectl plugin distinguishing
+// an intended override from an ambiguous collision — must classify
+// selectors exactly the same way.
+func IsCatchAll(sel *metav1.LabelSelector) bool {
 	return sel == nil || (len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0)
 }
 

--- a/pkg/apis/purelb/v2/nodeselect.go
+++ b/pkg/apis/purelb/v2/nodeselect.go
@@ -1,0 +1,85 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// AgentsForNode returns the agents whose NodeSelector matches
+// nodeLabels, in precedence order: specific selectors before
+// catch-alls, then namespace/name sort. A nil selector and an empty
+// selector (no matchLabels, no matchExpressions) are both catch-alls —
+// LabelSelectorAsSelector turns an empty selector into
+// labels.Everything(), so ranking it "specific" would invert the
+// default-plus-override precedence. Agents whose selector cannot be
+// converted are skipped; the caller is responsible for logging or
+// eventing skipped and ignored agents.
+func AgentsForNode(agents []*LBNodeAgent, nodeLabels map[string]string) []*LBNodeAgent {
+	var specific, catchAll []*LBNodeAgent
+
+	set := labels.Set(nodeLabels)
+	for _, agent := range agents {
+		if agent == nil {
+			continue
+		}
+		if isCatchAll(agent.Spec.NodeSelector) {
+			catchAll = append(catchAll, agent)
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(agent.Spec.NodeSelector)
+		if err != nil {
+			// Invalid selector: this agent can't match any node.
+			continue
+		}
+		if selector.Matches(set) {
+			specific = append(specific, agent)
+		}
+	}
+
+	sortByNamespaceName(specific)
+	sortByNamespaceName(catchAll)
+	return append(specific, catchAll...)
+}
+
+// FirstLocalAgent returns the first agent with Spec.Local != nil, or
+// nil if there is none. It is shared by the announcer and the election
+// selector so that both sides always choose the same agent.
+func FirstLocalAgent(agents []*LBNodeAgent) *LBNodeAgent {
+	for _, agent := range agents {
+		if agent != nil && agent.Spec.Local != nil {
+			return agent
+		}
+	}
+	return nil
+}
+
+// isCatchAll reports whether the selector matches all nodes: nil, or
+// empty (no matchLabels and no matchExpressions).
+func isCatchAll(sel *metav1.LabelSelector) bool {
+	return sel == nil || (len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0)
+}
+
+func sortByNamespaceName(agents []*LBNodeAgent) {
+	sort.SliceStable(agents, func(i, j int) bool {
+		if agents[i].Namespace != agents[j].Namespace {
+			return agents[i].Namespace < agents[j].Namespace
+		}
+		return agents[i].Name < agents[j].Name
+	})
+}

--- a/pkg/apis/purelb/v2/nodeselect_test.go
+++ b/pkg/apis/purelb/v2/nodeselect_test.go
@@ -1,0 +1,132 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func agent(namespace, name string, selector *metav1.LabelSelector, local *LBNodeAgentLocalSpec) *LBNodeAgent {
+	return &LBNodeAgent{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       LBNodeAgentSpec{NodeSelector: selector, Local: local},
+	}
+}
+
+func names(agents []*LBNodeAgent) []string {
+	result := []string{}
+	for _, a := range agents {
+		result = append(result, a.Namespace+"/"+a.Name)
+	}
+	return result
+}
+
+func TestAgentsForNode(t *testing.T) {
+	nodeLabels := map[string]string{
+		"kubernetes.io/hostname": "node-1",
+		"zone":                   "a",
+	}
+
+	matchNode1 := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/hostname": "node-1"},
+	}
+	matchOther := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/hostname": "node-2"},
+	}
+	matchExprZone := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "zone", Operator: metav1.LabelSelectorOpIn, Values: []string{"a", "b"}},
+		},
+	}
+	invalid := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "zone", Operator: "BogusOperator"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		agents []*LBNodeAgent
+		want   []string
+	}{
+		{name: "empty agents", agents: nil, want: []string{}},
+		{
+			name:   "nil selector matches all",
+			agents: []*LBNodeAgent{agent("purelb", "default", nil, nil)},
+			want:   []string{"purelb/default"},
+		},
+		{
+			name:   "matchLabels match and no-match",
+			agents: []*LBNodeAgent{agent("purelb", "scoped", matchNode1, nil), agent("purelb", "other", matchOther, nil)},
+			want:   []string{"purelb/scoped"},
+		},
+		{
+			name:   "matchExpressions",
+			agents: []*LBNodeAgent{agent("purelb", "zoned", matchExprZone, nil)},
+			want:   []string{"purelb/zoned"},
+		},
+		{
+			name:   "specific beats catch-all regardless of list order",
+			agents: []*LBNodeAgent{agent("purelb", "aaa-default", nil, nil), agent("purelb", "zzz-scoped", matchNode1, nil)},
+			want:   []string{"purelb/zzz-scoped", "purelb/aaa-default"},
+		},
+		{
+			name:   "empty selector is catch-all, not specific",
+			agents: []*LBNodeAgent{agent("purelb", "aaa-empty", &metav1.LabelSelector{}, nil), agent("purelb", "zzz-scoped", matchNode1, nil)},
+			want:   []string{"purelb/zzz-scoped", "purelb/aaa-empty"},
+		},
+		{
+			name: "namespace/name tie-break within each class",
+			agents: []*LBNodeAgent{
+				agent("zeta", "a", matchNode1, nil),
+				agent("alpha", "b", matchNode1, nil),
+				agent("alpha", "a", matchNode1, nil),
+				agent("beta", "catch", nil, nil),
+				agent("alpha", "catch", nil, nil),
+			},
+			want: []string{"alpha/a", "alpha/b", "zeta/a", "alpha/catch", "beta/catch"},
+		},
+		{
+			name:   "invalid selector skipped, others still considered",
+			agents: []*LBNodeAgent{agent("purelb", "broken", invalid, nil), agent("purelb", "default", nil, nil)},
+			want:   []string{"purelb/default"},
+		},
+		{
+			name:   "no match at all",
+			agents: []*LBNodeAgent{agent("purelb", "other", matchOther, nil)},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, names(AgentsForNode(tt.agents, nodeLabels)))
+		})
+	}
+}
+
+func TestFirstLocalAgent(t *testing.T) {
+	local := &LBNodeAgentLocalSpec{LocalInterface: "default"}
+
+	assert.Nil(t, FirstLocalAgent(nil))
+	assert.Nil(t, FirstLocalAgent([]*LBNodeAgent{agent("purelb", "remote-only", nil, nil)}))
+
+	first := agent("purelb", "first", nil, local)
+	second := agent("purelb", "second", nil, local)
+	assert.Same(t, first, FirstLocalAgent([]*LBNodeAgent{agent("purelb", "remote-only", nil, nil), first, second}))
+}

--- a/pkg/apis/purelb/v2/types.go
+++ b/pkg/apis/purelb/v2/types.go
@@ -358,6 +358,16 @@ type LBNodeAgent struct {
 
 // LBNodeAgentSpec configures the node agents.
 type LBNodeAgentSpec struct {
+	// NodeSelector limits which nodes this agent configuration applies
+	// to. A nil or empty selector matches all nodes (catch-all). When
+	// multiple LBNodeAgent resources match a node, specific selectors
+	// take precedence over catch-alls, then resources are ordered by
+	// namespace/name and the first is used. Like a Pod's nodeSelector,
+	// node label changes are evaluated when configuration is next
+	// delivered, not continuously.
+	// +optional
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+
 	// Local configures announcement of service addresses by configuring
 	// the underlying operating system networking.
 	// +optional

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,14 +32,19 @@ skipping). One-command invocation for the prox-purelb2 profile
 subnet; nodes 1-2 provide the other-node-on-subnet the migration
 assertion needs):
 
+The pool ranges must not overlap the suite's generated default
+ServiceGroup (`.200-.220` and `:a::1-:a::20` per subnet) or the per-test
+ranges (`.230-.240`, `:b::1-:b::20`) — the allocator rejects overlapping
+ServiceGroups outright.
+
 ```bash
 cd local
 MULTI_IF_NODE=purelb2-3 \
 MULTI_IF_IFACE=eth0 \
 MULTI_IF_SUBNET=172.30.250.0/24 \
 MULTI_IF_SUBNET6=2001:470:b8f3:250::/64 \
-MULTI_IF_POOL_V4=172.30.250.220/30 \
-MULTI_IF_POOL_V6=2001:470:b8f3:250::dc0/124 \
+MULTI_IF_POOL_V4=172.30.250.244-172.30.250.247 \
+MULTI_IF_POOL_V6=2001:470:b8f3:250:c::1-2001:470:b8f3:250:c::10 \
 ./test-local-allocation.sh
 ```
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -21,6 +21,28 @@ cd <test-directory>
 ./<test-script>.sh
 ```
 
+### Multi-interface test (gated)
+
+`test_multi_interface` in the local suite exercises nodeSelector-scoped
+LBNodeAgent CRs and multi-NIC announcement on a dual-homed node. It only
+runs when the `MULTI_IF_*` environment variables are set (all six are
+required together — a partial set fails loudly rather than silently
+skipping). One-command invocation for the prox-purelb2 profile
+(purelb2-3 is dual-homed: eth1 on the 251 subnet, eth2 on the 250
+subnet; nodes 1-2 provide the other-node-on-subnet the migration
+assertion needs):
+
+```bash
+cd local
+MULTI_IF_NODE=purelb2-3 \
+MULTI_IF_IFACE=eth2 \
+MULTI_IF_SUBNET=172.30.250.0/24 \
+MULTI_IF_SUBNET6=2001:470:b8f3:250::/64 \
+MULTI_IF_POOL_V4=172.30.250.220/30 \
+MULTI_IF_POOL_V6=2001:470:b8f3:250::dc0/124 \
+./test-local-allocation.sh
+```
+
 ## Testing Methodology
 
 These E2E tests use **SSH-based connectivity testing** rather than external routing (BGP, static routes). This approach:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,14 +28,14 @@ LBNodeAgent CRs and multi-NIC announcement on a dual-homed node. It only
 runs when the `MULTI_IF_*` environment variables are set (all six are
 required together — a partial set fails loudly rather than silently
 skipping). One-command invocation for the prox-purelb2 profile
-(purelb2-3 is dual-homed: eth1 on the 251 subnet, eth2 on the 250
+(purelb2-3 is dual-homed: eth1 on the 251 subnet, eth0 on the 250
 subnet; nodes 1-2 provide the other-node-on-subnet the migration
 assertion needs):
 
 ```bash
 cd local
 MULTI_IF_NODE=purelb2-3 \
-MULTI_IF_IFACE=eth2 \
+MULTI_IF_IFACE=eth0 \
 MULTI_IF_SUBNET=172.30.250.0/24 \
 MULTI_IF_SUBNET6=2001:470:b8f3:250::/64 \
 MULTI_IF_POOL_V4=172.30.250.220/30 \

--- a/test/e2e/local/test-local-allocation.sh
+++ b/test/e2e/local/test-local-allocation.sh
@@ -402,6 +402,23 @@ test_multi_interface() {
     echo "TEST: Multi-Interface Node ($MULTI_IF_NODE via $MULTI_IF_IFACE)"
     echo "=========================================="
 
+    # ----- Pre-clean: a failed earlier run leaks the scoped CR and node
+    # label (fail() exits before this test's cleanup, and the suite's
+    # iteration cleanup doesn't touch LBNodeAgent resources), which the
+    # baseline guard below would then trip over. Self-heal first.
+    if kubectl get lbnodeagent multi-if-test -n purelb-system >/dev/null 2>&1 || \
+       kubectl get node "$MULTI_IF_NODE" -o jsonpath='{.metadata.labels.purelb-test}' 2>/dev/null | grep -q .; then
+        info "Cleaning up leftovers from a previous run..."
+        kubectl delete lbnodeagent multi-if-test -n purelb-system --ignore-not-found >/dev/null 2>&1 || true
+        kubectl delete svc multi-if-lb -n $NAMESPACE --ignore-not-found >/dev/null 2>&1 || true
+        kubectl delete deployment multi-if-echo -n $NAMESPACE --ignore-not-found >/dev/null 2>&1 || true
+        kubectl delete servicegroup multi-if-test -n purelb-system --ignore-not-found >/dev/null 2>&1 || true
+        kubectl label node "$MULTI_IF_NODE" purelb-test- >/dev/null 2>&1 || true
+        wait_for_lease_subnet_gone "$MULTI_IF_NODE" "$MULTI_IF_SUBNET" 30 \
+            || fail "Multi-interface: pre-clean did not restore baseline lease"
+        pass "Leftovers cleaned, baseline restored"
+    fi
+
     # ----- Baselines
     local baseline_subnets baseline_count metrics
     baseline_subnets=$(get_node_lease_subnets "$MULTI_IF_NODE")
@@ -5228,6 +5245,12 @@ for iter in $(seq 1 $ITERATIONS); do
         kubectl get servicegroup -n purelb-system -o name 2>/dev/null \
             | grep -v '/default$' \
             | xargs -r kubectl delete -n purelb-system --ignore-not-found 2>/dev/null || true
+        # Test-created LBNodeAgent resources (multi-interface test) leak the
+        # same way; keep only 'default'.
+        kubectl get lbnodeagent -n purelb-system -o name 2>/dev/null \
+            | grep -v '/default$' \
+            | xargs -r kubectl delete -n purelb-system --ignore-not-found 2>/dev/null || true
+        kubectl label node --all purelb-test- 2>/dev/null || true
     fi
 done
 

--- a/test/e2e/local/test-local-allocation.sh
+++ b/test/e2e/local/test-local-allocation.sh
@@ -273,6 +273,404 @@ test_lease_verification() {
 }
 
 #---------------------------------------------------------------------
+# Test: Multi-Interface Node (gated on MULTI_IF_* env)
+# Exercises nodeSelector-scoped LBNodeAgent CRs and multi-NIC subnet
+# detection/announcement on a dual-homed node: regex and interfaces[]
+# selection, lease convergence, affinity pinning, withdrawal on config
+# shrink (renewal-timer death), migration to another eligible node, and
+# full deselection (noConfig withdrawal).
+#
+# Requires a node with a second NIC plus explicit configuration; the
+# expectations are deliberately NOT autodetected (they would then be
+# derived from the code under test). Skips when none of the MULTI_IF_*
+# variables are set; fails loudly when only some are.
+#
+# Env contract (all required together):
+#   MULTI_IF_NODE     dual-homed node name             (e.g. purelb2-3)
+#   MULTI_IF_IFACE    second NIC on that node          (e.g. eth2)
+#   MULTI_IF_SUBNET   second NIC's IPv4 subnet, exact network form
+#                     matching the SG subnet spec      (e.g. 172.30.250.0/24)
+#   MULTI_IF_SUBNET6  second NIC's IPv6 subnet, exact network form
+#                                            (e.g. 2001:470:b8f3:250::/64)
+#   MULTI_IF_POOL_V4  IPv4 pool inside MULTI_IF_SUBNET (e.g. 172.30.250.220/30)
+#   MULTI_IF_POOL_V6  IPv6 pool inside MULTI_IF_SUBNET6
+# The migration assertion additionally expects at least one OTHER node
+# to be on MULTI_IF_SUBNET (true on prox-purelb2: nodes 1-2).
+#---------------------------------------------------------------------
+MULTI_IF_REQUIRED_VARS="MULTI_IF_NODE MULTI_IF_IFACE MULTI_IF_SUBNET MULTI_IF_SUBNET6 MULTI_IF_POOL_V4 MULTI_IF_POOL_V6"
+
+# wait_for_lease_subnet NODE SUBNET [TIMEOUT] — poll until the node's
+# lease annotation contains SUBNET (fixed-string match).
+wait_for_lease_subnet() {
+    local node=$1 subnet=$2 timeout=${3:-20} elapsed=0
+    while [ $elapsed -lt $timeout ]; do
+        if get_node_lease_subnets "$node" | grep -qF "$subnet"; then return 0; fi
+        sleep 2; elapsed=$((elapsed + 2))
+    done
+    return 1
+}
+
+# wait_for_lease_subnet_gone NODE SUBNET [TIMEOUT]
+wait_for_lease_subnet_gone() {
+    local node=$1 subnet=$2 timeout=${3:-20} elapsed=0
+    while [ $elapsed -lt $timeout ]; do
+        if ! get_node_lease_subnets "$node" | grep -qF "$subnet"; then return 0; fi
+        sleep 2; elapsed=$((elapsed + 2))
+    done
+    return 1
+}
+
+# vip_on_iface NODE IFACE IP — is IP configured on NODE's IFACE?
+vip_on_iface() {
+    node_ssh "$1" "ip -o addr show $2 2>/dev/null | grep -q ' $3/'" 2>/dev/null
+}
+
+# assert_selector_state NODE STATE — the selector_state gauge must
+# report 1 for STATE on NODE.
+assert_selector_state() {
+    local node=$1 state=$2
+    local metrics value
+    metrics=$(scrape_lbnodeagent_metrics "$node")
+    value=$(extract_metric "$metrics" "purelb_lbnodeagent_selector_state{state=\"$state\"}")
+    if [ "$value" = "1" ]; then
+        pass "selector_state{state=\"$state\"}=1 on $node"
+    else
+        fail "selector_state{state=\"$state\"} on $node is '${value:-missing}', want 1"
+    fi
+}
+
+# apply_multi_if_cr VARIANT — create/update the scoped LBNodeAgent CR.
+# VARIANT "regex" uses a localInterface regex covering both NICs;
+# VARIANT "interfaces" uses localInterface default + interfaces[].
+# validLifetime 60 makes the renewal interval 30s so the
+# "not re-added after >35s" assertions actually prove timer death
+# (at the default 300 the first re-add is at 150s and a short wait
+# would pass even with the bug present).
+apply_multi_if_cr() {
+    local variant=$1
+    local primary_iface="${NODE_IFACE[$MULTI_IF_NODE]}"
+    local iface_config
+    if [ "$variant" = "regex" ]; then
+        iface_config="localInterface: \"^(${primary_iface}|${MULTI_IF_IFACE})\$\""
+    else
+        iface_config=$(printf 'localInterface: default\n    interfaces:\n    - %s' "$MULTI_IF_IFACE")
+    fi
+    kubectl apply -f - <<EOF
+apiVersion: purelb.io/v2
+kind: LBNodeAgent
+metadata:
+  name: multi-if-test
+  namespace: purelb-system
+spec:
+  nodeSelector:
+    matchLabels:
+      purelb-test: multi-if
+  local:
+    ${iface_config}
+    garpConfig:
+      enabled: true
+    addressConfig:
+      localInterface:
+        validLifetime: 60
+        preferredLifetime: 60
+EOF
+}
+
+test_multi_interface() {
+    # ----- Env gate: skip only when nothing is set; partial = loud fail
+    local set_count=0 total=0 missing=""
+    local var
+    for var in $MULTI_IF_REQUIRED_VARS; do
+        total=$((total + 1))
+        if [ -n "${!var:-}" ]; then
+            set_count=$((set_count + 1))
+        else
+            missing="$missing $var"
+        fi
+    done
+    if [ "$set_count" -eq 0 ]; then
+        info "SKIP: Multi-interface test (set these to enable):"
+        for var in $MULTI_IF_REQUIRED_VARS; do detail "$var"; done
+        return 0
+    fi
+    if [ "$set_count" -ne "$total" ]; then
+        fail "Multi-interface: partial MULTI_IF_* environment - missing:$missing"
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "TEST: Multi-Interface Node ($MULTI_IF_NODE via $MULTI_IF_IFACE)"
+    echo "=========================================="
+
+    # ----- Baselines
+    local baseline_subnets baseline_count metrics
+    baseline_subnets=$(get_node_lease_subnets "$MULTI_IF_NODE")
+    metrics=$(scrape_lbnodeagent_metrics "$MULTI_IF_NODE")
+    baseline_count=$(extract_metric "$metrics" "purelb_election_local_subnet_count")
+    detail "$MULTI_IF_NODE baseline lease subnets: $baseline_subnets (count metric: ${baseline_count:-?})"
+    if echo "$baseline_subnets" | grep -qF "$MULTI_IF_SUBNET"; then
+        fail "Multi-interface: baseline lease already contains $MULTI_IF_SUBNET - stale scoped config?"
+    fi
+
+    declare -A other_baseline
+    local node
+    for node in $NODES; do
+        [ "$node" = "$MULTI_IF_NODE" ] && continue
+        other_baseline[$node]=$(get_node_lease_subnets "$node")
+    done
+
+    # ----- Phase 1: scoped CR (nodeSelector) with interface regex
+    info "Labeling $MULTI_IF_NODE and creating scoped LBNodeAgent (regex variant)..."
+    kubectl label node "$MULTI_IF_NODE" purelb-test=multi-if --overwrite >/dev/null
+    apply_multi_if_cr regex
+
+    wait_for_lease_subnet "$MULTI_IF_NODE" "$MULTI_IF_SUBNET" 20 \
+        || fail "Multi-interface: lease never gained $MULTI_IF_SUBNET"
+    pass "Lease gained $MULTI_IF_SUBNET"
+    wait_for_lease_subnet "$MULTI_IF_NODE" "$MULTI_IF_SUBNET6" 20 \
+        || fail "Multi-interface: lease never gained $MULTI_IF_SUBNET6"
+    pass "Lease gained $MULTI_IF_SUBNET6"
+
+    assert_log_contains_on_node "$MULTI_IF_NODE" "subnetsChanged" \
+        "lease subnet annotation updated after scoped config"
+    pass "subnetsChanged logged on $MULTI_IF_NODE"
+    assert_selector_state "$MULTI_IF_NODE" "configured"
+
+    metrics=$(scrape_lbnodeagent_metrics "$MULTI_IF_NODE")
+    local new_count
+    new_count=$(extract_metric "$metrics" "purelb_election_local_subnet_count")
+    if [ -n "$baseline_count" ] && [ -n "$new_count" ] && [ "$new_count" -gt "$baseline_count" ]; then
+        pass "local_subnet_count increased ($baseline_count -> $new_count)"
+    else
+        fail "local_subnet_count did not increase (was ${baseline_count:-?}, now ${new_count:-?})"
+    fi
+
+    for node in $NODES; do
+        [ "$node" = "$MULTI_IF_NODE" ] && continue
+        if [ "$(get_node_lease_subnets "$node")" = "${other_baseline[$node]}" ]; then
+            pass "Scoping: $node lease unchanged"
+        else
+            fail "Multi-interface: scoped CR changed $node lease (was '${other_baseline[$node]}', now '$(get_node_lease_subnets "$node")')"
+        fi
+    done
+
+    # ----- Second-subnet pool + affinity-pinned service
+    info "Creating second-subnet ServiceGroup, pinned endpoints and dual-stack Service..."
+    kubectl apply -f - <<EOF
+apiVersion: purelb.io/v2
+kind: ServiceGroup
+metadata:
+  name: multi-if-test
+  namespace: purelb-system
+spec:
+  local:
+    v4pools:
+    - subnet: ${MULTI_IF_SUBNET}
+      pool: ${MULTI_IF_POOL_V4}
+      aggregation: default
+    v6pools:
+    - subnet: ${MULTI_IF_SUBNET6}
+      pool: ${MULTI_IF_POOL_V6}
+      aggregation: default
+EOF
+    CLEANUP_SGS+=("multi-if-test")
+
+    kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-if-echo
+  namespace: $NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multi-if-echo
+  template:
+    metadata:
+      labels:
+        app: multi-if-echo
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ${MULTI_IF_NODE}
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+    kubectl wait --for=condition=Available deployment/multi-if-echo -n $NAMESPACE --timeout=120s \
+        || fail "Multi-interface: pinned deployment never became available"
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: multi-if-lb
+  namespace: $NAMESPACE
+  annotations:
+    purelb.io/service-group: multi-if-test
+    purelb.io/node-affinity: service-endpoints
+spec:
+  type: LoadBalancer
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+  - IPv4
+  - IPv6
+  selector:
+    app: multi-if-echo
+  ports:
+  - port: 80
+    targetPort: 80
+EOF
+
+    kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' \
+        svc/multi-if-lb -n $NAMESPACE --timeout=30s || fail "Multi-interface: no IP allocated"
+
+    local vip4="" vip6="" ip
+    for ip in $(kubectl get svc multi-if-lb -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[*].ip}'); do
+        case "$ip" in
+            *:*) vip6="$ip" ;;
+            *)   vip4="$ip" ;;
+        esac
+    done
+    [ -n "$vip4" ] || fail "Multi-interface: no IPv4 VIP allocated"
+    [ -n "$vip6" ] || fail "Multi-interface: no IPv6 VIP allocated"
+    detail "VIPs: $vip4 / $vip6"
+
+    wait_for_announcer "$NAMESPACE" multi-if-lb IPv4 "$MULTI_IF_NODE" 30 \
+        || fail "Multi-interface: $MULTI_IF_NODE never announced $vip4 ($(get_announcing "$NAMESPACE" multi-if-lb IPv4))"
+    pass "$MULTI_IF_NODE announces $vip4"
+    wait_for_announcer "$NAMESPACE" multi-if-lb IPv6 "$MULTI_IF_NODE" 30 \
+        || fail "Multi-interface: $MULTI_IF_NODE never announced $vip6 ($(get_announcing "$NAMESPACE" multi-if-lb IPv6))"
+    pass "$MULTI_IF_NODE announces $vip6"
+
+    vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip4" \
+        || fail "Multi-interface: $vip4 not present on $MULTI_IF_IFACE"
+    pass "$vip4 on $MULTI_IF_IFACE"
+    vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip6" \
+        || fail "Multi-interface: $vip6 not present on $MULTI_IF_IFACE"
+    pass "$vip6 on $MULTI_IF_IFACE"
+
+    # IPv6 failover parity: announcing a v6 VIP must send unsolicited
+    # Neighbor Advertisements (the GARP counterpart).
+    sleep 3
+    metrics=$(scrape_lbnodeagent_metrics "$MULTI_IF_NODE")
+    local na_sent
+    na_sent=$(extract_metric "$metrics" "purelb_lbnodeagent_na_sent_total")
+    if [ -n "$na_sent" ] && [ "$na_sent" -gt 0 ]; then
+        pass "Unsolicited NA sent (na_sent_total=$na_sent)"
+    else
+        fail "Multi-interface: na_sent_total is '${na_sent:-missing}' after IPv6 announcement"
+    fi
+
+    # ----- Transition A: delete the scoped CR (fallback to catch-all)
+    info "Deleting scoped CR - node must withdraw and the VIP must migrate..."
+    kubectl delete lbnodeagent multi-if-test -n purelb-system
+
+    wait_for_lease_subnet_gone "$MULTI_IF_NODE" "$MULTI_IF_SUBNET" 20 \
+        || fail "Multi-interface: lease kept $MULTI_IF_SUBNET after scoped CR deletion"
+    pass "Lease shrank (lost $MULTI_IF_SUBNET)"
+
+    sleep 3
+    assert_log_contains_on_node "$MULTI_IF_NODE" "withdrawAddress" \
+        "withdrawal after config shrink"
+    pass "withdrawAddress logged on $MULTI_IF_NODE"
+
+    # The renewal timer must be dead: with validLifetime 60 the timer
+    # would re-add the address after 30s, so absence after >35s proves
+    # the withdrawal cancelled it.
+    info "Waiting 40s to prove the renewal timer died (interval 30s at validLifetime 60)..."
+    sleep 40
+    if vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip4"; then
+        fail "Multi-interface: $vip4 re-appeared on $MULTI_IF_IFACE - renewal timer survived withdrawal"
+    fi
+    pass "$vip4 stayed off $MULTI_IF_IFACE for >35s (timer dead)"
+    if vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip6"; then
+        fail "Multi-interface: $vip6 re-appeared on $MULTI_IF_IFACE - renewal timer survived withdrawal"
+    fi
+    pass "$vip6 stayed off $MULTI_IF_IFACE for >35s (timer dead)"
+
+    # Convergence upper bound: another node on that subnet must have
+    # picked the VIP up (not just absence on the old node).
+    local new_announcer
+    new_announcer=$(get_announcing "$NAMESPACE" multi-if-lb IPv4)
+    if [ -n "$new_announcer" ] && ! announcing_has_node "$new_announcer" "$MULTI_IF_NODE"; then
+        pass "VIP migrated: $new_announcer"
+    else
+        fail "Multi-interface: VIP did not migrate to another eligible node (annotation: '$new_announcer')"
+    fi
+
+    # ----- Phase 2: scoped CR with localInterface default + interfaces[]
+    info "Re-creating scoped CR (interfaces[] variant) - affinity must pull the VIP back..."
+    apply_multi_if_cr interfaces
+
+    wait_for_lease_subnet "$MULTI_IF_NODE" "$MULTI_IF_SUBNET" 20 \
+        || fail "Multi-interface: interfaces[] variant never restored $MULTI_IF_SUBNET"
+    pass "interfaces[] variant restored lease subnet"
+
+    wait_for_announcer "$NAMESPACE" multi-if-lb IPv4 "$MULTI_IF_NODE" 45 \
+        || fail "Multi-interface: affinity did not pull $vip4 back to $MULTI_IF_NODE"
+    pass "Affinity pulled $vip4 back to $MULTI_IF_NODE (interfaces[] path)"
+    vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip4" \
+        || fail "Multi-interface: $vip4 not on $MULTI_IF_IFACE via interfaces[]"
+    pass "$vip4 on $MULTI_IF_IFACE via interfaces[]"
+
+    # ----- Transition B: deselect the node entirely (noConfig path).
+    # The default catch-all CR would still match, so it temporarily gets
+    # a NotIn selector that excludes the labeled node. The subshell trap
+    # restores it even if an assertion fails mid-test.
+    info "Deselecting $MULTI_IF_NODE from every CR (noConfig withdrawal)..."
+    if ! (
+        trap 'kubectl patch lbnodeagent default -n purelb-system --type=json -p "[{\"op\":\"remove\",\"path\":\"/spec/nodeSelector\"}]" >/dev/null 2>&1 || true' EXIT
+        kubectl patch lbnodeagent default -n purelb-system --type=merge -p \
+            '{"spec":{"nodeSelector":{"matchExpressions":[{"key":"purelb-test","operator":"NotIn","values":["multi-if"]}]}}}' >/dev/null
+        kubectl patch lbnodeagent multi-if-test -n purelb-system --type=merge -p \
+            '{"spec":{"nodeSelector":{"matchLabels":{"purelb-test":"deselected-nothing-matches"}}}}' >/dev/null
+
+        elapsed=0
+        while [ $elapsed -lt 20 ]; do
+            [ -z "$(get_node_lease_subnets "$MULTI_IF_NODE")" ] && break
+            sleep 2; elapsed=$((elapsed + 2))
+        done
+        [ -z "$(get_node_lease_subnets "$MULTI_IF_NODE")" ] \
+            || fail "Multi-interface: deselected node still advertises subnets: $(get_node_lease_subnets "$MULTI_IF_NODE")"
+        pass "Deselected node advertises no subnets"
+
+        assert_selector_state "$MULTI_IF_NODE" "deselected"
+
+        sleep 3
+        assert_log_contains_on_node "$MULTI_IF_NODE" "noConfig" \
+            "deselection lands in the noConfig path"
+        pass "noConfig logged on deselected node"
+
+        info "Waiting 40s to prove the noConfig withdrawal killed the renewal timer..."
+        sleep 40
+        if vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip4" || \
+           vip_on_iface "$MULTI_IF_NODE" "$MULTI_IF_IFACE" "$vip6"; then
+            fail "Multi-interface: VIP re-appeared on deselected node - noConfig withdrawal incomplete"
+        fi
+        pass "VIPs stayed off the deselected node for >35s"
+    ); then
+        fail "Multi-interface: deselect sub-test failed"
+    fi
+
+    # ----- Cleanup (default CR was restored by the subshell trap)
+    info "Cleaning up multi-interface test resources..."
+    kubectl delete svc multi-if-lb -n $NAMESPACE --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete deployment multi-if-echo -n $NAMESPACE --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete lbnodeagent multi-if-test -n purelb-system --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete servicegroup multi-if-test -n purelb-system --ignore-not-found >/dev/null 2>&1 || true
+    kubectl label node "$MULTI_IF_NODE" purelb-test- >/dev/null 2>&1 || true
+
+    wait_for_lease_subnet_gone "$MULTI_IF_NODE" "$MULTI_IF_SUBNET" 20 \
+        || fail "Multi-interface: cleanup did not restore baseline lease"
+    pass "Baseline lease restored after cleanup"
+
+    pass "Multi-interface node test complete"
+}
+
+#---------------------------------------------------------------------
 # Test: Local Pool No Matching Subnet
 # Tests that when no node has the pool's subnet, the IP is NOT announced
 # anywhere. There is no fallback - subnet filtering is strict.
@@ -4692,6 +5090,7 @@ run_all_tests() {
     echo -e "${BLUE}  TEST GROUP: Subnet-Aware Election${NC}"
     echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
     test_lease_verification
+    test_multi_interface
     test_local_pool_no_matching_subnet
     test_remote_pool
     pause_for_review

--- a/website/content/docs/configuration/lbnodeagent/_index.md
+++ b/website/content/docs/configuration/lbnodeagent/_index.md
@@ -16,7 +16,7 @@ default   5m
 
 ### Local Interface
 
-The `localInterface` field determines which network interface PureLB uses to announce [local addresses]({{< relref "/docs/overview/address-types#local-addresses" >}}).
+The `localInterface` field determines which network interfaces PureLB uses to announce [local addresses]({{< relref "/docs/overview/address-types#local-addresses" >}}). It governs **both** sides of announcement: which interface the address is added to, **and** which subnets the node advertises in the [election]({{< relref "/docs/overview/election" >}}) — a node only becomes a candidate for an address whose subnet its selected interfaces carry.
 
 ```yaml
 apiVersion: purelb.io/v2
@@ -32,7 +32,13 @@ spec:
 Value | Behavior
 ------|--------
 `default` | Use the interface with the lowest-cost default route (recommended)
-Regex pattern | Match interface names (e.g., `eth.*`, `enp0s.*`)
+Regex pattern | Match interface names (e.g., `^eth[12]$`)
+
+> [!WARNING]
+> Regex matching is **unanchored**: the pattern `eth` matches `veth1a2b3c` and every other name containing "eth". Always anchor your pattern (`^eth1$`, `^(eth1|eth2)$`) — an under-anchored regex on a busy node pulls pod and bridge interfaces into subnet detection, and the selected interface list is logged at info level when it changes so this is visible in the agent logs.
+
+> [!WARNING]
+> An **invalid regex** makes the node announce nothing: the agent emits a Warning Event on the LBNodeAgent resource, sets `purelb_lbnodeagent_selector_state{state="invalid"}` to 1, empties its lease subnets within a few seconds, and withdraws its addresses so they migrate to healthy nodes. A typo in a cluster-wide (catch-all) resource therefore affects **every node at once** — treat edits to it as change-window operations.
 
 ### Dummy Interface
 
@@ -48,7 +54,7 @@ Default: `kube-lb0`. Change this only if you have a naming conflict.
 
 ### Additional Interfaces
 
-The `interfaces` field adds extra interfaces for subnet detection in the [election]({{< relref "/docs/overview/election" >}}). By default, only the interface with the default route is used. If your nodes have multiple network interfaces on different subnets, add them here:
+The `interfaces` field adds extra interfaces by exact name, on top of whatever `localInterface` selects. Each listed interface participates in **both** subnet detection for the [election]({{< relref "/docs/overview/election" >}}) and address announcement: when the primary selection (default route or regex) doesn't resolve an address, the listed interfaces are tried **in the order written** and the first one whose subnet contains the address wins. Interfaces that don't exist on a given node are skipped silently, so one cluster-wide resource works across heterogeneous nodes.
 
 ```yaml
 spec:
@@ -59,9 +65,83 @@ spec:
     - bond0
 ```
 
+## Node Selection (nodeSelector)
+
+By default an LBNodeAgent resource applies to every node. The optional `nodeSelector` (a standard Kubernetes label selector) scopes it to matching nodes, enabling per-node-group configuration — the natural pattern for clusters with heterogeneous NIC naming or a few special multi-NIC nodes: one catch-all `default` resource plus a scoped override.
+
+```yaml
+# Catch-all for the cluster
+apiVersion: purelb.io/v2
+kind: LBNodeAgent
+metadata:
+  name: default
+  namespace: purelb-system
+spec:
+  local:
+    localInterface: default
+---
+# Override for the dual-homed node(s)
+apiVersion: purelb.io/v2
+kind: LBNodeAgent
+metadata:
+  name: dual-homed
+  namespace: purelb-system
+spec:
+  nodeSelector:
+    matchLabels:
+      example.com/dual-homed: "true"
+  local:
+    localInterface: default
+    interfaces:
+    - eth2
+```
+
+**Precedence** when multiple resources match a node: a resource with a specific selector beats a catch-all (`nodeSelector` absent **or** empty `{}` — both match all nodes); remaining ties are broken by namespace/name sort order, first wins. Ignored matches are logged and receive a Warning Event, visible in `kubectl describe lbnodeagent`.
+
+**Label evaluation** follows the Kubernetes scheduling convention: labels are read when configuration is delivered, not watched continuously. A label-only change takes effect on the next LBNodeAgent/ServiceGroup change, on the periodic re-sync (within about 10 minutes), or on agent restart. If no resource matches a node, that node announces nothing and advertises no subnets (`selector_state{state="deselected"}`).
+
+> [!NOTE]
+> With the `NodeRestriction` admission plugin, kubelets can still set most labels on their own Node object. For selector keys that must not be node-settable, use the `node-restriction.kubernetes.io/` prefix.
+
+**Upgrade and rollback ordering** matters once scoped resources exist:
+
+- Upgrade the CRD and **all** agents before creating any resource that uses `nodeSelector`. Older CRDs silently prune the field (turning a scoped resource into a second catch-all), and older agent binaries ignore it and adopt the first Local resource in arbitrary order — a one-node override could be applied cluster-wide.
+- Delete scoped resources **before** rolling the agent binary back, for the same reason.
+
+## Multi-NIC Nodes: Routing Requirements
+
+Announcing a VIP on a NIC that does **not** hold the node's default route works at the PureLB layer, but the host's routing must cooperate when clients are outside the VIP's subnet:
+
+- Reply traffic follows the default route out the *other* NIC (asymmetric routing). With strict reverse-path filtering (`rp_filter=1`, the RHEL-family default) the kernel drops the inbound connection on the VIP's NIC before PureLB's announcement even matters.
+- Fix it with source-based policy routing — route traffic *from* the VIP's subnet via that NIC's gateway — or relax `rp_filter` to loose (`2`) on the announcing NIC. Deployments whose clients are all on the VIP's own subnet are unaffected.
+
+Example (netplan, second NIC `eth2` on `172.30.250.0/24`, gateway `.1`; keeps DHCP and demotes eth2's default route so eth1 stays primary):
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    eth2:
+      dhcp4: true
+      dhcp4-overrides: {route-metric: 200, use-dns: false}
+      routes:
+      - {to: default, via: 172.30.250.1, table: 250}
+      routing-policy:
+      - {from: 172.30.250.0/24, to: 172.24.0.0/16, table: 254, priority: 990}   # pods stay on main
+      - {from: 172.30.250.0/24, to: 172.30.0.0/16, table: 254, priority: 991}   # cluster nets stay on main
+      - {from: 172.30.250.0/24, table: 250, priority: 1000}                      # everything else via eth2
+```
+
+## Known Limitations
+
+- **DHCPv6-managed NICs**: DHCPv6 (IA_NA) assigns `/128` addresses, so subnet detection yields a subnet containing only the node itself — the NIC can never become an election candidate for pool addresses. Use SLAAC or a static address with the real prefix length; the agent logs at debug level when a v6 address collapses to `/128`.
+- **`validLifetime: 0` is unsupported for local announcements**: it makes IPv6 VIPs permanent, defeating the deprecated-address marking that both CNI plugins (Flannel) and the election's self-interference filtering rely on.
+- **Primary-address loss**: if a NIC loses its real (e.g. DHCP) address while a VIP remains, Linux `promote_secondaries` promotes the VIP and the node can keep advertising that subnet from its own VIP until the VIP's lifetime expires. This window is narrow (address loss without link loss) and bounded by the address lifetime (default 300s).
+- **Startup transient**: for the first seconds after an agent starts, before configuration arrives, the node advertises its default-interface subnets. A node that is deliberately deselected by every `nodeSelector` may therefore briefly win an election it won't serve; this self-corrects at the first configuration delivery.
+
 ## GARP Configuration
 
-Gratuitous ARP (GARP) notifies network equipment (switches, routers) that an IP-to-MAC binding has changed. This enables faster failover when a local address moves between nodes.
+Gratuitous ARP (GARP) notifies network equipment (switches, routers) that an IP-to-MAC binding has changed. This enables faster failover when a local address moves between nodes. For IPv6 addresses the same configuration sends **unsolicited Neighbor Advertisements** — the NDP counterpart of GARP — with identical delay/count/interval/verify semantics; without them a moved IPv6 VIP converges only via neighbor-cache timeouts (typically 5–30 seconds).
 
 ```yaml
 apiVersion: purelb.io/v2

--- a/website/content/docs/overview/election/_index.md
+++ b/website/content/docs/overview/election/_index.md
@@ -79,7 +79,14 @@ Variable | Default | Description
 The election is subnet-aware: only nodes that have the address's subnet in their Lease annotations are candidates. This means:
 
 - On a multi-subnet cluster, an address from subnet A will only be announced by a node on subnet A.
-- The `interfaces` field in the [LBNodeAgent configuration]({{< relref "/docs/configuration/lbnodeagent" >}}) can add additional interfaces for subnet detection.
+- The subnets a node advertises come from its [LBNodeAgent configuration]({{< relref "/docs/configuration/lbnodeagent" >}}): the interfaces selected by `localInterface` (default route or regex) plus any listed in `interfaces`. The Lease advertises exactly the subnets the announcer can announce on — the two sides always agree.
+- A dual-homed node (NICs on two subnets) is a candidate for addresses on both, once its configuration selects both NICs.
+
+### Convergence After Configuration Changes
+
+Changing an LBNodeAgent resource converges in two waves: services are first re-processed against the not-yet-updated Lease subnets, then the next Lease renewal (within ~2.5s) publishes the new subnets and peers re-elect. Total convergence is typically 3–5 seconds, during which a *shrinking* change (a node losing a subnet) is a bounded traffic gap for affected addresses, and a *growing* change can briefly leave two nodes answering ARP/NDP for the same address. Both windows are the same magnitude as an unplanned node failure; on clusters with many services, prefer making LBNodeAgent edits in a maintenance window.
+
+IPv4 failover convergence is accelerated by GARP and IPv6 by unsolicited Neighbor Advertisements — see [GARP Configuration]({{< relref "/docs/configuration/lbnodeagent#garp-configuration" >}}).
 
 ## Monitoring
 

--- a/website/content/docs/reference/crd-reference/_index.md
+++ b/website/content/docs/reference/crd-reference/_index.md
@@ -77,27 +77,30 @@ Field | Type | Description
 
 Field | Type | Description
 ------|------|------------
+`nodeSelector` | metav1.LabelSelector | Limits which nodes this resource applies to. Absent or empty = all nodes (catch-all). When multiple resources match a node: specific selector beats catch-all, then namespace/name sort order. See [Node Selection]({{< relref "/docs/configuration/lbnodeagent#node-selection-nodeselector" >}}).
 `local` | LBNodeAgentLocalSpec | Local announcer configuration
 
 ### LBNodeAgentLocalSpec
 
 Field | Type | Default | Description
 ------|------|---------|------------
-`localInterface` | string | `"default"` | Interface for local address announcement. `"default"` uses the interface with the default route. Regex patterns match interface names.
+`localInterface` | string | `"default"` | Interface for local address announcement **and** election subnet detection. `"default"` uses the interface with the default route. Regex patterns match interface names (unanchored — anchor your pattern).
 `dummyInterface` | string | `"kube-lb0"` | Dummy interface for remote addresses. Created automatically if it doesn't exist.
-`interfaces` | []string | | Additional interfaces for subnet detection in election
-`garpConfig` | GARPConfig | | Gratuitous ARP configuration
+`interfaces` | []string | | Additional interfaces, by exact name, for election subnet detection and announcement. Tried in listed order; missing names are skipped.
+`garpConfig` | GARPConfig | | Gratuitous announcement configuration (GARP for IPv4, unsolicited Neighbor Advertisement for IPv6)
 `addressConfig` | AddressConfig | | Address lifetime and flag configuration
 
 ### GARPConfig
 
+Applies to both IPv4 (gratuitous ARP) and IPv6 (unsolicited Neighbor Advertisement) announcements.
+
 Field | Type | Default | Description
 ------|------|---------|------------
-`enabled` | bool | `true` | Send GARP packets when addresses are added
-`initialDelay` | string (duration) | `"100ms"` | Wait time before first GARP
-`count` | int (1-10) | `3` | Number of GARP packets to send
-`interval` | string (duration) | `"500ms"` | Time between GARP packets
-`verifyBeforeSend` | bool | `true` | Verify election win before each GARP
+`enabled` | bool | `true` | Send announcement packets when addresses are added
+`initialDelay` | string (duration) | `"100ms"` | Wait time before first packet
+`count` | int (1-10) | `3` | Number of packets to send
+`interval` | string (duration) | `"500ms"` | Time between packets
+`verifyBeforeSend` | bool | `true` | Verify election win before each packet
 
 ### AddressConfig
 


### PR DESCRIPTION
Fixes multi-subnet announcement on a dual-homed node: a node with two NICs on different subnets could not announce on its second subnet. Reported by a user who configured two interfaces on one node and found it never won elections for the second subnet.

## The two blockers (both proven live before the fix)

**Config never reached the election.** `cmd/lbnodeagent/main.go` hardcoded `GetLocalSubnets([]string{}, true, logger)` behind a `// TODO Milestone 4`, so the lease only ever advertised the default-route interface's subnets. The node was never a candidate for its second subnet, lost every election, and the addresses stranded elsewhere.

**`interfaces[]` was dead.** `LBNodeAgentLocalSpec.Interfaces` existed in the CRD and was documented on the website as working, with zero Go consumers.

## What's here

- **`nodeSelector` on LBNodeAgent** with deterministic multi-resource precedence (specific selector > catch-all > namespace/name order). Enables the default-plus-override pattern for heterogeneous NIC naming. `nil` and empty `{}` are both catch-alls, so existing single-resource clusters are byte-identical.
- **Config-driven subnet detection** — the election honours `localInterface` (default or regex) and `interfaces[]`, funnelled through the existing `GetLocalSubnets` so dedup/sort/IPv6-flag filtering are shared. The lease advertises exactly what the announcer can announce on.
- **`interfaces[]` implemented in the announcer**, tried in listed order; names absent on a node are skipped, so one cluster-wide resource serves a heterogeneous cluster.
- **Two withdrawal-gap fixes.** The `noLocalInterface` branches and the `noConfig` early-return cleared the announcing annotation but never withdrew the address, leaving a stale VIP whose renewal timer re-added it forever while another node won — duplicate ARP responders. `noConfig` matters doubly now: nodeSelector deselection lands there.
- **Resolution hardening**, required before withdrawal became destructive: `findLocal` continues past per-link errors (veth churn would otherwise cause spurious withdrawals) and sorts matches for cross-reboot determinism; `checkLocal` distinguishes an interrupted netlink dump from "non-local" and skips withdrawal that cycle.
- **Config delivery is retried.** `SyncStateError` from `ConfigChanged` was silently swallowed by the CR controller, so a transient failure left an agent on stale config until the next CR event. It now requeues with backoff; a 10-minute informer resync provides a self-healing floor.
- **IPv6 failover parity.** IPv4 converged in ~100ms via GARP while IPv6 had nothing — the comment claiming the kernel notifies neighbours was wrong (address-add only triggers DAD, sourced from `::`, which updates no neighbour caches). Adds unsolicited Neighbour Advertisements with the same config gate and sequence semantics.
- **Observability**: `purelb_lbnodeagent_selector_state{state=…}`, `na_sent_total`/`na_errors_total`, Warning Events on bad config, and `local_subnet_count` now recorded on renewal rather than only at lease creation.
- **kubectl-purelb** catches up — six defects, each found by running the plugin against a live cluster. Most serious: `status` reported a total announcement outage as `Overall: OK` while `services` called the same addresses NO ANNOUNCER, and `inspect` declared healthy affinity-enabled services split-brain because it predicted the plain-hash winner instead of the affinity-biased one.

## Verification

Full local e2e suite on prox-purelb2: **246 assertions, 0 failures**, including a new gated multi-interface test (28 assertions) covering both selection paths, per-node scoping, dual-stack announcement on the second NIC, affinity migration, and withdrawal with a probative renewal-timer-death check (`validLifetime: 60` so a re-add would occur within the wait).

Manual verification on a dual-homed node, all passing: lease convergence via regex and via `interfaces[]`; VIPs on the correct NIC with correct CNI-protection flags (v4 secondary, v6 deprecated, finite lifetime, noprefixroute); both families reachable end-to-end; GARP and unsolicited NA sent with zero errors; withdrawal with proven timer death and migration to another eligible node; invalid-regex blast radius (cluster-wide lease drain, Warning Events, gauge) with clean recovery; empty-`{}` precedence; and ungraceful `kill -9` of a winning agent with no traffic loss.

End-to-end demonstration: with every other node deselected, a single dual-homed node correctly carried all four addresses of a multipool service across two NICs simultaneously — the exact scenario originally reported as broken.

## Notes for review

- The plan was reviewed by a four-domain panel and a go/no-go pass before implementation. Three findings changed the design: the retry path the plan assumed did not exist; an `IFA_F_SECONDARY` filter was dropped as ineffective (`promote_secondaries` clears the flag in exactly the scenario it targeted); and a proposed `onLeaseUpdate` optimisation was cut after it was shown to risk a permanent dead-node blackhole, since lease expiry is detected only inside `rebuildMaps`.
- Documented deliberately, not fixed here: DHCPv6 `/128` addresses can't form a usable subnet; `validLifetime: 0` is unsupported for local announcements; the narrow zombie-candidacy window after primary-address loss; and the `rp_filter`/policy-routing requirement for VIPs on a non-default-route NIC.
- `make scan` reports pre-existing vulnerabilities on main (grpc, x/text, x/net) that this branch neither introduces nor fixes — better handled as a separate dependency bump.