### PR TITLE
fix(allocator): publish ServiceGroup status when a pool is configured

### DIFF
--- a/build/helm/purelb/templates/deployment.yaml
+++ b/build/helm/purelb/templates/deployment.yaml
@@ -8,6 +8,14 @@ metadata:
   name: allocator
   namespace: {{ .Release.Namespace }}
 spec:
+  # The allocator is the cluster-wide owner of IP allocation, so exactly
+  # one must run. Recreate rather than the default RollingUpdate: with a
+  # single replica maxSurge rounds up to 1, which would briefly run two
+  # allocators handing out addresses from the same pools during every
+  # upgrade. A short gap in allocation is the safer trade.
+  replicas: 1
+  strategy:
+    type: Recreate
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/deployments/default/purelb.yaml
+++ b/deployments/default/purelb.yaml
@@ -323,6 +323,14 @@ metadata:
   name: allocator
   namespace: purelb-system
 spec:
+  # The allocator is the cluster-wide owner of IP allocation, so exactly
+  # one must run. Recreate rather than the default RollingUpdate: with a
+  # single replica maxSurge rounds up to 1, which would briefly run two
+  # allocators handing out addresses from the same pools during every
+  # upgrade. A short gap in allocation is the safer trade.
+  replicas: 1
+  strategy:
+    type: Recreate
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/docs/v0.17.0-release-material.md
+++ b/docs/v0.17.0-release-material.md
@@ -53,6 +53,20 @@ at release time.
   `sendGARP` closed.
 - `kubectl-purelb` no longer counts a departed node's stale annotation slots as
   announcing (lease-gated).
+- **ServiceGroup `.status` is published as soon as a pool is configured** (Issue #60),
+  instead of staying blank until the pool's first allocation. A new ServiceGroup now
+  shows its announce method, IPAM source, addresses and capacity immediately, and a
+  spec edit refreshes them even when no Service uses the pool. A blank status now
+  reliably means "PureLB rejected this spec", which makes it a usable diagnostic.
+- **ServiceGroup status writes use server-side apply** instead of `UpdateStatus` with
+  a cached `resourceVersion`. Previously any change that bumped a ServiceGroup's
+  `resourceVersion` without bumping its `generation` — a label, a GitOps tracking
+  annotation, a finalizer, or a second allocator during a rolling upgrade — stranded
+  the allocator's cached version and made every later status write conflict
+  permanently. Status could freeze after a routine `kubectl label` or an upgrade.
+- The allocator Deployment now sets `replicas: 1` and `strategy: Recreate`. The
+  default `RollingUpdate` rounds `maxSurge` up to 1, so every image upgrade briefly
+  ran two allocators allocating from the same pools.
 
 ## Known limitations / operational notes to document
 
@@ -61,15 +75,33 @@ at release time.
   benign (VIP stable, reachable). Consider documenting; a warning event is a possible
   future nicety.
 - External-pool `.status` counters can go **stale** until the next event
-  (`SidecarPool.Contains` returns false); data plane is unaffected.
+  (`SidecarPool.Contains` returns false); data plane is unaffected. The
+  configure-time publish refreshes a sidecar's `Stats` only when its cache is
+  cold (a restart or a config change), deliberately — a sweep runs on every
+  config change and every Service deletion, and an unconditional refresh would
+  put one blocking gRPC per external pool on the allocation path each time.
 - `purelb.io/re-evaluate` does **not** re-allocate an IP after its pool/subnet
   changes (keeps the now-orphaned IP). Workaround: delete + recreate, or pin a new
   address. (Bug, fix later.)
 - **IPv6 neighbour convergence after a VIP migration:** a neighbour can hold the old
   MAC for up to ~53s. Recommend `net.ipv6.conf.all.ndisc_notify=1`. There is **no
   unsolicited-NA sender yet** (the IPv6 counterpart to GARP) — note as a known gap.
-- Issue #60 display gap: a ServiceGroup with no allocations shows blank `.status`
-  (and blank `kubectl get sg` columns) until first use.
+- **Helm does not upgrade CRDs.** `helm upgrade` ignores the chart's `crds/`
+  directory by design, so a cluster upgrading from v0.16.x keeps the old
+  ServiceGroup CRD — which has **no status subresource**. Every status write then
+  fails with a 404 and `kubectl get sg` stays blank. Upgrading users must apply the
+  CRDs themselves:
+
+  ```bash
+  kubectl apply --server-side -f deployments/crds/purelb.io_servicegroups.yaml
+  ```
+
+  Kustomize/manifest users get this automatically. The failure is visible in
+  `purelb_allocator_sg_status_writes_total{outcome="other"}` and in the allocator
+  log; it does not affect address allocation or announcement.
+- **Downgrade:** a v0.16.x allocator neither writes nor clears ServiceGroup
+  `.status`, so whatever v0.17.0 last wrote persists and will silently go stale
+  after a rollback.
 
 ## Doc pages to touch (Hugo)
 

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -16,6 +16,7 @@ package allocator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -53,9 +54,10 @@ type ListServicesFunc func() []v1.Service
 //
 // sgByName is parallel to pools (same keys, same lifetime) and holds
 // DeepCopies of the ServiceGroup objects from the informer cache.
-// DeepCopying is mandatory — informer-cache objects must never be mutated
-// per k8s client-go contract, and the status writer needs a stable SG
-// pointer to construct UpdateStatus requests from.
+// DeepCopying is mandatory — informer-cache objects must never be
+// mutated per the client-go contract. The status writer uses these only
+// for identity (name/namespace); status writes are server-side applies
+// and carry no ResourceVersion, so nothing here goes stale.
 type allocatorState struct {
 	pools    map[string]Pool
 	sgByName map[string]*purelbv2.ServiceGroup
@@ -73,10 +75,10 @@ type Allocator struct {
 	listServices    ListServicesFunc
 
 	// lastWritten caches the most recently successfully-written status per
-	// ServiceGroup name. Used by maybeUpdateSGStatus to elide no-op API
-	// writes when the computed status equals what was last sent. Owned by
-	// G1 (queue worker) — sync.Map is safe for the rare concurrent reads
-	// from any future helper goroutines.
+	// ServiceGroup name. Used by writeSGStatus to elide no-op API writes
+	// when the computed status equals what was last sent. Written only by
+	// G1 (queue worker); G2 deletes entries for pools that config removed
+	// (SetPools), which is why this is a sync.Map rather than a plain map.
 	lastWritten sync.Map // map[svcGroupName]purelbv2.ServiceGroupStatus
 
 	// sidecarConns holds one shared *grpc.ClientConn per external-IPAM
@@ -236,46 +238,138 @@ func (a *Allocator) maybeUpdateSGStatus(pool Pool) {
 		return
 	}
 
-	// For sidecar pools, refresh the cached Stats before building status.
-	// Pure display accessors read that cache; this is the only place an
-	// RPC fires for status. Best-effort — on failure we proceed with the
-	// last-good cache (the interceptor records the RPC error metric).
-	if sp, isSidecar := pool.(*SidecarPool); isSidecar {
-		ctx, cancel := a.sgStatusClient.APIContext()
+	ctx, cancel := a.sgStatusClient.APIContext()
+	defer cancel()
+
+	// refresh=true: this call follows an allocation or release from
+	// this pool, so a sidecar's Stats are known to be out of date.
+	if _, err := a.writeSGStatus(ctx, sg, pool, true); err != nil {
+		if !a.sgStatusClient.IsShutdownError(err) {
+			logging.Info(a.logger, "op", "updateSGStatus", "error", err, "sg", sg.Name)
+		}
+	}
+}
+
+// PublishAllSGStatus writes .status for every configured pool,
+// including pools that have no allocations. This is what makes a
+// freshly-created ServiceGroup show its announce method, IPAM source,
+// addresses and capacity immediately, rather than staying blank until
+// the first Service happens to allocate from it.
+//
+// Runs from G1 (the work queue goroutine) via the poolStatus queue
+// item, so it shares the allocation hot path's single-writer
+// discipline. Best-effort: it returns an aggregate error for logging,
+// but the caller must not requeue on it (see the poolStatus case in
+// k8s.Client.sync for why).
+//
+// ctx bounds the whole sweep, not each ServiceGroup, so one queue item
+// stays bounded at the standard API timeout however many pools are
+// configured. Pools not reached before the deadline are picked up by
+// the next publish.
+func (a *Allocator) PublishAllSGStatus(ctx context.Context) error {
+	if a.sgStatusClient == nil {
+		return nil
+	}
+	s := a.state.Load()
+	if s == nil {
+		return nil
+	}
+
+	// Register the IPs of Services that already exist before computing
+	// counts. A publish is normally triggered by a config change, which
+	// can land before the work queue has processed the Service backlog
+	// (and, at startup, before the controller is even marked synced, so
+	// SetBalancer refuses to allocate). Without this the sweep would
+	// report every pool as empty and lastWritten would cache that as
+	// authoritative. populateFromExisting reads the Service informer
+	// cache directly, so it does not depend on either.
+	a.populateFromExisting(s.pools)
+
+	var (
+		errs    []error
+		written int
+		elided  int
+	)
+	for name, pool := range s.pools {
+		sg, ok := s.sgByName[name]
+		if !ok || sg == nil {
+			continue
+		}
+
+		// Only pay for a sidecar Stats RPC when we have nothing cached.
+		// A sweep runs on every config change and every Service
+		// deletion; refreshing unconditionally would put one blocking
+		// gRPC per external-IPAM pool on the allocation goroutine each
+		// time. A cold cache means a restart or a fresh config, which
+		// is exactly when a sidecar pool needs its first read — and
+		// because SidecarPool.Contains reports false, NotifyExisting
+		// never reaches updateStats for these pools, so this is their
+		// only refresh path at startup.
+		refresh := false
+		if sp, isSidecar := pool.(*SidecarPool); isSidecar {
+			refresh = sp.stats.Load() == nil
+		}
+
+		wrote, err := a.writeSGStatus(ctx, sg, pool, refresh)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+			if !a.sgStatusClient.IsShutdownError(err) {
+				logging.Info(a.logger, "op", "publishPoolStatus", "error", err, "sg", name)
+			}
+		case wrote:
+			written++
+		default:
+			elided++
+		}
+	}
+
+	logging.Debug(a.logger, "op", "publishPoolStatus", "pools", len(s.pools),
+		"written", written, "unchanged", elided, "errors", len(errs))
+	return errors.Join(errs...)
+}
+
+// writeSGStatus computes pool's status and writes it to sg. Reports
+// whether an API write was actually issued — false when the lastWritten
+// cache elided it as a no-op.
+//
+// refresh asks an external-IPAM sidecar for fresh Stats before the
+// status is computed. Callers on the allocation path pass true (the
+// allocation just changed the numbers); the bulk publish passes true
+// only for a cold cache, to keep a blocking RPC off the hot path.
+//
+// Caller must hold a non-nil sgStatusClient and a live sg.
+func (a *Allocator) writeSGStatus(ctx context.Context, sg *purelbv2.ServiceGroup, pool Pool, refresh bool) (bool, error) {
+	// Pure display accessors read the Stats cache; this is the only
+	// place an RPC fires for status. Best-effort — on failure we
+	// proceed with the last-good cache (the interceptor records the
+	// RPC error metric).
+	if sp, isSidecar := pool.(*SidecarPool); isSidecar && refresh {
 		if err := sp.refreshStats(ctx); err != nil {
 			logging.Info(a.logger, "op", "refreshSidecarStats", "error", err, "sg", sg.Name)
 		}
-		cancel()
 	}
 
 	newStatus := buildStatus(pool)
 	if prev, loaded := a.lastWritten.Load(sg.Name); loaded {
 		if statusEqual(prev.(purelbv2.ServiceGroupStatus), newStatus) {
-			return // no-op
+			return false, nil // no-op
 		}
 	}
 
 	sgCopy := sg.DeepCopy()
 	sgCopy.Status = newStatus
-	updated, err := a.sgStatusClient.UpdateServiceGroupStatus(sgCopy)
-	if err != nil {
+	if err := a.sgStatusClient.UpdateServiceGroupStatus(ctx, sgCopy); err != nil {
 		sgStatusWritesTotal.WithLabelValues(classifyStatusErr(err)).Inc()
-		if !a.sgStatusClient.IsShutdownError(err) {
-			logging.Info(a.logger, "op", "updateSGStatus", "error", err, "sg", sg.Name)
-		}
-		// Do NOT update lastWritten — next call retries.
-		return
+		// Do NOT update lastWritten — the next publish retries.
+		return false, err
 	}
 	sgStatusWritesTotal.WithLabelValues("success").Inc()
 	a.lastWritten.Store(sg.Name, newStatus)
-	// Refresh the cached SG's ResourceVersion so the next UpdateStatus
-	// call uses the latest server version and doesn't hit "object has
-	// been modified" conflicts. Safe to mutate in-place: sgByName is
-	// G1-single-writer (this code path); the SG pointer is exclusive
-	// to the allocator (DeepCopy was taken in SetPools).
-	if updated != nil {
-		sg.ResourceVersion = updated.ResourceVersion
-	}
+	logging.Info(a.logger, "op", "updateSGStatus", "sg", sg.Name,
+		"announce", newStatus.Announce, "ipam", newStatus.IPAM,
+		"allocatedV4", newStatus.AllocatedIPv4, "allocatedV6", newStatus.AllocatedIPv6)
+	return true, nil
 }
 
 // buildStatus computes the ServiceGroupStatus payload for a pool. Pure

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -26,11 +26,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	ptu "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	ipamv1 "purelb.io/api/ipam/v1"
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
 
@@ -1590,27 +1592,27 @@ func TestCapitalize(t *testing.T) {
 }
 
 // fakeStatusWriter captures ServiceGroupStatusWriter calls for tests of
-// maybeUpdateSGStatus. The next write returns nextErr when non-nil.
+// maybeUpdateSGStatus. The next write returns nextErr when non-nil;
+// errForSG fails every write for the named ServiceGroups.
 type fakeStatusWriter struct {
 	updates       []*purelbv2.ServiceGroup
 	nextErr       error
+	errForSG      map[string]error
 	apiCtxCalls   int
 	shutdownCalls int
 }
 
-func (f *fakeStatusWriter) UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error) {
+func (f *fakeStatusWriter) UpdateServiceGroupStatus(_ context.Context, sg *purelbv2.ServiceGroup) error {
 	f.updates = append(f.updates, sg.DeepCopy())
+	if err, ok := f.errForSG[sg.Name]; ok {
+		return err
+	}
 	if f.nextErr != nil {
 		err := f.nextErr
 		f.nextErr = nil
-		return nil, err
+		return err
 	}
-	// Simulate API server: bump ResourceVersion to demonstrate the fake
-	// behaves like the real one. Tests that care about ResourceVersion
-	// propagation can assert on this.
-	updated := sg.DeepCopy()
-	updated.ResourceVersion = sg.ResourceVersion + "-bumped"
-	return updated, nil
+	return nil
 }
 func (f *fakeStatusWriter) APIContext() (context.Context, context.CancelFunc) {
 	f.apiCtxCalls++
@@ -1709,4 +1711,240 @@ func TestMaybeUpdateSGStatus_UnknownPool(t *testing.T) {
 	})
 	// No-op; no panic.
 	alloc.maybeUpdateSGStatus(pool)
+}
+
+// sgFor builds a minimal ServiceGroup object for status-writer tests.
+func sgFor(name string) *purelbv2.ServiceGroup {
+	return &purelbv2.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "purelb-system"},
+	}
+}
+
+// statusByName indexes a fakeStatusWriter's captured writes by
+// ServiceGroup name. Map iteration in PublishAllSGStatus makes write
+// order nondeterministic, so tests must never assert on it.
+func statusByName(w *fakeStatusWriter) map[string]purelbv2.ServiceGroupStatus {
+	out := map[string]purelbv2.ServiceGroupStatus{}
+	for _, sg := range w.updates {
+		out[sg.Name] = sg.Status
+	}
+	return out
+}
+
+// TestPublishAllSGStatus is the core of the "blank status" fix: pools
+// that have never allocated an address must still publish their
+// announce method, IPAM source, addresses and capacity. Covers IPv4,
+// IPv6 and dual-stack so the v6 half can't silently regress.
+func TestPublishAllSGStatus(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	writer := &fakeStatusWriter{}
+	alloc.SetServiceGroupStatusWriter(writer)
+
+	v4 := &fakeStatusPool{
+		name: "v4-only", poolType: "local", ipamSource: "Cluster",
+		displayAddresses: []string{"192.168.1.0/24"},
+		sizeV4:           254, hasKnownCapacity: true,
+	}
+	v6 := &fakeStatusPool{
+		name: "v6-only", poolType: "local", ipamSource: "Cluster",
+		displayAddresses: []string{"fc00::/120"},
+		sizeV6:           256, hasKnownCapacity: true,
+	}
+	dual := &fakeStatusPool{
+		name: "dual", poolType: "remote", ipamSource: "Cluster",
+		displayAddresses: []string{"10.0.0.0/24", "fc00:1::/120"},
+		sizeV4:           254, sizeV6: 256, hasKnownCapacity: true,
+	}
+
+	alloc.state.Store(&allocatorState{
+		pools: map[string]Pool{"v4-only": v4, "v6-only": v6, "dual": dual},
+		sgByName: map[string]*purelbv2.ServiceGroup{
+			"v4-only": sgFor("v4-only"), "v6-only": sgFor("v6-only"), "dual": sgFor("dual"),
+		},
+	})
+
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, 3, len(writer.updates), "every pool should publish, allocations or not")
+
+	got := statusByName(writer)
+	assert.Equal(t, purelbv2.ServiceGroupStatus{
+		Announce: "Local", IPAM: "Cluster",
+		Addresses:     []string{"192.168.1.0/24"},
+		AllocatedIPv4: 0, AllocatedIPv6: 0,
+		AvailableIPv4: ptrI64(254), AvailableIPv6: ptrI64(0),
+	}, got["v4-only"])
+	assert.Equal(t, purelbv2.ServiceGroupStatus{
+		Announce: "Local", IPAM: "Cluster",
+		Addresses:     []string{"fc00::/120"},
+		AllocatedIPv4: 0, AllocatedIPv6: 0,
+		AvailableIPv4: ptrI64(0), AvailableIPv6: ptrI64(256),
+	}, got["v6-only"])
+	assert.Equal(t, purelbv2.ServiceGroupStatus{
+		Announce: "Remote", IPAM: "Cluster",
+		Addresses:     []string{"10.0.0.0/24", "fc00:1::/120"},
+		AllocatedIPv4: 0, AllocatedIPv6: 0,
+		AvailableIPv4: ptrI64(254), AvailableIPv6: ptrI64(256),
+	}, got["dual"])
+
+	// A second sweep with unchanged pools must not hit the API at all.
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, 3, len(writer.updates), "unchanged sweep should write nothing")
+}
+
+// TestPublishAllSGStatus_BeforeSynced is the regression test for the
+// startup ordering trap: a publish triggered by a config change can run
+// before the work queue has processed any Service, and SetBalancer
+// refuses to allocate until the controller is marked synced. Without
+// populateFromExisting the sweep would report every pool empty and cache
+// that as authoritative.
+func TestPublishAllSGStatus_BeforeSynced(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	writer := &fakeStatusWriter{}
+	alloc.SetServiceGroupStatusWriter(writer)
+
+	pool, err := NewLocalPool("default", allocatorTestLogger,
+		&purelbv2.AddressPool{Pool: "192.168.1.1-192.168.1.10", Subnet: "192.168.1.0/24", Aggregation: "default"},
+		&purelbv2.AddressPool{Pool: "fc00::1-fc00::10", Subnet: "fc00::/120", Aggregation: "default"},
+		nil, nil, purelbv2.PoolTypeLocal, false, false, false)
+	require.NoError(t, err)
+
+	// Two dual-stack Services already carry allocated addresses, exactly
+	// as they would in the informer cache after an allocator restart.
+	// Note SetBalancer has NOT run for them (controller not synced).
+	alloc.SetListServices(func() []v1.Service {
+		return []v1.Service{
+			existingSvc("ns1", "svc1", "192.168.1.1", "fc00::1"),
+			existingSvc("ns2", "svc2", "192.168.1.2", "fc00::2"),
+		}
+	})
+
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"default": &pool},
+		sgByName: map[string]*purelbv2.ServiceGroup{"default": sgFor("default")},
+	})
+
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+
+	got := statusByName(writer)["default"]
+	assert.Equal(t, int64(2), got.AllocatedIPv4, "must count IPs of pre-existing Services, not report an empty pool")
+	assert.Equal(t, int64(2), got.AllocatedIPv6, "must count pre-existing IPv6 allocations too")
+	assert.Equal(t, int64(8), *got.AvailableIPv4, "10-address v4 range less 2 allocated")
+	// fc00::1-fc00::10 is hex: 16 addresses, less the 2 allocated.
+	assert.Equal(t, int64(14), *got.AvailableIPv6)
+}
+
+// existingSvc builds a Service that looks like one PureLB already
+// allocated for: branded, with LoadBalancer ingress addresses.
+func existingSvc(ns, name string, ips ...string) v1.Service {
+	svc := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns,
+			Name:        name,
+			Annotations: map[string]string{purelbv2.BrandAnnotation: purelbv2.Brand},
+		},
+		Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+	}
+	for _, ip := range ips {
+		svc.Status.LoadBalancer.Ingress = append(svc.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{IP: ip})
+	}
+	return svc
+}
+
+// TestPublishAllSGStatus_SidecarRefreshOnlyWhenCold guards the hot path:
+// a sweep runs on every config change and every Service deletion, so it
+// must not fire a blocking gRPC per external-IPAM pool each time. Only a
+// cold cache (restart, fresh config) justifies the RPC.
+func TestPublishAllSGStatus_SidecarRefreshOnlyWhenCold(t *testing.T) {
+	fake := &fakeIPAM{statsFunc: func(*ipamv1.StatsRequest) (*ipamv1.StatsResponse, error) {
+		return &ipamv1.StatsResponse{
+			InUseV4: 1, InUseV6: 2, SizeV4: 10, SizeV6: 20,
+			HasKnownCapacity: true,
+			DisplayAddresses: []string{"10.1.0.0/24", "fc00:2::/120"},
+		}, nil
+	}}
+	conn := startFakeIPAM(t, fake)
+
+	alloc := New(allocatorTestLogger)
+	alloc.SetServiceGroupStatusWriter(&fakeStatusWriter{})
+
+	pool := NewSidecarPool("ext", allocatorTestLogger,
+		purelbv2.ServiceGroupExternalSpec{Provider: "test", Announce: "local"}, conn)
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"ext": pool},
+		sgByName: map[string]*purelbv2.ServiceGroup{"ext": sgFor("ext")},
+	})
+
+	// Cold cache: one RPC, and the status reflects what the sidecar said.
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, 1, fake.statsCalls, "cold cache should be filled by exactly one Stats RPC")
+
+	// Warm cache: repeated sweeps must be free.
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, 1, fake.statsCalls, "warm cache must not fire further Stats RPCs")
+}
+
+// TestPublishAllSGStatus_ErrorsAreCollectedNotFatal: one broken
+// ServiceGroup must not stop the others from publishing, and the failed
+// one must stay uncached so the next sweep retries it.
+func TestPublishAllSGStatus_ErrorsAreCollectedNotFatal(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	writer := &fakeStatusWriter{
+		errForSG: map[string]error{
+			"broken": apierrors.NewForbidden(
+				schema.GroupResource{Group: "purelb.io", Resource: "servicegroups"}, "broken", nil),
+		},
+	}
+	alloc.SetServiceGroupStatusWriter(writer)
+
+	mk := func(name string) *fakeStatusPool {
+		return &fakeStatusPool{
+			name: name, poolType: "local", ipamSource: "Cluster",
+			displayAddresses: []string{"192.168.1.0/24"},
+			sizeV4:           254, hasKnownCapacity: true,
+		}
+	}
+	alloc.state.Store(&allocatorState{
+		pools: map[string]Pool{"ok1": mk("ok1"), "broken": mk("broken"), "ok2": mk("ok2")},
+		sgByName: map[string]*purelbv2.ServiceGroup{
+			"ok1": sgFor("ok1"), "broken": sgFor("broken"), "ok2": sgFor("ok2"),
+		},
+	})
+
+	err := alloc.PublishAllSGStatus(context.Background())
+	require.Error(t, err, "the aggregate error must surface the failure")
+	assert.Contains(t, err.Error(), "broken")
+	assert.Equal(t, 3, len(writer.updates), "a failing pool must not abort the sweep")
+
+	// The two healthy pools are cached; only the broken one is retried.
+	writer.updates = nil
+	assert.Error(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, 1, len(writer.updates), "only the failed pool should be retried")
+	assert.Equal(t, "broken", writer.updates[0].Name)
+}
+
+// TestPublishAllSGStatus_NoClient: the allocator must run happily with
+// no status writer wired (unit tests, and any consumer that owns no
+// pools).
+func TestPublishAllSGStatus_NoClient(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"p": &fakeStatusPool{name: "p", poolType: "local"}},
+		sgByName: map[string]*purelbv2.ServiceGroup{"p": sgFor("p")},
+	})
+	assert.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+}
+
+// TestPublishAllSGStatus_PoolWithoutServiceGroup: a pool whose
+// ServiceGroup is missing from the snapshot is skipped, not panicked on.
+func TestPublishAllSGStatus_PoolWithoutServiceGroup(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	writer := &fakeStatusWriter{}
+	alloc.SetServiceGroupStatusWriter(writer)
+	alloc.state.Store(&allocatorState{
+		pools:    map[string]Pool{"orphan": &fakeStatusPool{name: "orphan", poolType: "local"}},
+		sgByName: map[string]*purelbv2.ServiceGroup{},
+	})
+	assert.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Empty(t, writer.updates)
 }

--- a/internal/allocator/controller.go
+++ b/internal/allocator/controller.go
@@ -67,6 +67,7 @@ func (c *controller) SetClient(client *k8s.Client) {
 	c.ips.SetClient(client)
 	c.ips.SetServiceGroupStatusWriter(client)
 	c.ips.SetListServices(client.ListServices)
+	client.SetPoolStatusPublisher(c.ips.PublishAllSGStatus)
 
 	data, err := os.ReadFile(namespacePath)
 	if err != nil {

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -56,6 +56,13 @@ type Controller struct {
 	lbnasSynced cache.InformerSynced
 	lbnaLister  listers.LBNodeAgentLister
 
+	// publishPoolStatus asks the consumer to republish every pool's
+	// ServiceGroup .status after a config change. Separate from
+	// forceSync because a pool with no Services has nothing for
+	// forceSync to reprocess — which is exactly the case that left
+	// .status blank.
+	publishPoolStatus func()
+
 	// workqueue is a rate limited work queue. This is used to queue
 	// work to be processed instead of performing it as soon as a change
 	// happens. This means we can ensure we only process a fixed amount
@@ -75,6 +82,7 @@ func NewCRController(
 	logger log.Logger,
 	configCB func(*purelbv2.Config) SyncState,
 	forceSync func(),
+	publishPoolStatus func(),
 	kubeclientset kubernetes.Interface,
 	purelbclientset clientset.Interface,
 	informerFactory externalversions.SharedInformerFactory) *Controller {
@@ -91,10 +99,11 @@ func NewCRController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	controller := &Controller{
-		logger:          logger,
-		configCB:        configCB,
-		forceSync:       forceSync,
-		kubeclientset:   kubeclientset,
+		logger:            logger,
+		configCB:          configCB,
+		forceSync:         forceSync,
+		publishPoolStatus: publishPoolStatus,
+		kubeclientset:     kubeclientset,
 		purelbclientset: purelbclientset,
 		lbnaLister:      lbnaInformer.Lister(),
 		lbnasSynced:     lbnaInformer.Informer().HasSynced,
@@ -242,6 +251,13 @@ func (c *Controller) syncHandler() error {
 	case SyncStateReprocessAll:
 		configLoaded.Set(1)
 		c.forceSync()
+		// Republish pool status too. forceSync only re-enqueues
+		// Services, so a ServiceGroup that owns none would otherwise
+		// never have its status written. Enqueued after forceSync so
+		// the sweep lands behind the Service keys it depends on.
+		if c.publishPoolStatus != nil {
+			c.publishPoolStatus()
+		}
 	}
 
 	return nil

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -17,6 +17,7 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -36,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -44,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 )
 
 // serviceNameIndexName is the name of the custom indexer that maps
@@ -85,6 +88,32 @@ type Client struct {
 	configChanged  func(*purelbv2.Config) SyncState
 	synced         func()
 	shutdown       func()
+
+	// publishPoolStatus republishes every address pool's ServiceGroup
+	// .status. Set by SetPoolStatusPublisher; nil in consumers that own
+	// no pools (lbnodeagent), which makes EnqueuePoolStatus a no-op.
+	publishPoolStatus func(context.Context) error
+}
+
+// SetPoolStatusPublisher wires the callback invoked when a poolStatus
+// work item is processed. Only the allocator sets this.
+func (c *Client) SetPoolStatusPublisher(fn func(context.Context) error) {
+	c.publishPoolStatus = fn
+}
+
+// EnqueuePoolStatus schedules a republish of every pool's ServiceGroup
+// .status on the work queue.
+//
+// The publish has to happen on the queue goroutine: pools are swapped
+// in from the CR controller goroutine, while status writing belongs to
+// the same goroutine that allocates, so that the two cannot interleave
+// on a pool's counters. Repeated calls collapse into a single pending
+// sweep.
+func (c *Client) EnqueuePoolStatus() {
+	if c.publishPoolStatus == nil {
+		return
+	}
+	c.queue.Add(poolStatus{})
 }
 
 // ServiceEvent adds events to services.
@@ -107,12 +136,11 @@ type ServiceEvent interface {
 // APIContext on the new interface lets the allocator construct
 // cancellable contexts without needing a *Client reference.
 type ServiceGroupStatusWriter interface {
-	// UpdateServiceGroupStatus writes sg.Status via the status subresource.
-	// Returns the updated ServiceGroup (with bumped ResourceVersion) on
-	// success — callers should use this to refresh their cached SG so
-	// subsequent UpdateStatus calls don't hit "object has been modified"
-	// conflicts. nil + error on failure.
-	UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error)
+	// UpdateServiceGroupStatus writes sg.Status via the status
+	// subresource. The caller supplies ctx so that a bulk publish can
+	// bound the cost of the whole sweep with one deadline rather than
+	// paying a fresh timeout per ServiceGroup.
+	UpdateServiceGroupStatus(ctx context.Context, sg *purelbv2.ServiceGroup) error
 	APIContext() (context.Context, context.CancelFunc)
 	IsShutdownError(err error) bool
 }
@@ -132,25 +160,48 @@ func (c *Client) IsShutdownError(err error) bool {
 	return c.isShutdownError(err)
 }
 
-// UpdateServiceGroupStatus writes sg's .status subresource. Mirrors
-// maybeUpdateService's pattern: uses apiContext() for timeout-bounded
-// cancellable I/O; sets FieldManager so SSA users see PureLB's owner
-// identity correctly; classifies shutdown errors as benign.
-func (c *Client) UpdateServiceGroupStatus(sg *purelbv2.ServiceGroup) (*purelbv2.ServiceGroup, error) {
-	ctx, cancel := c.apiContext()
-	defer cancel()
-	updated, err := c.crClient.PurelbV2().ServiceGroups(sg.Namespace).UpdateStatus(ctx, sg, metav1.UpdateOptions{
-		FieldManager: "purelb-allocator",
+// UpdateServiceGroupStatus writes sg's .status subresource using a
+// server-side apply patch.
+//
+// Apply rather than UpdateStatus deliberately. UpdateStatus is a
+// read-modify-write keyed on ResourceVersion, which forced the
+// allocator to cache an RV per ServiceGroup and refresh it after every
+// write. That cache is only rebuilt when a ServiceGroup's *generation*
+// changes (see sgUpdateNeedsReconcile), so any RV bump that leaves the
+// spec alone — a label, a GitOps tracking annotation, a finalizer, or a
+// second allocator during a rolling upgrade — stranded the cached RV
+// and made every subsequent status write conflict permanently. PureLB
+// is the sole writer of ServiceGroup .status, so the optimistic
+// concurrency check bought nothing and cost that failure mode.
+//
+// Apply also gives correct removal semantics: fields PureLB owns but
+// omits (availableIPv4/6 when capacity is unknowable) are deleted
+// rather than left stale.
+func (c *Client) UpdateServiceGroupStatus(ctx context.Context, sg *purelbv2.ServiceGroup) error {
+	// Minimal apply configuration: identity plus the fields we own. No
+	// ResourceVersion — apply is not conditional on one.
+	body, err := json.Marshal(map[string]interface{}{
+		"apiVersion": purelbv2.SchemeGroupVersion.String(),
+		"kind":       "ServiceGroup",
+		"metadata": map[string]interface{}{
+			"name":      sg.Name,
+			"namespace": sg.Namespace,
+		},
+		"status": sg.Status,
 	})
 	if err != nil {
-		if c.isShutdownError(err) {
-			c.logger.Log("op", "updateSGStatus", "msg", "skipping update during shutdown")
-			return nil, nil
-		}
-		// Caller is responsible for logging + classifying for metrics.
-		return nil, err
+		return err
 	}
-	return updated, nil
+
+	_, err = c.crClient.PurelbV2().ServiceGroups(sg.Namespace).Patch(ctx, sg.Name,
+		types.ApplyPatchType, body,
+		metav1.PatchOptions{FieldManager: "purelb-allocator", Force: ptr.To(true)},
+		"status")
+	// The error is returned even during shutdown: the write did not
+	// happen, so the caller must not cache the status as persisted.
+	// The caller suppresses the log for shutdown errors via
+	// IsShutdownError.
+	return err
 }
 
 // SyncState is the result of calling synchronization callbacks.
@@ -198,6 +249,13 @@ type synced string
 
 func (synced) isQueueItem() {}
 
+// poolStatus asks the consumer to republish .status for every
+// configured address pool. A singleton: all instances compare equal, so
+// the work queue collapses a burst of triggers into one sweep.
+type poolStatus struct{}
+
+func (poolStatus) isQueueItem() {}
+
 // New connects to masterAddr, using kubeconfig to authenticate.
 //
 // The client uses processName to identify itself to the cluster
@@ -244,7 +302,7 @@ func New(cfg *Config) (*Client, error) {
 	// nodeSelector evaluation and gives config delivery a self-healing
 	// floor if a delivery was lost.
 	c.crInformerFactory = externalversions.NewSharedInformerFactory(crClient, time.Minute*10)
-	c.crController = *NewCRController(c.logger, cfg.ConfigChanged, c.ForceSync, clientset, crClient, c.crInformerFactory)
+	c.crController = *NewCRController(c.logger, cfg.ConfigChanged, c.ForceSync, c.EnqueuePoolStatus, clientset, crClient, c.crInformerFactory)
 
 	// Service Watcher
 
@@ -736,6 +794,29 @@ func (c *Client) sync(key queueItem) SyncState {
 		if c.synced != nil {
 			c.synced()
 		}
+		// Publish pool status once the caches are warm, so pools that
+		// own no Services still get a status even if the config arrived
+		// before this point.
+		c.EnqueuePoolStatus()
+		return SyncStateSuccess
+
+	case poolStatus:
+		if c.publishPoolStatus == nil {
+			return SyncStateSuccess
+		}
+		ctx, cancel := c.apiContext()
+		defer cancel()
+		if err := c.publishPoolStatus(ctx); err != nil {
+			c.logger.Log("op", "publishPoolStatus", "error", err)
+		}
+		// Deliberately never SyncStateError. The failures that persist
+		// here are permanent, not transient: a ServiceGroup CRD without
+		// the status subresource (404) or a missing servicegroups/status
+		// RBAC grant (403). Requeuing those would spin forever on the
+		// goroutine that allocates addresses. Transient failures are
+		// covered by how often a publish is triggered anyway — every
+		// config change, every Service deletion, and the LBNodeAgent
+		// informer resync.
 		return SyncStateSuccess
 
 	default:

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -15,6 +15,8 @@
 package k8s
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -302,3 +304,96 @@ func (m *mockIndexer) ListIndexFuncValues(indexName string) []string          { 
 func (m *mockIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error)  { return nil, nil }
 func (m *mockIndexer) GetIndexers() cache.Indexers                            { return nil }
 func (m *mockIndexer) AddIndexers(newIndexers cache.Indexers) error           { return nil }
+
+// TestEnqueuePoolStatus_NoPublisher verifies that a consumer which owns
+// no address pools (lbnodeagent) never puts a dead item on the queue.
+func TestEnqueuePoolStatus_NoPublisher(t *testing.T) {
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[queueItem](),
+	)
+	defer queue.ShutDown()
+
+	c := &Client{queue: queue} // publishPoolStatus left nil
+	c.EnqueuePoolStatus()
+
+	assert.Equal(t, 0, queue.Len(), "no publisher wired should mean nothing queued")
+}
+
+// TestEnqueuePoolStatus_Collapses verifies the sweep is a singleton: a
+// burst of triggers (one per Service deletion, say) must collapse into a
+// single pending sweep rather than queueing one item each.
+func TestEnqueuePoolStatus_Collapses(t *testing.T) {
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[queueItem](),
+	)
+	defer queue.ShutDown()
+
+	c := &Client{queue: queue}
+	c.SetPoolStatusPublisher(func(context.Context) error { return nil })
+
+	for i := 0; i < 5; i++ {
+		c.EnqueuePoolStatus()
+	}
+
+	assert.Equal(t, 1, queue.Len(), "repeated triggers should collapse into one sweep")
+
+	item, _ := queue.Get()
+	assert.Equal(t, poolStatus{}, item)
+	queue.Done(item)
+}
+
+// TestSyncPoolStatus_NeverRequeues is the guard on the no-retry
+// decision. The failures that persist on this path (a ServiceGroup CRD
+// with no status subresource, or a missing servicegroups/status RBAC
+// grant) are permanent, so requeuing would spin forever on the same
+// goroutine that allocates addresses.
+func TestSyncPoolStatus_NeverRequeues(t *testing.T) {
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[queueItem](),
+	)
+	defer queue.ShutDown()
+
+	calls := 0
+	c := &Client{queue: queue, logger: log.NewNopLogger()}
+	c.SetPoolStatusPublisher(func(context.Context) error {
+		calls++
+		return errors.New("servicegroups.purelb.io \"x\" not found")
+	})
+
+	assert.Equal(t, SyncStateSuccess, c.sync(poolStatus{}),
+		"a failed publish must not be requeued")
+	assert.Equal(t, 1, calls)
+}
+
+// TestSyncPoolStatus_NilPublisher verifies sync tolerates the item
+// arriving with no publisher wired.
+func TestSyncPoolStatus_NilPublisher(t *testing.T) {
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[queueItem](),
+	)
+	defer queue.ShutDown()
+
+	c := &Client{queue: queue, logger: log.NewNopLogger()}
+	assert.Equal(t, SyncStateSuccess, c.sync(poolStatus{}))
+}
+
+// TestSyncSynced_PublishesPoolStatus verifies that reaching the synced
+// milestone schedules a publish, so pools that own no Services still get
+// a status when the config arrived before the caches were warm.
+func TestSyncSynced_PublishesPoolStatus(t *testing.T) {
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[queueItem](),
+	)
+	defer queue.ShutDown()
+
+	c := &Client{queue: queue, logger: log.NewNopLogger()}
+	c.SetPoolStatusPublisher(func(context.Context) error { return nil })
+	c.synced = func() {}
+
+	assert.Equal(t, SyncStateSuccess, c.sync(synced("")))
+
+	require.Equal(t, 1, queue.Len(), "synced should schedule a pool status publish")
+	item, _ := queue.Get()
+	assert.Equal(t, poolStatus{}, item)
+	queue.Done(item)
+}

--- a/test/e2e/ipam-external/README.md
+++ b/test/e2e/ipam-external/README.md
@@ -14,7 +14,10 @@ reflects the sidecar's `Stats`.
 - `pool-type` annotation matches the configured `announce` mode.
 - For `announce: local`, the VIP lands on a node interface and is reachable.
 - `.status.ipam`, `.status.allocatedIPv4`, `.status.availableIPv4` are
-  populated from the sidecar's `Stats` RPC.
+  populated from the sidecar's `Stats` RPC. These appear as soon as the
+  ServiceGroup is configured — PureLB reads `Stats` once when a pool's cache
+  is cold, so an external pool reports its addresses and capacity before
+  anything has allocated from it.
 - `purelb_allocator_sidecar_rpc_total` records `Allocate`/`Stats`/`Release`
   with `code="OK"` and **no** failed RPCs.
 - On delete, the address is withdrawn and `Release` is called on the sidecar.

--- a/test/e2e/local/servicegroup-remote.yaml
+++ b/test/e2e/local/servicegroup-remote.yaml
@@ -11,3 +11,8 @@ spec:
     v4pools:
     - pool: 10.255.1.100-10.255.1.110
       subnet: 10.255.1.0/24
+    # No Service allocates from the v6 range; it exists so the
+    # idle-pool status assertions cover both families.
+    v6pools:
+    - pool: fc00:255:1::100-fc00:255:1::110
+      subnet: fc00:255:1::/64

--- a/test/e2e/local/test-local-allocation.sh
+++ b/test/e2e/local/test-local-allocation.sh
@@ -778,9 +778,59 @@ test_remote_pool() {
     info "Remote pools should place IPs on kube-lb0, not local interface."
     info "They bypass subnet filtering entirely."
 
+    # Sample the status-write counter BEFORE the ServiceGroup exists.
+    # The allocator publishes within milliseconds of the apply, so a
+    # baseline taken afterwards would already include the write.
+    local SG_METRICS_BEFORE SG_WRITES_BEFORE
+    SG_METRICS_BEFORE=$(scrape_allocator_metrics)
+    SG_WRITES_BEFORE=$(extract_metric "${SG_METRICS_BEFORE:-}" 'purelb_allocator_sg_status_writes_total{outcome="success"}')
+    SG_WRITES_BEFORE=${SG_WRITES_BEFORE:-0}
+
     # Apply the remote ServiceGroup
     info "Applying remote-pool ServiceGroup..."
     kubectl apply -f ${SCRIPT_DIR}/servicegroup-remote.yaml
+
+    # A pool must publish its status as soon as it is configured, before
+    # anything allocates from it. This runs while no Service references
+    # remote-pool, so it fails if status is still only a side effect of
+    # allocation.
+    info "Verifying ServiceGroup status is populated before any allocation..."
+    kubectl wait --for=jsonpath='{.status.announce}'=Remote \
+        servicegroup/remote-pool -n purelb-system --timeout=30s \
+        || fail "ServiceGroup status not published for an idle pool"
+
+    local SG_IPAM SG_ADDR SG_ALLOC_V4 SG_ALLOC_V6 SG_AVAIL_V4 SG_AVAIL_V6
+    SG_IPAM=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.ipam}')
+    SG_ADDR=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.addresses[0]}')
+    SG_ALLOC_V4=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.allocatedIPv4}')
+    SG_ALLOC_V6=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.allocatedIPv6}')
+    SG_AVAIL_V4=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.availableIPv4}')
+    SG_AVAIL_V6=$(kubectl get servicegroup remote-pool -n purelb-system -o jsonpath='{.status.availableIPv6}')
+
+    [ -n "$SG_IPAM" ] || fail "ServiceGroup status.ipam empty for idle pool"
+    [ -n "$SG_ADDR" ] || fail "ServiceGroup status.addresses empty for idle pool"
+    [ "$SG_ALLOC_V4" = "0" ] || fail "Idle pool reports allocatedIPv4=$SG_ALLOC_V4, expected 0"
+    [ "$SG_ALLOC_V6" = "0" ] || fail "Idle pool reports allocatedIPv6=$SG_ALLOC_V6, expected 0"
+    [ "${SG_AVAIL_V4:-0}" -gt 0 ] || fail "Idle pool reports availableIPv4=$SG_AVAIL_V4, expected > 0"
+    [ "${SG_AVAIL_V6:-0}" -gt 0 ] || fail "Idle pool reports availableIPv6=$SG_AVAIL_V6, expected > 0"
+    pass "Idle pool published status (ipam=$SG_IPAM addresses=$SG_ADDR v4avail=$SG_AVAIL_V4 v6avail=$SG_AVAIL_V6)"
+
+    assert_log_contains "allocator" "updateSGStatus" "ServiceGroup status write logged"
+
+    local SG_METRICS_AFTER SG_WRITES_AFTER SG_FORBIDDEN SG_OTHER
+    SG_METRICS_AFTER=$(scrape_allocator_metrics)
+    if [ -n "$SG_METRICS_AFTER" ]; then
+        SG_WRITES_AFTER=$(extract_metric "$SG_METRICS_AFTER" 'purelb_allocator_sg_status_writes_total{outcome="success"}')
+        [ "${SG_WRITES_AFTER:-0}" -gt "$SG_WRITES_BEFORE" ] \
+            || fail "sg_status_writes_total{success} did not increase (${SG_WRITES_BEFORE} -> ${SG_WRITES_AFTER:-0})"
+        # Server-side apply removes the conflict class entirely, and a
+        # missing RBAC grant or CRD status subresource would show here.
+        SG_FORBIDDEN=$(extract_metric "$SG_METRICS_AFTER" 'purelb_allocator_sg_status_writes_total{outcome="forbidden"}')
+        SG_OTHER=$(extract_metric "$SG_METRICS_AFTER" 'purelb_allocator_sg_status_writes_total{outcome="other"}')
+        [ "${SG_FORBIDDEN:-0}" -eq 0 ] || fail "sg_status_writes_total{forbidden}=${SG_FORBIDDEN} (check servicegroups/status RBAC)"
+        [ "${SG_OTHER:-0}" -eq 0 ] || fail "sg_status_writes_total{other}=${SG_OTHER} (check the ServiceGroup CRD has a status subresource)"
+        pass "ServiceGroup status writes succeeded with no forbidden/other errors"
+    fi
 
     # Create service requesting IP from remote pool
     info "Creating service requesting IP from remote-pool..."

--- a/website/content/docs/configuration/service-groups/_index.md
+++ b/website/content/docs/configuration/service-groups/_index.md
@@ -163,6 +163,34 @@ When `balancePools: true`, new allocations pick the range with the fewest IPs cu
 
 Setting `skipIPv6DAD: true` (local pools only) disables IPv6 Duplicate Address Detection. This speeds up address configuration but should only be used when you are certain there are no address conflicts on the network.
 
+## ServiceGroup Status
+
+PureLB writes a `.status` to every ServiceGroup it has parsed, and `kubectl get servicegroups` surfaces it:
+
+```console
+$ kubectl get servicegroups -n purelb-system
+NAME      ANNOUNCE   IPAM      ADDRESSES                                    ALLOCATED-V4   ALLOCATED-V6
+default   Local      Cluster   ["192.168.1.100-192.168.1.200","fc00::/120"] 3              1
+```
+
+`kubectl get servicegroups -o wide` adds the `Available-V4` and `Available-V6` columns.
+
+| Field | Meaning |
+|---|---|
+| `announce` | How the addresses are announced: `Local` or `Remote` |
+| `ipam` | Where addresses come from: `Cluster` for local pools, or the external provider name |
+| `addresses` | The configured address ranges, as written in the spec |
+| `allocatedIPv4` / `allocatedIPv6` | Addresses currently in use, per family |
+| `availableIPv4` / `availableIPv6` | Addresses still free, per family. Absent when the pool's capacity is not knowable — an external IPAM provider that does not report a size |
+
+Status is published as soon as the ServiceGroup is configured, so a new pool reports its addresses and capacity before anything has allocated from it. It is refreshed on every allocation and release, and whenever the ServiceGroup's spec changes.
+
+{{< hint info >}}
+**A blank status means PureLB did not accept the ServiceGroup.** If `kubectl get servicegroups` shows empty columns for a group, its spec failed to parse — check the allocator logs (`kubectl logs -n purelb-system deployment/allocator`) for the reason.
+{{< /hint >}}
+
+An IPv6-only pool reports `availableIPv4: 0`, and an IPv4-only pool reports `availableIPv6: 0`, because the pool has no capacity in that family. This is not the same as an exhausted pool — compare against `addresses` to tell them apart.
+
 ## Modifying ServiceGroups
 
 Changing a ServiceGroup does **not** change services that have already been allocated. Modified ServiceGroups only affect subsequently created services. This is intentional: address changes should happen service by service, not by a pool change affecting all associated services.


### PR DESCRIPTION
## Problem

ServiceGroup `.status` was only ever written as a side effect of a per-Service allocation, so a pool that no Service used stayed blank — including its announce method, IPAM source, addresses and capacity, all of which are known the moment the spec is parsed. Editing such a pool never refreshed it either.

That made a blank row ambiguous: it could mean "unused" or "PureLB rejected this spec". Closes the Issue #60 display gap.

## What changed

**Publish on config change.** A new `poolStatus` work-queue item, enqueued from the CR controller's `SyncStateReprocessAll` case and once the informer caches are warm, sweeps every configured pool. It runs on the queue goroutine so status writing keeps the allocation path's single-writer discipline rather than racing the pool swap on the CR controller goroutine. `ForceSync` is deliberately left alone — it only re-enqueues Services, which is why a pool owning none never got a status, and its contract and existing tests are unchanged.

Three things the sweep has to get right:

- It calls `populateFromExisting` first. A config-change publish can land before the queue has processed any Service, and `SetBalancer` refuses to allocate until the controller is marked synced — without this it would report every pool empty and cache that as authoritative.
- One context bounds the whole sweep rather than each ServiceGroup, so a single item stays within the standard API timeout however many pools exist.
- An external IPAM sidecar's `Stats` are refreshed only when its cache is cold. A sweep runs on every config change and every Service deletion; refreshing unconditionally would put one blocking gRPC per external pool on the allocation goroutine each time. It can't be dropped entirely — `SidecarPool.Contains` returns false, so `NotifyExisting` never reaches `updateStats` for these pools and this is their only refresh path after a restart.

The item **never requeues on error**. The failures that persist there are permanent, not transient — a ServiceGroup CRD without the status subresource (404), or a missing `servicegroups/status` grant (403) — and retrying would spin forever on the goroutine that hands out addresses.

**Server-side apply for status writes.** `UpdateStatus` is keyed on ResourceVersion, which forced the allocator to cache one per ServiceGroup and refresh it after every write. That cache is rebuilt only when `generation` changes, so any bump that left the spec alone — a label, a GitOps tracking annotation, a finalizer, or the second allocator a `RollingUpdate` briefly runs — stranded it and made every later status write conflict **permanently**. PureLB is the sole writer of `.status`, so the optimistic concurrency check bought nothing and cost that failure mode. `patch` on `servicegroups/status` is already granted in every install path, so this needs no RBAC change.

**Deployment hardening.** `replicas: 1` and `strategy: Recreate` on the allocator. With one replica `maxSurge` rounds up to 1, so every image upgrade ran two allocators over the same pools.

## Verification

`make check` green; 10 new unit tests covering IPv4/IPv6/dual-stack idle pools, the before-synced ordering case, sidecar refresh gating, and the no-requeue guarantee.

Verified on a 5-node dual-stack cluster:

- Idle IPv4-only, IPv6-only and dual-stack pools publish immediately with correct per-family capacity; editing a CIDR on a pool with no Services refreshes it.
- **SSA regression check:** `kubectl label` bumped resourceVersion while `generation` stayed at 1 — the exact stranding condition — and the next status write still succeeded. `sg_status_writes_total` reports only `outcome="success"`; no `conflict`, `forbidden` or `other` series exist.
- Counts survive an allocator restart in a single write per group, with no zero-then-correct ramp.
- resourceVersions stable across 30s at steady state — no write loop.

Local e2e suite: the new inline idle-pool assertions in `test_remote_pool` pass (v4 and v6). One unrelated pre-existing failure in `test_ipv4_singlestack` is left as-is — it will be covered by the planned full e2e review before the 0.17 release.

## Upgrade note

Helm never upgrades files in `crds/`, and the released v0.16.x ServiceGroup CRD has **no status subresource**. Upgrading Helm users must apply the CRDs themselves or every status write 404s:

```bash
kubectl apply --server-side -f deployments/crds/purelb.io_servicegroups.yaml
```

Kustomize users get this automatically. Documented in `docs/v0.17.0-release-material.md` along with the downgrade caveat.