### PR TITLE
feat: namespace-scoped ServiceGroups, plus post-v0.16.6 review fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,18 @@ help: ## Display help message
 all: check crd image ## Build it all!
 
 .PHONY: check
-check: generate check-deps check-helm-rbac-source ## Run "short" tests + bundled-dep consistency check
+check: generate check-deps check-helm-rbac-source check-gofmt ## Run "short" tests + bundled-dep consistency check
 	go vet ./...
 	go test -race -short ./...
+
+.PHONY: check-gofmt
+check-gofmt: ## Fail if any tracked Go source is not gofmt-clean
+	@unformatted=$$(gofmt -l ./api ./cmd ./internal ./pkg 2>/dev/null); \
+	if [ -n "$$unformatted" ]; then \
+		echo "These files are not gofmt-clean; run: gofmt -w <file>"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 
 .PHONY: image
 image: generate ## Build executables and containers

--- a/build/helm/purelb/templates/clusterrole-allocator.yaml
+++ b/build/helm/purelb/templates/clusterrole-allocator.yaml
@@ -45,10 +45,3 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ''
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list

--- a/build/helm/purelb/templates/clusterrole-lbnodeagent.yaml
+++ b/build/helm/purelb/templates/clusterrole-lbnodeagent.yaml
@@ -48,13 +48,6 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ''
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
 # Leases are used for leader election (subnet-aware election via K8s leases)
 - apiGroups:
   - coordination.k8s.io

--- a/build/helm/purelb/templates/deployment.yaml
+++ b/build/helm/purelb/templates/deployment.yaml
@@ -36,12 +36,10 @@ spec:
       {{- end }}
       containers:
       - env:
-        - name: NETBOX_USER_TOKEN
+        - name: PURELB_NAMESPACE
           valueFrom:
-            secretKeyRef:
-              name: netbox-client
-              key: user-token
-              optional: true
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: DEFAULT_ANNOUNCER
           value: "{{ .Values.defaultAnnouncer }}"
         image: "{{ .Values.image.repository }}/allocator:{{ .Values.image.tag }}"

--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -31,8 +31,15 @@ func main() {
 	var (
 		port       = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
 		kubeconfig = flag.String("kubeconfig", os.Getenv("KUBECONFIG"), "absolute path to the kubeconfig file (only needed when running outside of k8s)")
+		namespace  = flag.String("namespace", os.Getenv("PURELB_NAMESPACE"), "namespace in which PureLB is installed (from the downward API)")
 	)
 	flag.Parse()
+
+	// Resolve once and share: the allocator uses it for lease lookups and the
+	// CR controller for ServiceGroup scoping, and the two disagreeing would be
+	// worse than either being wrong.
+	installNamespace := k8s.InstallNamespace(logger, *namespace)
+	logger.Log("op", "startup", "installNamespace", installNamespace)
 
 	stopCh := make(chan struct{})
 	go func() {
@@ -46,7 +53,7 @@ func main() {
 	defer logger.Log("op", "shutdown", "msg", "done")
 
 	// Set up controller
-	c, err := allocator.NewController(logger, allocator.New(logger))
+	c, err := allocator.NewController(logger, allocator.New(logger), installNamespace)
 	if err != nil {
 		logger.Log("op", "startup", "error", err, "msg", "failed to allocate controller")
 		os.Exit(1)
@@ -56,6 +63,7 @@ func main() {
 		ProcessName: "purelb-allocator",
 		Logger:      logger,
 		Kubeconfig:  *kubeconfig,
+		Namespace:   installNamespace,
 
 		ServiceChanged: c.SetBalancer,
 		ServiceDeleted: c.DeleteBalancer,

--- a/cmd/kubectl-purelb/bgp.go
+++ b/cmd/kubectl-purelb/bgp.go
@@ -43,10 +43,10 @@ type bgpSessionRow struct {
 }
 
 type bgpSessionsSummary struct {
-	GlobalASN  int64           `json:"globalASN"`
-	RouterIDMode string       `json:"routerIDMode"`
-	Sessions   []bgpSessionRow `json:"sessions"`
-	Problems   []string        `json:"problems,omitempty"`
+	GlobalASN    int64           `json:"globalASN"`
+	RouterIDMode string          `json:"routerIDMode"`
+	Sessions     []bgpSessionRow `json:"sessions"`
+	Problems     []string        `json:"problems,omitempty"`
 }
 
 func newBGPCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {

--- a/cmd/kubectl-purelb/bgp_dataplane.go
+++ b/cmd/kubectl-purelb/bgp_dataplane.go
@@ -119,7 +119,7 @@ func runBGPDataplaneImpl(ctx context.Context, c *clients, format outputFormat, f
 
 	// Build service IP -> name map for cross-reference
 	svcList, _ := c.core.CoreV1().Services("").List(ctx, metav1.ListOptions{ResourceVersion: "0", FieldSelector: svcFieldSelector})
-	svcByIP := map[string]string{}  // ip -> "namespace/name"
+	svcByIP := map[string]string{}   // ip -> "namespace/name"
 	etpLocalIPs := map[string]bool{} // IPs from ETP Local services
 	var remoteSvcIPs []string
 	if svcList != nil {

--- a/cmd/kubectl-purelb/commands_test.go
+++ b/cmd/kubectl-purelb/commands_test.go
@@ -70,8 +70,8 @@ func newFakeClients(coreObjects []runtime.Object, dynamicObjects ...runtime.Obje
 	)
 
 	return &clients{
-		core:    fake.NewSimpleClientset(coreObjects...),
-		dynamic: dynClient,
+		core:      fake.NewSimpleClientset(coreObjects...),
+		dynamic:   dynClient,
 		namespace: "purelb-system",
 	}
 }
@@ -293,7 +293,7 @@ func TestRunServices_NoAnnouncerRemoteIsOK(t *testing.T) {
 // =============================================================================
 
 func TestBuildHealthyNodeSet(t *testing.T) {
-	healthy := makeLease("node-a", "10.0.0.0/24", 2) // renewed 2s ago, dur=10s, not expired
+	healthy := makeLease("node-a", "10.0.0.0/24", 2)  // renewed 2s ago, dur=10s, not expired
 	expired := makeLease("node-b", "10.1.0.0/24", 20) // renewed 20s ago, dur=10s, expired
 
 	result := buildHealthyNodeSet([]coordinationv1.Lease{*healthy, *expired})

--- a/cmd/kubectl-purelb/election.go
+++ b/cmd/kubectl-purelb/election.go
@@ -42,7 +42,7 @@ type nodeLeaseInfo struct {
 	// healthy lease still announces nothing when no nodeSelector selects it
 	// ("deselected") or its localInterface regex is invalid ("invalid"),
 	// which lease health alone cannot express.
-	Config      nodeConfig `json:"config"`
+	Config nodeConfig `json:"config"`
 }
 
 type subnetCoverage struct {
@@ -67,11 +67,11 @@ type drainResult struct {
 }
 
 type electionSummary struct {
-	Nodes      []nodeLeaseInfo  `json:"nodes"`
-	Coverage   []subnetCoverage `json:"subnetCoverage"`
-	Uncovered  []uncoveredRange `json:"uncoveredRanges,omitempty"`
-	DrainSim   []drainResult    `json:"drainSimulation,omitempty"`
-	DrainNode  string           `json:"drainNode,omitempty"`
+	Nodes     []nodeLeaseInfo  `json:"nodes"`
+	Coverage  []subnetCoverage `json:"subnetCoverage"`
+	Uncovered []uncoveredRange `json:"uncoveredRanges,omitempty"`
+	DrainSim  []drainResult    `json:"drainSimulation,omitempty"`
+	DrainNode string           `json:"drainNode,omitempty"`
 }
 
 func newElectionCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {

--- a/cmd/kubectl-purelb/inspect.go
+++ b/cmd/kubectl-purelb/inspect.go
@@ -31,27 +31,27 @@ import (
 )
 
 type inspectResult struct {
-	Service      string             `json:"service"`
-	Type         string             `json:"type"`
-	IPFamilies   string             `json:"ipFamilies"`
-	ETP          string             `json:"externalTrafficPolicy"`
-	Status       string             `json:"status"`
-	Allocations  []allocationInfo   `json:"allocations,omitempty"`
-	Elections    []electionInfo     `json:"elections,omitempty"`
+	Service       string             `json:"service"`
+	Type          string             `json:"type"`
+	IPFamilies    string             `json:"ipFamilies"`
+	ETP           string             `json:"externalTrafficPolicy"`
+	Status        string             `json:"status"`
+	Allocations   []allocationInfo   `json:"allocations,omitempty"`
+	Elections     []electionInfo     `json:"elections,omitempty"`
 	Announcements []announcementInfo `json:"announcements,omitempty"`
-	Sharing      *sharingInfo       `json:"sharing,omitempty"`
-	Endpoints    endpointsInfo      `json:"endpoints"`
-	BGP          []bgpRouteCheck    `json:"bgp,omitempty"`
-	BGPNote      string             `json:"bgpNote,omitempty"` // canonical sentence when BGP state is NotEnabled / NotConfigured
-	Diagnosis    *diagnosisInfo     `json:"diagnosis,omitempty"`
+	Sharing       *sharingInfo       `json:"sharing,omitempty"`
+	Endpoints     endpointsInfo      `json:"endpoints"`
+	BGP           []bgpRouteCheck    `json:"bgp,omitempty"`
+	BGPNote       string             `json:"bgpNote,omitempty"` // canonical sentence when BGP state is NotEnabled / NotConfigured
+	Diagnosis     *diagnosisInfo     `json:"diagnosis,omitempty"`
 }
 
 type allocationInfo struct {
-	IP          string `json:"ip"`
-	Pool        string `json:"pool"`
-	PoolType    string `json:"poolType"`
-	Range       string `json:"range,omitempty"`
-	Subnet      string `json:"subnet,omitempty"`
+	IP       string `json:"ip"`
+	Pool     string `json:"pool"`
+	PoolType string `json:"poolType"`
+	Range    string `json:"range,omitempty"`
+	Subnet   string `json:"subnet,omitempty"`
 }
 
 type electionInfo struct {
@@ -70,15 +70,15 @@ type electionInfo struct {
 }
 
 type announcementInfo struct {
-	IP        string `json:"ip"`
-	Node      string `json:"node"`
-	Interface string `json:"interface"`
-	Healthy   bool   `json:"leaseHealthy"`
+	IP         string `json:"ip"`
+	Node       string `json:"node"`
+	Interface  string `json:"interface"`
+	Healthy    bool   `json:"leaseHealthy"`
 	RenewedAgo string `json:"renewedAgo,omitempty"`
 }
 
 type sharingInfo struct {
-	Key      string   `json:"key"`
+	Key       string   `json:"key"`
 	CoTenants []string `json:"coTenants"` // "namespace/name (ports)"
 }
 
@@ -88,10 +88,10 @@ type endpointsInfo struct {
 }
 
 type bgpRouteCheck struct {
-	IP       string `json:"ip"`
-	Node     string `json:"node"`
-	InRIB    bool   `json:"inRIB"`
-	Advertised bool  `json:"advertised"`
+	IP         string `json:"ip"`
+	Node       string `json:"node"`
+	InRIB      bool   `json:"inRIB"`
+	Advertised bool   `json:"advertised"`
 }
 
 type diagnosisInfo struct {
@@ -145,9 +145,9 @@ func runInspect(ctx context.Context, c *clients, format outputFormat, svcArg str
 	}
 
 	result := inspectResult{
-		Service:    nsName,
-		Type:       string(svc.Spec.Type),
-		ETP:        string(svc.Spec.ExternalTrafficPolicy),
+		Service: nsName,
+		Type:    string(svc.Spec.Type),
+		ETP:     string(svc.Spec.ExternalTrafficPolicy),
 	}
 
 	// IP families

--- a/cmd/kubectl-purelb/main.go
+++ b/cmd/kubectl-purelb/main.go
@@ -41,6 +41,14 @@ func main() {
 	// Bind kubeconfig / context / namespace flags to all commands
 	flags.AddFlags(root.PersistentFlags())
 
+	// -n/--namespace selects the namespace PureLB is installed in, which is
+	// what every command needs to find PureLB's own resources.
+	root.PersistentPreRun = func(_ *cobra.Command, _ []string) {
+		if flags.Namespace != nil && *flags.Namespace != "" {
+			purelbNamespace = *flags.Namespace
+		}
+	}
+
 	root.AddCommand(
 		newStatusCmd(flags),
 		newPoolsCmd(flags),

--- a/cmd/kubectl-purelb/main.go
+++ b/cmd/kubectl-purelb/main.go
@@ -32,9 +32,9 @@ func main() {
 	flags := genericclioptions.NewConfigFlags(true)
 
 	root := &cobra.Command{
-		Use:   "kubectl-purelb",
-		Short: "Operational visibility for PureLB LoadBalancer",
-		Long:  "kubectl-purelb provides consolidated views of PureLB pool utilization, service announcements, election state, and BGP data plane health.",
+		Use:          "kubectl-purelb",
+		Short:        "Operational visibility for PureLB LoadBalancer",
+		Long:         "kubectl-purelb provides consolidated views of PureLB pool utilization, service announcements, election state, and BGP data plane health.",
 		SilenceUsage: true,
 	}
 

--- a/cmd/kubectl-purelb/nodeconfig.go
+++ b/cmd/kubectl-purelb/nodeconfig.go
@@ -31,9 +31,19 @@ import (
 // LBNodeAgent sets one (matches the CRD default).
 const defaultDummyInterface = "kube-lb0"
 
-// Announcement configuration states for a node. These mirror the states the
-// node agent itself reports via purelb_lbnodeagent_selector_state, but are
-// derived from the API so the plugin needs no access to node metrics ports.
+// Announcement configuration states for a node, derived from the API so
+// the plugin needs no access to node metrics ports.
+//
+// These are deliberately FINER-GRAINED than the node agent's
+// purelb_lbnodeagent_selector_state, and the two sets are not
+// interchangeable. The agent reports default / configured / deselected /
+// invalid; its "default" covers both of the cases this file separates as
+// "remote" (an agent governs the node but has no local spec) and
+// "no-config" (no LBNodeAgent exists at all), because in both the agent
+// falls back to default-interface subnet detection.
+//
+// Read the metric when you want to know what the agent decided; read these
+// when you want to know why. Do not assume a one-to-one mapping.
 const (
 	// configStateConfigured: an LBNodeAgent with a local spec governs this node.
 	configStateConfigured = "configured"

--- a/cmd/kubectl-purelb/services.go
+++ b/cmd/kubectl-purelb/services.go
@@ -26,6 +26,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -36,6 +37,7 @@ type svcRow struct {
 	IP         string `json:"ip"`
 	Pool       string `json:"pool"`
 	PoolType   string `json:"poolType"`
+	IPAM       string `json:"ipam"`
 	Announcing string `json:"announcing"` // "node/iface" or ""
 	SharingKey string `json:"sharingKey"`
 	Status     string `json:"status"`
@@ -49,11 +51,11 @@ type sharedIPGroup struct {
 }
 
 type servicesSummary struct {
-	Services    []svcRow        `json:"services"`
-	SharedIPs   []sharedIPGroup `json:"sharedIPs,omitempty"`
-	TotalSvc    int             `json:"totalServices"`
-	TotalIPs    int             `json:"totalIPs"`
-	Problems    int             `json:"problems"`
+	Services  []svcRow        `json:"services"`
+	SharedIPs []sharedIPGroup `json:"sharedIPs,omitempty"`
+	TotalSvc  int             `json:"totalServices"`
+	TotalIPs  int             `json:"totalIPs"`
+	Problems  int             `json:"problems"`
 }
 
 func newServicesCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
@@ -98,11 +100,15 @@ func runServices(ctx context.Context, c *clients, format outputFormat, filterPoo
 		return fmt.Errorf("listing leases: %w", err)
 	}
 	lbnaList, _ := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	// ServiceGroups carry .status.ipam, the only place the address source is
+	// recorded. Best-effort: without it every pool simply reports "cluster".
+	sgList, _ := c.dynamic.Resource(gvrServiceGroups).Namespace("").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 
 	snap := &clusterSnapshot{
-		services:     svcList,
-		leases:       leaseList,
-		lbNodeAgents: lbnaList,
+		services:      svcList,
+		serviceGroups: sgList,
+		leases:        leaseList,
+		lbNodeAgents:  lbnaList,
 	}
 	return renderServices(snap, format, filterPool, filterNode, filterIP, problemsOnly)
 }
@@ -112,6 +118,7 @@ func runServices(ctx context.Context, c *clients, format outputFormat, filterPoo
 func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filterNode, filterIP string, problemsOnly bool) error {
 	healthyNodes := buildHealthyNodeSet(snap.leases.Items)
 	dummyIface := resolveDummyInterface(snap.lbNodeAgents)
+	poolIPAM := buildPoolIPAM(snap.serviceGroups)
 
 	var rows []svcRow
 	// Track sharing: sharingKey -> IP -> []services with ports
@@ -169,6 +176,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 				IP:         "<pending>",
 				Pool:       poolName,
 				PoolType:   poolType,
+				IPAM:       poolIPAM[poolName],
 				SharingKey: sharingKey,
 				Status:     svcStatusPending,
 			}
@@ -202,6 +210,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 				IP:         ipStr,
 				Pool:       poolName,
 				PoolType:   poolType,
+				IPAM:       poolIPAM[poolName],
 				Announcing: announcing,
 				SharingKey: sharingKey,
 				Status:     status,
@@ -286,7 +295,7 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 
 	// Table output
 	tw := tableWriter(os.Stdout)
-	fmt.Fprintf(tw, "NAMESPACE\tSERVICE\tIPS\tPOOL\tTYPE\tANNOUNCING\tSHARING\tSTATUS\n")
+	fmt.Fprintf(tw, "NAMESPACE\tSERVICE\tIPS\tPOOL\tTYPE\tIPAM\tANNOUNCING\tSHARING\tSTATUS\n")
 
 	for _, r := range rows {
 		announcing := r.Announcing
@@ -301,14 +310,18 @@ func renderServices(snap *clusterSnapshot, format outputFormat, filterPool, filt
 		if poolType == "" {
 			poolType = "-"
 		}
+		ipam := r.IPAM
+		if ipam == "" {
+			ipam = "-"
+		}
 
 		statusMarker := r.Status
 		if r.Status != svcStatusOK && r.Status != svcStatusPending {
 			statusMarker = r.Status + "  ***"
 		}
 
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Namespace, r.Name, r.IP, r.Pool, poolType, announcing, sharing, statusMarker)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Namespace, r.Name, r.IP, r.Pool, poolType, ipam, announcing, sharing, statusMarker)
 	}
 	tw.Flush()
 
@@ -362,4 +375,37 @@ func countUniqueSvcs(rows []svcRow) int {
 		seen[r.Namespace+"/"+r.Name] = true
 	}
 	return len(seen)
+}
+
+// buildPoolIPAM maps ServiceGroup name to the source that allocates its
+// addresses, read from .status.ipam.
+//
+// The TYPE column reports the announcement mechanism, which SidecarPool
+// derives from spec.external.announce -- so an external pool announced
+// locally reports "local", identical to a cluster-IPAM pool, and nothing in
+// the output revealed that PureLB was not the allocator. The ServiceGroup
+// CRD keeps these as two separate print columns (Announce and IPAM) for
+// exactly that reason; this mirrors it.
+//
+// Pools with no status yet fall back to "cluster": .status is written by
+// the allocator, and a ServiceGroup that has not been reconciled is far more
+// likely to be a local pool than an external one.
+func buildPoolIPAM(sgs *unstructured.UnstructuredList) map[string]string {
+	out := map[string]string{}
+	if sgs == nil {
+		return out
+	}
+	for i := range sgs.Items {
+		sg := &sgs.Items[i]
+		name := sg.GetName()
+		if name == "" {
+			continue
+		}
+		ipam, found, err := unstructured.NestedString(sg.Object, "status", "ipam")
+		if err != nil || !found || ipam == "" {
+			ipam = "cluster"
+		}
+		out[name] = strings.ToLower(ipam)
+	}
+	return out
 }

--- a/cmd/kubectl-purelb/status.go
+++ b/cmd/kubectl-purelb/status.go
@@ -39,9 +39,9 @@ type statusOverview struct {
 }
 
 type componentStatus struct {
-	AllocatorReady   string `json:"allocator"`
-	NodeAgentReady   string `json:"lbnodeagent"`
-	K8GoBGPReady     string `json:"k8gobgp,omitempty"`
+	AllocatorReady string `json:"allocator"`
+	NodeAgentReady string `json:"lbnodeagent"`
+	K8GoBGPReady   string `json:"k8gobgp,omitempty"`
 }
 
 type poolStatus struct {
@@ -369,4 +369,3 @@ func renderStatus(snap *clusterSnapshot, format outputFormat) error {
 
 	return nil
 }
-

--- a/cmd/kubectl-purelb/util.go
+++ b/cmd/kubectl-purelb/util.go
@@ -62,8 +62,12 @@ const (
 	subnetsAnnotation = "purelb.io/subnets"
 )
 
-// PureLB system namespace default.
-const purelbNamespace = "purelb-system"
+// purelbNamespace is where PureLB is installed. Every command resolves
+// PureLB's own resources here, and the allocator reads ServiceGroups only
+// from this namespace, so a plugin that assumed the default would flag every
+// correctly-placed ServiceGroup on a non-standard install and miss the real
+// ones. Overridden by -n/--namespace in main.
+var purelbNamespace = "purelb-system"
 
 // svcFieldSelector limits Services.List to LoadBalancer type, reducing
 // response payload and API server work via server-side filtering.

--- a/cmd/kubectl-purelb/util_test.go
+++ b/cmd/kubectl-purelb/util_test.go
@@ -226,9 +226,9 @@ func TestElectionHashMatchesPureLB(t *testing.T) {
 		winner     string
 	}{
 		// 3-node cluster, various IPs
-		{"192.168.1.100", []string{"node-a", "node-b", "node-c"}, ""},   // computed below
-		{"10.0.0.1", []string{"alpha", "beta", "gamma"}, ""},            // computed below
-		{"2001:db8::1", []string{"node-1", "node-2"}, ""},               // computed below
+		{"192.168.1.100", []string{"node-a", "node-b", "node-c"}, ""}, // computed below
+		{"10.0.0.1", []string{"alpha", "beta", "gamma"}, ""},          // computed below
+		{"2001:db8::1", []string{"node-1", "node-2"}, ""},             // computed below
 	}
 
 	// We can't hardcode expected winners without running the real code,

--- a/cmd/kubectl-purelb/validate.go
+++ b/cmd/kubectl-purelb/validate.go
@@ -17,8 +17,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -68,13 +70,37 @@ func newValidateCmd(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	return cmd
 }
 
+const defaultPoolName = "default"
+
 func runValidate(ctx context.Context, c *clients, format outputFormat, strict bool) error {
 	var checks []checkResult
 
-	// Fetch resources
-	sgList, err := c.dynamic.Resource(gvrServiceGroups).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	// List across all namespaces, not just the install namespace. The
+	// allocator reads only its own, so anything elsewhere is ignored -- and
+	// this is the pre-upgrade gate that has to report exactly that. A
+	// namespace-scoped list cannot see what it needs to flag.
+	allSGs, err := c.dynamic.Resource(gvrServiceGroups).Namespace("").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return fmt.Errorf("listing ServiceGroups: %w", err)
+	}
+
+	sgList := &unstructured.UnstructuredList{}
+	for _, sg := range allSGs.Items {
+		if sg.GetNamespace() == purelbNamespace {
+			sgList.Items = append(sgList.Items, sg)
+			continue
+		}
+		kind := "local"
+		if _, isRemote, _ := unstructured.NestedMap(sg.Object, "spec", "remote"); isRemote {
+			kind = "remote"
+		}
+		impact := "its pool is not allocatable"
+		if kind == "remote" {
+			impact = "addresses allocated from it are withdrawn from every node"
+		}
+		checks = append(checks, checkResult{"FAIL", fmt.Sprintf(
+			"ServiceGroup %q is in namespace %q, not the PureLB install namespace %q. PureLB ignores it: %s. Move it, or re-run with -n if PureLB is installed elsewhere",
+			sg.GetName(), sg.GetNamespace(), purelbNamespace, impact)})
 	}
 
 	lbnaList, err := c.dynamic.Resource(gvrLBNodeAgents).Namespace(purelbNamespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
@@ -123,6 +149,16 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 		family string
 	}
 	var allRanges []rangeEntry
+
+	// nsBinding mirrors the allocator's eligibility model: several
+	// ServiceGroups may serve one namespace, and exactly one of them must
+	// mark itself as that namespace's default.
+	type nsBinding struct {
+		eligible []string
+		marked   []string
+		enforced bool
+	}
+	nsBindings := map[string]nsBinding{}
 
 	sgCount := 0
 	for _, sg := range sgList.Items {
@@ -206,13 +242,51 @@ func runValidate(ctx context.Context, c *clients, format outputFormat, strict bo
 			}
 		}
 
-		if _, ok := spec["netbox"]; ok {
-			checks = append(checks, checkResult{"PASS", fmt.Sprintf("ServiceGroup %q: Netbox config present (URL reachability not checked)", sgName)})
+		if spec["local"] == nil && spec["remote"] == nil && spec["external"] == nil {
+			checks = append(checks, checkResult{"FAIL", fmt.Sprintf("ServiceGroup %q: no local, remote, or external spec", sgName)})
 		}
 
-		if spec["local"] == nil && spec["remote"] == nil && spec["netbox"] == nil {
-			checks = append(checks, checkResult{"FAIL", fmt.Sprintf("ServiceGroup %q: no local, remote, or netbox spec", sgName)})
+		// Record namespace bindings for the cross-object checks below.
+		if nss, found, _ := unstructured.NestedStringSlice(sg.Object, "spec", "namespaces"); found {
+			isDefault, _, _ := unstructured.NestedBool(sg.Object, "spec", "namespaceDefault")
+			enforces, _, _ := unstructured.NestedBool(sg.Object, "spec", "enforceNamespaces")
+			for _, ns := range nss {
+				binding := nsBindings[ns]
+				if !slices.Contains(binding.eligible, sgName) {
+					binding.eligible = append(binding.eligible, sgName)
+				}
+				if isDefault && !slices.Contains(binding.marked, sgName) {
+					binding.marked = append(binding.marked, sgName)
+				}
+				binding.enforced = binding.enforced || enforces
+				nsBindings[ns] = binding
+			}
 		}
+	}
+
+	// Several ServiceGroups may serve one namespace -- an L2 + BGP tenant
+	// needs two -- but exactly one must say which an unannotated Service
+	// gets. When enforcement is off this is silent at allocation time (the
+	// Service quietly lands on "default"), so this check is the only signal
+	// an operator gets.
+	for _, ns := range slices.Sorted(maps.Keys(nsBindings)) {
+		b := nsBindings[ns]
+		if len(b.eligible) < 2 || len(b.marked) == 1 {
+			continue
+		}
+		slices.Sort(b.eligible)
+		outcome := fmt.Sprintf("unannotated Services in %q fall back to the %q pool", ns, defaultPoolName)
+		if b.enforced {
+			outcome = fmt.Sprintf("unannotated Services in %q are denied", ns)
+		}
+		what := "none sets namespaceDefault"
+		if len(b.marked) > 1 {
+			slices.Sort(b.marked)
+			what = fmt.Sprintf("%v all set namespaceDefault", b.marked)
+		}
+		checks = append(checks, checkResult{"FAIL", fmt.Sprintf(
+			"Namespace %q is served by %v and %s; exactly one must. Until then, %s",
+			ns, b.eligible, what, outcome)})
 	}
 
 	// Check for overlapping ranges between ServiceGroups

--- a/cmd/kubectl-purelb/validate_namespace_test.go
+++ b/cmd/kubectl-purelb/validate_namespace_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// sgInNamespace is makeSG placed somewhere other than the install namespace.
+func sgInNamespace(namespace, name, poolType string) *unstructured.Unstructured {
+	sg := makeSG(name, poolType, "192.168.1.0-192.168.1.10", "192.168.1.0/24")
+	sg.SetNamespace(namespace)
+	return sg
+}
+
+// withNamespaces adds the binding fields to a ServiceGroup.
+func withNamespaces(sg *unstructured.Unstructured, namespaces []string, isDefault bool) *unstructured.Unstructured {
+	spec := sg.Object["spec"].(map[string]interface{})
+	nss := make([]interface{}, 0, len(namespaces))
+	for _, n := range namespaces {
+		nss = append(nss, n)
+	}
+	spec["namespaces"] = nss
+	spec["namespaceDefault"] = isDefault
+	return sg
+}
+
+// validateOutput runs validate against a fake cluster and captures what it
+// prints. runValidate writes the table straight to os.Stdout, so the pipe is
+// the only way to assert on the operator-visible text -- which is the whole
+// point of these checks.
+func validateOutput(t *testing.T, objs ...runtime.Object) string {
+	t.Helper()
+	c := newFakeClients(nil, objs...)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	_ = runValidate(context.Background(), c, outputTable, false)
+	os.Stdout = orig
+	w.Close()
+
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, r); err != nil {
+		t.Fatalf("read captured output: %v", err)
+	}
+	return sb.String()
+}
+
+// TestValidateFlagsOutOfNamespaceServiceGroup: this check is PR C's only
+// pre-upgrade gate, and a namespace-scoped list cannot see what it must flag.
+// A remote group is called out specifically because ignoring one withdraws
+// its addresses from every node, where a local one only makes its pool
+// unallocatable.
+func TestValidateFlagsOutOfNamespaceServiceGroup(t *testing.T) {
+	out := validateOutput(t,
+		makeSG("default", "local", "192.168.9.0-192.168.9.10", "192.168.9.0/24"),
+		sgInNamespace("tenant-a", "stray", "remote"),
+	)
+	if !strings.Contains(out, "stray") || !strings.Contains(out, "tenant-a") {
+		t.Fatalf("out-of-namespace ServiceGroup not reported:\n%s", out)
+	}
+	if !strings.Contains(out, "withdrawn from every node") {
+		t.Fatalf("a remote group's consequence must be named, not generic:\n%s", out)
+	}
+}
+
+// TestValidateAcceptsInstallNamespaceServiceGroup guards the false-positive
+// direction: a correctly-placed ServiceGroup must not be flagged.
+func TestValidateAcceptsInstallNamespaceServiceGroup(t *testing.T) {
+	out := validateOutput(t, makeSG("default", "local", "192.168.9.0-192.168.9.10", "192.168.9.0/24"))
+	if strings.Contains(out, "not the PureLB install namespace") {
+		t.Fatalf("correctly-placed ServiceGroup was flagged:\n%s", out)
+	}
+}
+
+// TestValidateFlagsAmbiguousNamespaceDefault: with enforcement off, an
+// unresolved namespaceDefault is silent at allocation time -- the Service
+// quietly lands on "default" -- so this check is the only signal an operator
+// gets. One ServiceGroup serving a namespace must NOT be flagged.
+func TestValidateFlagsAmbiguousNamespaceDefault(t *testing.T) {
+	out := validateOutput(t,
+		makeSG("default", "local", "192.168.9.0-192.168.9.10", "192.168.9.0/24"),
+		withNamespaces(makeSG("a-l2", "local", "192.168.2.0-192.168.2.10", "192.168.2.0/24"), []string{"tenant-a"}, false),
+		withNamespaces(makeSG("a-bgp", "remote", "192.168.3.0-192.168.3.10", "192.168.3.0/24"), []string{"tenant-a"}, false),
+	)
+	if !strings.Contains(out, "namespaceDefault") || !strings.Contains(out, "tenant-a") {
+		t.Fatalf("ambiguous namespaceDefault not reported:\n%s", out)
+	}
+
+	// Exactly one marked resolves it.
+	out = validateOutput(t,
+		makeSG("default", "local", "192.168.9.0-192.168.9.10", "192.168.9.0/24"),
+		withNamespaces(makeSG("a-l2", "local", "192.168.2.0-192.168.2.10", "192.168.2.0/24"), []string{"tenant-a"}, true),
+		withNamespaces(makeSG("a-bgp", "remote", "192.168.3.0-192.168.3.10", "192.168.3.0/24"), []string{"tenant-a"}, false),
+	)
+	if strings.Contains(out, "exactly one must") {
+		t.Fatalf("a resolved namespaceDefault must not be flagged:\n%s", out)
+	}
+}

--- a/cmd/lbnodeagent/controller.go
+++ b/cmd/lbnodeagent/controller.go
@@ -76,7 +76,7 @@ func (c *controller) ServiceChanged(svc *v1.Service, epSlices []*discoveryv1.End
 		delete(svc.Annotations, purelbv2.AnnounceAnnotation+"-unknown")
 
 		logging.Info(c.logger, "op", "withdraw", "reason", "notLoadBalancerType", "node", c.myNode, "service", nsName)
-		c.DeleteBalancer(nsName)
+		c.DeleteBalancer(nsName, "")
 
 		// This is a "best-effort" operation. If it fails there's not much
 		// point in retrying because it's unlikely that anything will
@@ -113,7 +113,11 @@ func (c *controller) ServiceChanged(svc *v1.Service, epSlices []*discoveryv1.End
 // DeleteBalancer deletes any changes that we have made on behalf of
 // nsName. nsName must be a namespaced name string, e.g.,
 // "purelb/example".
-func (c *controller) DeleteBalancer(nsName string) k8s.SyncState {
+// DeleteBalancer withdraws a deleted Service's addresses. The pool the
+// address came from is irrelevant here -- the node agent keys everything on
+// the Service name and the addresses it recorded -- so it is accepted to
+// satisfy the shared client interface and ignored.
+func (c *controller) DeleteBalancer(nsName string, _ string) k8s.SyncState {
 	retval := k8s.SyncStateSuccess
 
 	logging.Debug(c.logger, "op", "deleteBalancer", "name", nsName)

--- a/cmd/lbnodeagent/main.go
+++ b/cmd/lbnodeagent/main.go
@@ -157,6 +157,15 @@ func main() {
 			return k8s.SyncStateError
 		}
 
+		// Log locally as well as in the allocator. An operator debugging a
+		// VIP that stopped being announced looks at the node agent, and a
+		// dropped `remote` group is exactly why it would have stopped.
+		for _, g := range cfg.DroppedGroups {
+			logging.Info(logger, "op", "configChanged", "event", "serviceGroupOutOfScope",
+				"sg", g.Namespace+"/"+g.Name, "isRemote", fmt.Sprintf("%t", g.Spec.Remote != nil),
+				"msg", "ignored: ServiceGroups are read only from the PureLB install namespace")
+		}
+
 		for _, agent := range cfg.Agents {
 			logging.Debug(logger, "op", "configChanged", "agent", agent.Namespace+"/"+agent.Name,
 				"hasNodeSelector", fmt.Sprintf("%t", agent.Spec.NodeSelector != nil))
@@ -227,6 +236,7 @@ func main() {
 		NodeName:           *myNode,
 		Logger:             logger,
 		Kubeconfig:         *kubeconfig,
+		Namespace:          *namespace,
 		ReadEndpointSlices: true,
 
 		ServiceChanged: ctrl.ServiceChanged,

--- a/cmd/lbnodeagent/main.go
+++ b/cmd/lbnodeagent/main.go
@@ -171,12 +171,45 @@ func main() {
 				"hasNodeSelector", fmt.Sprintf("%t", agent.Spec.NodeSelector != nil))
 		}
 
+		// AgentsForNode drops agents whose selector will not convert, and
+		// documents that reporting them is the caller's job. Do that here:
+		// otherwise a typo in matchExpressions removes an LBNodeAgent from
+		// consideration with no log, no event and no metric, which looks
+		// exactly like the CR not existing.
 		preFilter := len(cfg.Agents)
+		for _, agent := range cfg.Agents {
+			if purelbv2.IsCatchAll(agent.Spec.NodeSelector) {
+				continue
+			}
+			if _, err := metav1.LabelSelectorAsSelector(agent.Spec.NodeSelector); err != nil {
+				logging.Info(logger, "op", "configChanged", "event", "invalidNodeSelector",
+					"agent", agent.Namespace+"/"+agent.Name, "error", err,
+					"msg", "nodeSelector could not be evaluated; this LBNodeAgent matches no node")
+				client.Errorf(agent, "InvalidNodeSelector",
+					"nodeSelector could not be evaluated (%s); this LBNodeAgent applies to no node", err)
+			}
+		}
+
 		cfg.Agents = purelbv2.AgentsForNode(cfg.Agents, node.Labels)
+
+		// Report the agent whose configuration is actually applied, which is
+		// the first one with a Local spec, not simply the highest-precedence
+		// match. The announcer and the election selector both resolve through
+		// FirstLocalAgent, so an LBNodeAgent carrying only a nodeSelector
+		// sorts to the front, gets skipped, and naming it here would event
+		// "ignored" against the CR that is genuinely in force.
 		if len(cfg.Agents) > 1 {
-			winner := cfg.Agents[0]
-			for _, ignored := range cfg.Agents[1:] {
-				logging.Info(logger, "op", "configChanged", "msg", "multiple LBNodeAgents match this node, using highest precedence",
+			winner := purelbv2.FirstLocalAgent(cfg.Agents)
+			if winner == nil {
+				logging.Info(logger, "op", "configChanged", "event", "noLocalSpec", "node", *myNode,
+					"matching", fmt.Sprintf("%d", len(cfg.Agents)),
+					"msg", "LBNodeAgents match this node but none has a local spec; announcing nothing")
+			}
+			for _, ignored := range cfg.Agents {
+				if winner == nil || ignored == winner {
+					continue
+				}
+				logging.Info(logger, "op", "configChanged", "msg", "multiple LBNodeAgents match this node, using highest precedence with a local spec",
 					"node", *myNode, "using", winner.Namespace+"/"+winner.Name, "ignoring", ignored.Namespace+"/"+ignored.Name)
 				client.Errorf(ignored, "ConfigIgnored",
 					"LBNodeAgent %s/%s takes precedence on node %s", winner.Namespace, winner.Name, *myNode)

--- a/cmd/test-sidecar/main.go
+++ b/cmd/test-sidecar/main.go
@@ -52,9 +52,9 @@ func env(key, def string) string {
 
 // pool is a single in-memory IPv4 pool over a CIDR.
 type pool struct {
-	cidr     *net.IPNet
-	bySvc    map[string]net.IP // service -> allocated IP (idempotency)
-	inUse    map[string]string // ip string -> service
+	cidr  *net.IPNet
+	bySvc map[string]net.IP // service -> allocated IP (idempotency)
+	inUse map[string]string // ip string -> service
 }
 
 func newPool(cidr *net.IPNet) *pool {

--- a/deployments/default/purelb.yaml
+++ b/deployments/default/purelb.yaml
@@ -61,13 +61,6 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ''
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -118,13 +111,6 @@ rules:
   verbs:
   - create
   - patch
-- apiGroups:
-  - ''
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
 # Leases are used for leader election (subnet-aware election via K8s leases)
 - apiGroups:
   - coordination.k8s.io

--- a/deployments/default/purelb.yaml
+++ b/deployments/default/purelb.yaml
@@ -349,12 +349,10 @@ spec:
       - image: ghcr.io/purelb/purelb/allocator:VERSION_TAG
         imagePullPolicy: IfNotPresent
         env:
-        - name: NETBOX_USER_TOKEN
+        - name: PURELB_NAMESPACE
           valueFrom:
-            secretKeyRef:
-              name: netbox-client
-              key: user-token
-              optional: true
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: DEFAULT_ANNOUNCER
           value: "PureLB"
         name: allocator

--- a/docs/v0.17.0-release-material.md
+++ b/docs/v0.17.0-release-material.md
@@ -74,8 +74,9 @@ at release time.
   sidecar via `spec.external`. The unused `NETBOX_USER_TOKEN` env var has been
   dropped from the allocator Deployment.
 - **v2 API** is the served/stored version (see `docs/migration-v1-to-v2.md`).
-- Add a v0.17.0 entry to the migration guide covering Netbox → sidecar and the
-  annotation-format change.
+- Migration guide entry written: `website/content/docs/migration/v0-17-0/`
+  covers Netbox → sidecar, the removed `status.allocatedCount`, install-namespace
+  scoping, the manifest/RBAC changes and the annotation-format change.
 
 ## Fixes worth a release-note line
 

--- a/docs/v0.17.0-release-material.md
+++ b/docs/v0.17.0-release-material.md
@@ -7,6 +7,24 @@ at release time.
 
 ## New features
 
+- **Namespace-scoped address pools.** `spec.namespaces` on a ServiceGroup lists
+  the Service namespaces it serves; an unannotated Service in one of them
+  allocates from it. Omitting the field means every namespace, so this is
+  additive and changes nothing on an existing cluster.
+  - Several ServiceGroups may serve one namespace — a group is exactly one of
+    local/remote/external, so an L2 + BGP tenant needs two. `namespaceDefault`
+    picks which one an unannotated Service gets.
+  - `enforceNamespaces: true` turns the list into a boundary in both
+    directions, covering `purelb.io/service-group` *and* `purelb.io/addresses`.
+    Enforcement is a property of the namespace: setting it on any one of a
+    namespace's ServiceGroups fences that namespace completely.
+  - **It enforces nothing that is already allocated.** Addresses already held
+    are never revoked, so on the day it is enabled the boundary is not true of
+    any existing Service; it governs new allocations only.
+  - This is an allocation control, not RBAC. Restricting `create`/`patch` on
+    `servicegroups.purelb.io` to cluster admins remains the primary control.
+  - `status.boundNamespaces` reports the list the allocator parsed.
+
 - **External (sidecar) IPAM.** A ServiceGroup can now request addresses from an
   external IPAM system reached over a gRPC sidecar in the allocator pod.
   - `ServiceGroup.spec.external{ provider, socket, announce }` (provider = cosmetic
@@ -37,8 +55,24 @@ at release time.
 
 ## Removed / breaking
 
+- **ServiceGroups are read only from the PureLB install namespace.** Earlier
+  releases read them from every namespace, which provided no isolation (a group
+  in `tenant-a` fed the same cluster-wide pool table) while allowing two groups
+  in different namespaces to collide over a pool name — including `default`.
+  A ServiceGroup elsewhere is now ignored: its pool is not allocatable and, if
+  it is a `remote` group, **its addresses are withdrawn from every node**.
+  - Pre-upgrade check: `kubectl get servicegroups.purelb.io -A`
+  - Recovery is to move the object into the install namespace; addresses return
+    on the next reconcile, and the two copies may coexist during the move.
+  - PureLB logs, emits a Warning event on each ignored group, and reports them
+    in `purelb_servicegroups_out_of_scope{namespace,name,type}`.
+  - The allocator now takes `--namespace` / `PURELB_NAMESPACE`; the chart and
+    kustomize manifests supply it via the downward API. If it cannot be
+    determined, PureLB does **not** filter at all rather than risk discarding
+    every ServiceGroup.
 - **In-tree Netbox removed** (`spec.netbox` gone; CEL-rejected). Migrate to a
-  sidecar via `spec.external`.
+  sidecar via `spec.external`. The unused `NETBOX_USER_TOKEN` env var has been
+  dropped from the allocator Deployment.
 - **v2 API** is the served/stored version (see `docs/migration-v1-to-v2.md`).
 - Add a v0.17.0 entry to the migration guide covering Netbox → sidecar and the
   annotation-format change.

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -61,6 +63,30 @@ type ListServicesFunc func() []v1.Service
 type allocatorState struct {
 	pools    map[string]Pool
 	sgByName map[string]*purelbv2.ServiceGroup
+
+	// nsToPools maps a Service namespace to the ServiceGroups serving it.
+	// Absent means the namespace is bound by nothing and falls back to the
+	// pool named "default", exactly as before this feature existed.
+	nsToPools map[string]nsBinding
+
+	// confinedGroups holds every ServiceGroup that serves at least one
+	// confined namespace. Exclusion is derived from this rather than from a
+	// group's own EnforceNamespaces: fencing a tenant's L2 pool while
+	// leaving its BGP pool reachable cluster-wide would be a half-open
+	// fence, so enforcing on any one of a namespace's groups fences all of
+	// them.
+	confinedGroups map[string]bool
+}
+
+// nsBinding is what a namespace resolves to. eligible is a set, because
+// several ServiceGroups serving one namespace is normal -- a ServiceGroup is
+// exactly one of local, remote or external, so an L2 + BGP tenant needs two.
+// Only def needs a single pick.
+type nsBinding struct {
+	eligible []string // every ServiceGroup serving this namespace, sorted
+	def      string   // the unannotated default; "" when unresolvable
+	enforce  bool     // any eligible ServiceGroup sets EnforceNamespaces
+	defErr   string   // why def is empty, verbatim into the Service event
 }
 
 // An Allocator tracks IP address pools and allocates addresses from them.
@@ -107,15 +133,24 @@ func (a *Allocator) SetServiceGroupStatusWriter(w k8s.ServiceGroupStatusWriter) 
 	a.sgStatusClient = w
 }
 
-// Pools returns the current pool snapshot. Call once per processing
-// cycle and pass the result to all allocator methods within that cycle.
+// Pools returns the current pool snapshot. Retained for the release paths,
+// which are namespace-blind by design and must not see the binding index.
 // Nil-safe for startup before first config arrives.
 func (a *Allocator) Pools() map[string]Pool {
-	s := a.state.Load()
-	if s == nil {
-		return nil
+	return a.Snapshot().pools
+}
+
+// Snapshot returns the whole config snapshot -- pools, ServiceGroups and the
+// namespace binding index. Call once per processing cycle and pass the result
+// to every allocator method in that cycle, so that a Service is never
+// authorized against one generation's bindings and allocated from another's.
+//
+// Never returns nil, because callers dereference it on the allocation path.
+func (a *Allocator) Snapshot() *allocatorState {
+	if s := a.state.Load(); s != nil {
+		return s
 	}
-	return s.pools
+	return &allocatorState{}
 }
 
 // SetClient sets this Allocator's client field.
@@ -170,8 +205,18 @@ func (a *Allocator) SetPools(groups []*purelbv2.ServiceGroup) error {
 		}
 	}
 
-	// Atomic swap — after this, G1's next Pools() call sees the new map
-	a.state.Store(&allocatorState{pools: pools, sgByName: sgByName})
+	nsToPools, confinedGroups := a.buildNSIndex(groups, pools)
+
+	// Atomic swap — after this, G1's next Pools() call sees the new map.
+	// Everything derived from this config is published together so a reader
+	// can never mix a binding index from one generation with pools from
+	// another.
+	a.state.Store(&allocatorState{
+		pools:          pools,
+		sgByName:       sgByName,
+		nsToPools:      nsToPools,
+		confinedGroups: confinedGroups,
+	})
 	a.populated.Store(false)
 
 	// Set capacity for new pools (size is static, safe from G2).
@@ -181,6 +226,79 @@ func (a *Allocator) SetPools(groups []*purelbv2.ServiceGroup) error {
 	}
 
 	return nil
+}
+
+// buildNSIndex resolves, once per config change, which ServiceGroups serve
+// each namespace, which of them is the unannotated default, and whether the
+// namespace is confined. Runs on G2 from SetPools and is published by the
+// same atomic swap as pools, so an index can never be paired with a
+// different generation's pools.
+//
+// Only ServiceGroups that survived parseGroups contribute: a group whose
+// spec is broken has no pool, and binding a namespace to it would deny every
+// Service in that namespace on the strength of a YAML error elsewhere.
+func (a *Allocator) buildNSIndex(groups []*purelbv2.ServiceGroup, pools map[string]Pool) (map[string]nsBinding, map[string]bool) {
+	idx := map[string]nsBinding{}
+	marked := map[string][]string{}
+
+	for _, g := range groups {
+		if _, parsed := pools[g.Name]; !parsed {
+			continue
+		}
+		// Dedupe: +listType=set is deliberately not used (under server-side
+		// apply it gives per-element ownership, so an entry deleted from Git
+		// would silently persist). The API server therefore accepts
+		// `namespaces: [a, a]`, and without this a single ServiceGroup with a
+		// copy-pasted entry would appear twice in eligible, look like two
+		// groups competing, and deny its own namespace.
+		for _, ns := range slices.Compact(slices.Sorted(slices.Values(g.Spec.Namespaces))) {
+			b := idx[ns]
+			b.eligible = append(b.eligible, g.Name)
+			b.enforce = b.enforce || g.Spec.EnforceNamespaces
+			idx[ns] = b
+			if g.Spec.NamespaceDefault {
+				marked[ns] = append(marked[ns], g.Name)
+			}
+		}
+	}
+
+	for ns, b := range idx {
+		// Sorted for stable event text and inspect output only; it never
+		// selects anything, so the build stays order-independent.
+		slices.Sort(b.eligible)
+		m := marked[ns]
+		slices.Sort(m)
+		switch {
+		case len(b.eligible) == 1:
+			b.def = b.eligible[0]
+		case len(m) == 1:
+			b.def = m[0]
+		case len(m) == 0:
+			b.defErr = fmt.Sprintf("namespace %q is served by %v and none sets namespaceDefault; exactly one must", ns, b.eligible)
+		default:
+			b.defErr = fmt.Sprintf("namespace %q: %v all set namespaceDefault; exactly one must", ns, m)
+		}
+		idx[ns] = b
+	}
+
+	// Exclusion is derived from namespace confinement, not from a group's own
+	// EnforceNamespaces. Reading the target's own flag would fence a tenant's
+	// L2 pool while leaving its BGP pool reachable from every namespace in
+	// the cluster.
+	confined := map[string]bool{}
+	for _, b := range idx {
+		if !b.enforce {
+			continue
+		}
+		for _, name := range b.eligible {
+			confined[name] = true
+		}
+	}
+
+	if len(idx) == 0 {
+		return nil, nil
+	}
+	return idx, confined
 }
 
 // populateFromExisting scans the service cache and registers all
@@ -351,6 +469,13 @@ func (a *Allocator) writeSGStatus(ctx context.Context, sg *purelbv2.ServiceGroup
 	}
 
 	newStatus := buildStatus(pool)
+	// Set here rather than in buildStatus, which is a pure Pool function with
+	// no ServiceGroup in scope. Copied from the spec slice, never assembled
+	// from a map: statusEqual compares element-wise, so a varying order would
+	// defeat the elision cache and produce one apply per ServiceGroup on every
+	// sweep, forever.
+	newStatus.BoundNamespaces = slices.Clone(sg.Spec.Namespaces)
+
 	if prev, loaded := a.lastWritten.Load(sg.Name); loaded {
 		if statusEqual(prev.(purelbv2.ServiceGroupStatus), newStatus) {
 			return false, nil // no-op
@@ -428,6 +553,14 @@ func statusEqual(a, b purelbv2.ServiceGroupStatus) bool {
 			return false
 		}
 	}
+	// This list is hand-maintained, so a new status field that is not
+	// compared here is written once and then frozen: the elision cache would
+	// report the status unchanged forever while the allocator acted on a
+	// newer spec. Editing spec.namespaces changes nothing else, so without
+	// this the confirmation signal would show the old list indefinitely.
+	if !slices.Equal(a.BoundNamespaces, b.BoundNamespaces) {
+		return false
+	}
 	return true
 }
 
@@ -490,7 +623,9 @@ func (a *Allocator) NotifyExisting(pools map[string]Pool, svc *v1.Service) error
 // the pool specified in the purelbv2.DesiredGroupAnnotation
 // annotation. If neither is specified then we will attempt to
 // allocate from a pool named "default", if it exists.
-func (a *Allocator) Allocate(pools map[string]Pool, svc *v1.Service) error {
+func (a *Allocator) Allocate(st *allocatorState, svc *v1.Service) error {
+	pools := st.pools
+
 	// Ensure pool state reflects all existing allocations before
 	// assigning a new IP. This is called here (not in SetPools) because
 	// SetPools runs on the CR controller goroutine where the service
@@ -500,7 +635,7 @@ func (a *Allocator) Allocate(pools map[string]Pool, svc *v1.Service) error {
 	a.populateFromExisting(pools)
 
 	// If the user asked for a specific IP, allocate that.
-	allocated, err := a.allocateSpecificIP(pools, svc)
+	allocated, err := a.allocateSpecificIP(st, svc)
 	if err != nil {
 		return err
 	}
@@ -508,17 +643,17 @@ func (a *Allocator) Allocate(pools map[string]Pool, svc *v1.Service) error {
 	// The user didn't ask for a specific IP so we can allocate one from
 	// a pool.
 	if !allocated {
-		// Start with the default pool name.
-		poolName := defaultPoolName
-
-		// If the user specified a desiredGroup, then use that.
-		if userPool, has := svc.Annotations[purelbv2.DesiredGroupAnnotation]; has {
-			poolName = userPool
+		pool, via, err := st.resolve(svc)
+		if err != nil {
+			return err
 		}
-
-		pool, has := pools[poolName]
-		if !has {
-			return fmt.Errorf("unknown pool %q", poolName)
+		if via == viaAmbiguous {
+			// Falling back to "default" because the namespace could not
+			// resolve one of its own. Nothing is denied, so without this the
+			// operator who most needs namespaceDefault -- the L2 + BGP tenant
+			// -- gets silence and Services quietly landing on another subnet.
+			a.client.Errorf(svc, "ConfigurationWarning", "%s; allocated from %q instead",
+				st.nsToPools[svc.Namespace].defErr, defaultPoolName)
 		}
 
 		// Multi-pool and balancePools are mutually exclusive
@@ -544,7 +679,8 @@ func (a *Allocator) Allocate(pools map[string]Pool, svc *v1.Service) error {
 // a specific address then the return values will be ("", nil). If an
 // address was allocated then the string return value will be
 // non-"". If an error happened then the error return will be non-nil.
-func (a *Allocator) allocateSpecificIP(pools map[string]Pool, svc *v1.Service) (bool, error) {
+func (a *Allocator) allocateSpecificIP(st *allocatorState, svc *v1.Service) (bool, error) {
+	pools := st.pools
 	poolNames := ""
 	var firstPool Pool // Track first pool for annotations
 
@@ -564,18 +700,34 @@ func (a *Allocator) allocateSpecificIP(pools map[string]Pool, svc *v1.Service) (
 		logging.Info(a.logger, "op", "allocateSpecificIP", "warning", "addresses annotation overrides service-group annotation")
 	}
 
+	// Resolve and authorize every requested address BEFORE releasing
+	// anything. The Unassign below frees this Service's current addresses in
+	// pool accounting while .status still advertises them, so returning an
+	// error from inside the assign loop leaves a double-allocation window.
+	// Pinning a neighbour's address is a routine misconfiguration, not a rare
+	// one, so it must not reach that loop.
+	resolved := make([]Pool, len(ips))
+	for i, ip := range ips {
+		pool := poolFor(pools, ip)
+		if pool == nil {
+			return false, fmt.Errorf("%q does not belong to any group", ip)
+		}
+		// Same gate as the annotation path: an address is a way of naming a
+		// ServiceGroup, so pinning must not bypass the boundary that naming
+		// it would hit.
+		if _, err := st.checked(svc.Namespace, pool.String()); err != nil {
+			return false, fmt.Errorf("%s: %w", ip, err)
+		}
+		resolved[i] = pool
+	}
+
 	// If the service had addresses before, release them.
 	if err := a.Unassign(pools, namespacedName(svc)); err != nil {
 		return false, err
 	}
 
-	for _, ip := range ips {
-
-		// Check that the address belongs to a pool
-		pool := poolFor(pools, ip)
-		if pool == nil {
-			return false, fmt.Errorf("%q does not belong to any group", ip)
-		}
+	for i, ip := range ips {
+		pool := resolved[i]
 
 		// Track the first pool for setting annotations
 		if firstPool == nil {
@@ -630,8 +782,21 @@ func (a *Allocator) allocateFromPool(pools map[string]Pool, svc *v1.Service, poo
 		}
 	}
 
+	// AssignNext commits each family as it goes (assignFamily -> Assign ->
+	// addIngress + Notify) and returns on the first failure without
+	// unwinding. Left alone, a dual-stack Service against a single-family
+	// pool keeps the family that succeeded in .status -- which SetBalancer
+	// persists and the node agent announces, because it does not check the
+	// brand -- while BrandAnnotation is never set, since that happens only
+	// after a successful allocation. populateFromExisting then skips the
+	// Service, so after an allocator restart the address is handed out
+	// again: two Services, one VIP.
+	//
+	// Roll back only what this call added. Pre-existing addresses from an
+	// IP-family transition must survive, so this cannot be Unassign.
+	committed := len(svc.Status.LoadBalancer.Ingress)
 	if err := pool.AssignNext(context.Background(), svc); err != nil {
-		// Woops, no IPs :( Fail.
+		a.rollbackIngress(pool, svc, committed)
 		return err
 	}
 
@@ -653,6 +818,31 @@ func (a *Allocator) allocateFromPool(pools map[string]Pool, svc *v1.Service, poo
 	a.updateStats(pool)
 
 	return nil
+}
+
+// rollbackIngress releases every address added to svc beyond keep and
+// truncates .status back to that length, undoing a partial allocation.
+//
+// Truncating by index is safe because addIngress only ever appends and
+// nothing between the snapshot and here reorders the slice.
+func (a *Allocator) rollbackIngress(pool Pool, svc *v1.Service, keep int) {
+	ingress := svc.Status.LoadBalancer.Ingress
+	if keep >= len(ingress) {
+		return
+	}
+	for _, added := range ingress[keep:] {
+		ip := net.ParseIP(added.IP)
+		if ip == nil {
+			continue
+		}
+		if err := pool.ReleaseIP(context.Background(), namespacedName(svc), ip); err != nil {
+			logging.Info(a.logger, "op", "rollbackIngress", "error", err,
+				"svc", namespacedName(svc), "ip", added.IP)
+		}
+	}
+	logging.Info(a.logger, "op", "rollbackIngress", "svc", namespacedName(svc),
+		"released", len(ingress)-keep, "msg", "partial allocation rolled back")
+	svc.Status.LoadBalancer.Ingress = ingress[:keep]
 }
 
 // isMultiPool determines whether a service should use multi-pool allocation.
@@ -713,19 +903,79 @@ func (a *Allocator) allocateMultiPool(pools map[string]Pool, svc *v1.Service, po
 	return nil
 }
 
+// poolHoldingAll returns the pool containing every one of svc's ingress
+// addresses. It answers the identity question — which pool does this Service
+// actually hold — from the addresses themselves rather than from
+// purelb.io/allocated-from, which lives on the Service and is therefore
+// editable by whoever owns it.
+//
+// SidecarPool.Contains is hardcoded false, so an external pool can never be
+// resolved this way. Callers must reject external pools explicitly; treating
+// a nil result as "must be external" would hand a free pass to any address
+// that belongs to no configured pool at all.
+func poolHoldingAll(pools map[string]Pool, svc *v1.Service) (Pool, error) {
+	var held Pool
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		ip := net.ParseIP(ingress.IP)
+		if ip == nil {
+			return nil, fmt.Errorf("unparseable ingress address %q", ingress.IP)
+		}
+		p := poolFor(pools, ip)
+		if p == nil {
+			return nil, fmt.Errorf("address %s does not belong to any pool", ingress.IP)
+		}
+		if held == nil {
+			held = p
+		} else if held.String() != p.String() {
+			return nil, fmt.Errorf("addresses span more than one pool (%s, %s)", held, p)
+		}
+	}
+	if held == nil {
+		return nil, fmt.Errorf("service has no ingress addresses")
+	}
+	return held, nil
+}
+
 // IncrementalMultiPool attempts to allocate additional IPs from newly
 // available ranges for an existing multi-pool service. It does NOT
 // release existing IPs — AssignNextPerRange skips ranges where the
 // service already has an IP. Returns true if new IPs were added.
-func (a *Allocator) IncrementalMultiPool(pools map[string]Pool, svc *v1.Service) (bool, error) {
-	poolName, ok := svc.Annotations[purelbv2.PoolAnnotation]
-	if !ok {
-		return false, fmt.Errorf("service missing %s annotation", purelbv2.PoolAnnotation)
+func (a *Allocator) IncrementalMultiPool(st *allocatorState, svc *v1.Service) (bool, error) {
+	pools := st.pools
+	// Resolve the pool from the addresses the Service holds, not from
+	// purelb.io/allocated-from. Trusting the annotation let anyone with
+	// patch on their own Service draw addresses from any pool in the
+	// cluster. Rewriting the annotation from the result below also
+	// repairs it if it had been tampered with.
+	pool, err := poolHoldingAll(pools, svc)
+	if err != nil {
+		// A constant label, never the annotation value: the annotation is
+		// user-supplied, so using it here would let a Service mint an
+		// unbounded number of Prometheus series.
+		allocationRejected.WithLabelValues("<unknown>", "multipool_pool_mismatch").Inc()
+		return false, err
 	}
-	pool, ok := pools[poolName]
-	if !ok {
-		return false, fmt.Errorf("unknown pool %q", poolName)
+
+	// External pools have no per-range concept: SidecarPool.AssignNextPerRange
+	// just calls AssignNext and addIngress never dedupes, so each call would
+	// append another address and the resulting Status write would re-enqueue
+	// the Service — one new address per work-queue turn, forever.
+	// SidecarPool.MultiPool() is false, so the annotation was the only way in.
+	// Repair the annotation if it disagrees with the addresses. A mismatch is
+	// either tampering or a stale value after a config change; correcting it
+	// is safe either way, and leaving it would mislead `kubectl purelb` and
+	// any operator inventory built on allocated-from.
+	if named := svc.Annotations[purelbv2.PoolAnnotation]; named != pool.String() {
+		logging.Info(a.logger, "op", "incrementalMultiPool", "msg", "correcting allocated-from",
+			"svc", namespacedName(svc), "claimed", named, "actual", pool.String())
+		svc.Annotations[purelbv2.PoolAnnotation] = pool.String()
 	}
+
+	if _, external := pool.(*SidecarPool); external {
+		allocationRejected.WithLabelValues(pool.String(), "multipool_refused").Inc()
+		return false, fmt.Errorf("multi-pool allocation is not supported for external pool %q", pool)
+	}
+
 	if a.activeSubnets == nil {
 		return false, fmt.Errorf("activeSubnets not configured")
 	}
@@ -908,8 +1158,12 @@ Group:
 		}
 
 		// Check that this pool doesn't overlap with any of the previous
-		// ones
-		for name, r := range pools {
+		// ones. Iterate in sorted order: with three or more overlapping
+		// ServiceGroups a map walk names a different partner each time, so
+		// the event text changes, the recorder cannot aggregate it, and a
+		// fresh Event appears on every resync forever.
+		for _, name := range slices.Sorted(maps.Keys(pools)) {
+			r := pools[name]
 			if pool.Overlaps(r) {
 				a.client.Errorf(group, "ParseFailed", "Pool overlaps with already defined pool \"%s\"", name)
 				logging.Info(a.logger, "op", "parseGroups", "error", "ServiceGroup overlaps", "group", group.Name, "overlaps", name)

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -731,7 +731,7 @@ func (a *Allocator) allocateSpecificIP(st *allocatorState, svc *v1.Service) (boo
 	}
 
 	// If the service had addresses before, release them.
-	if err := a.Unassign(pools, namespacedName(svc)); err != nil {
+	if err := a.Unassign(pools, namespacedName(svc), svc.Annotations[purelbv2.PoolAnnotation]); err != nil {
 		return false, err
 	}
 
@@ -789,7 +789,7 @@ func (a *Allocator) allocateFromPool(pools map[string]Pool, svc *v1.Service, poo
 	// (e.g., SingleStack → DualStack) where we want to keep existing IPs
 	// and only allocate missing families.
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		if err := a.Unassign(pools, namespacedName(svc)); err != nil {
+		if err := a.Unassign(pools, namespacedName(svc), svc.Annotations[purelbv2.PoolAnnotation]); err != nil {
 			return err
 		}
 	}
@@ -885,7 +885,7 @@ func (a *Allocator) allocateMultiPool(pools map[string]Pool, svc *v1.Service, po
 	}
 
 	// Release any existing allocations for this service
-	if err := a.Unassign(pools, namespacedName(svc)); err != nil {
+	if err := a.Unassign(pools, namespacedName(svc), svc.Annotations[purelbv2.PoolAnnotation]); err != nil {
 		return err
 	}
 	svc.Status.LoadBalancer.Ingress = nil
@@ -1060,13 +1060,24 @@ func (a *Allocator) poolContext() (context.Context, context.CancelFunc) {
 // the case where dropping the error leaks an address in a system PureLB
 // does not own. Every pool is still attempted before returning, so one
 // unreachable sidecar cannot strand releases in the others.
-func (a *Allocator) Unassign(pools map[string]Pool, svc string) error {
+// namedPool is the ServiceGroup the Service says it was allocated from, or
+// "" when unknown. It is used only to skip external pools that demonstrably
+// did not hold the address: LocalPool.Release is an in-memory map walk, so
+// asking every local pool costs nothing and guards against a stale or
+// tampered annotation, whereas every SidecarPool asked is a gRPC round trip
+// to a separate IPAM system. A conforming sidecar scopes Release by the
+// request's pool field, so the spurious calls were harmless -- just work no
+// one needed.
+func (a *Allocator) Unassign(pools map[string]Pool, svc string, namedPool string) error {
 	var errs []error
 
 	// tell the pools that the address has been released. there might
 	// not be a pool, e.g., in the case of a config change that moves
 	// addresses from one pool to another
 	for name, p := range pools {
+		if _, external := p.(*SidecarPool); external && namedPool != "" && name != namedPool {
+			continue
+		}
 		ctx, cancel := a.poolContext()
 		err := p.Release(ctx, svc)
 		cancel()

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-kit/log"
 	"google.golang.org/grpc"
@@ -38,6 +39,11 @@ import (
 
 const (
 	defaultPoolName string = "default"
+
+	// defaultPoolTimeout bounds a single Pool mutating operation when no
+	// API-context source is wired (unit tests). Matches the standard PureLB
+	// API timeout so a sidecar gets the same grace as the apiserver.
+	defaultPoolTimeout = 10 * time.Second
 )
 
 // ActiveSubnetsFunc is a function that returns the set of subnets with
@@ -609,7 +615,10 @@ func (a *Allocator) NotifyExisting(pools map[string]Pool, svc *v1.Service) error
 		}
 
 		// Tell the pool about the assignment
-		if err := pool.Notify(context.Background(), svc); err != nil {
+		ctx, cancel := a.poolContext()
+		err := pool.Notify(ctx, svc)
+		cancel()
+		if err != nil {
 			return err
 		}
 		a.updateStats(pool)
@@ -737,7 +746,10 @@ func (a *Allocator) allocateSpecificIP(st *allocatorState, svc *v1.Service) (boo
 		// Does the IP already have allocs? If so, needs to be the same
 		// sharing key, and have non-overlapping ports. If not, the proposed
 		// IP needs to be allowed by configuration.
-		if err := pool.Assign(context.Background(), ip, svc); err != nil {
+		ctx, cancel := a.poolContext()
+		err := pool.Assign(ctx, ip, svc)
+		cancel()
+		if err != nil {
 			return false, err
 		}
 
@@ -795,7 +807,10 @@ func (a *Allocator) allocateFromPool(pools map[string]Pool, svc *v1.Service, poo
 	// Roll back only what this call added. Pre-existing addresses from an
 	// IP-family transition must survive, so this cannot be Unassign.
 	committed := len(svc.Status.LoadBalancer.Ingress)
-	if err := pool.AssignNext(context.Background(), svc); err != nil {
+	ctx, cancel := a.poolContext()
+	err := pool.AssignNext(ctx, svc)
+	cancel()
+	if err != nil {
 		a.rollbackIngress(pool, svc, committed)
 		return err
 	}
@@ -835,7 +850,10 @@ func (a *Allocator) rollbackIngress(pool Pool, svc *v1.Service, keep int) {
 		if ip == nil {
 			continue
 		}
-		if err := pool.ReleaseIP(context.Background(), namespacedName(svc), ip); err != nil {
+		ctx, cancel := a.poolContext()
+		err := pool.ReleaseIP(ctx, namespacedName(svc), ip)
+		cancel()
+		if err != nil {
 			logging.Info(a.logger, "op", "rollbackIngress", "error", err,
 				"svc", namespacedName(svc), "ip", added.IP)
 		}
@@ -881,7 +899,10 @@ func (a *Allocator) allocateMultiPool(pools map[string]Pool, svc *v1.Service, po
 	logging.Info(a.logger, "op", "allocateMultiPool", "activeSubnets", strings.Join(activeSubnets, ","),
 		"svc", namespacedName(svc))
 
-	if err := pool.AssignNextPerRange(context.Background(), svc, activeSubnets); err != nil {
+	ctx, cancel := a.poolContext()
+	err = pool.AssignNextPerRange(ctx, svc, activeSubnets)
+	cancel()
+	if err != nil {
 		return err
 	}
 
@@ -987,7 +1008,10 @@ func (a *Allocator) IncrementalMultiPool(st *allocatorState, svc *v1.Service) (b
 
 	existingCount := len(svc.Status.LoadBalancer.Ingress)
 
-	if err := pool.AssignNextPerRange(context.Background(), svc, activeSubnets); err != nil {
+	ctx, cancel := a.poolContext()
+	err = pool.AssignNextPerRange(ctx, svc, activeSubnets)
+	cancel()
+	if err != nil {
 		return false, err
 	}
 
@@ -1010,26 +1034,60 @@ func (a *Allocator) IncrementalMultiPool(st *allocatorState, svc *v1.Service) (b
 	return false, nil
 }
 
+// poolContext returns a bounded, cancellable context for a Pool mutating
+// operation.
+//
+// Pool methods take a context precisely so that implementations backed by
+// network I/O can be bounded; passing context.Background() defeated that.
+// The allocator's work queue is single-threaded, so an external IPAM
+// sidecar that accepts a connection and never replies would otherwise wedge
+// every Service reconcile, status write and release in the cluster.
+//
+// Prefers the client's API context, which shortens to 500ms during
+// shutdown; falls back to a fixed timeout when no client is wired (tests).
+// Callers MUST invoke the returned CancelFunc.
+func (a *Allocator) poolContext() (context.Context, context.CancelFunc) {
+	if a.sgStatusClient != nil {
+		return a.sgStatusClient.APIContext()
+	}
+	return context.WithTimeout(context.Background(), defaultPoolTimeout)
+}
+
 // Unassign frees the IP associated with service, if any.
+//
+// Release failures are returned, not discarded. LocalPool.Release cannot
+// fail, so in practice this reports only external-IPAM failures -- exactly
+// the case where dropping the error leaks an address in a system PureLB
+// does not own. Every pool is still attempted before returning, so one
+// unreachable sidecar cannot strand releases in the others.
 func (a *Allocator) Unassign(pools map[string]Pool, svc string) error {
-	var err error
+	var errs []error
 
 	// tell the pools that the address has been released. there might
 	// not be a pool, e.g., in the case of a config change that moves
 	// addresses from one pool to another
-	for _, p := range pools {
-		if err = p.Release(context.Background(), svc); err == nil {
-			a.updateStats(p) // This pool released the address
+	for name, p := range pools {
+		ctx, cancel := a.poolContext()
+		err := p.Release(ctx, svc)
+		cancel()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+			logging.Info(a.logger, "op", "unassign", "error", err, "pool", name, "svc", svc,
+				"msg", "pool failed to release the address")
+			continue
 		}
+		a.updateStats(p) // This pool released the address
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // ReleaseIPs releases specific IP addresses for a service. Used during
 // IP family transitions (e.g., DualStack → SingleStack) when only some
 // addresses need to be released.
-func (a *Allocator) ReleaseIPs(pools map[string]Pool, svc string, ips []string) error {
+func (a *Allocator) ReleaseIPs(pools map[string]Pool, svc string, ips []string, namedPool string) error {
+	var errs []error
+
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
@@ -1040,18 +1098,39 @@ func (a *Allocator) ReleaseIPs(pools map[string]Pool, svc string, ips []string) 
 		// Find which pool contains this IP and release it
 		pool := poolFor(pools, ip)
 		if pool == nil {
+			// SidecarPool.Contains is hardcoded false, so an external pool can
+			// never be found by address and this path would silently drop the
+			// release -- the address vanishes from the Service while the
+			// external IPAM still holds it. Fall back to the pool the Service
+			// says it came from, but only when that pool is external: for any
+			// other pool poolFor is authoritative, and trusting a user-editable
+			// annotation there would let a Service free a neighbour's address.
+			if p, ok := pools[namedPool]; ok {
+				if _, external := p.(*SidecarPool); external {
+					pool = p
+				}
+			}
+		}
+		if pool == nil {
 			logging.Info(a.logger, "op", "releaseIPs", "warning", "no pool found for IP", "ip", ipStr)
 			continue
 		}
 
-		if err := pool.ReleaseIP(context.Background(), svc, ip); err != nil {
+		ctx, cancel := a.poolContext()
+		err := pool.ReleaseIP(ctx, svc, ip)
+		cancel()
+		if err != nil {
+			// Returned, not just logged: for an external pool this is a
+			// leaked address in a system PureLB does not own.
+			errs = append(errs, fmt.Errorf("%s: %w", ipStr, err))
 			logging.Info(a.logger, "op", "releaseIPs", "error", err, "ip", ipStr)
 			// Continue releasing other IPs even if one fails
+			continue
 		}
 		a.updateStats(pool)
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // poolFor returns the pool that owns the requested IP, or "" if none.
@@ -1087,7 +1166,7 @@ func (a *Allocator) serviceAddresses(svc *v1.Service) ([]net.IP, error) {
 		logging.Info(a.logger, "op", "serviceAddresses", "svc", svc.Name, "deprecation", "Service.Spec.LoadBalancerIP is deprecated, use "+purelbv2.DesiredAddressAnnotation+" annotation")
 	}
 
-	for _, rawAddr := range(strings.Split(rawAddrs, ",")) {
+	for _, rawAddr := range strings.Split(rawAddrs, ",") {
 		ip := net.ParseIP(rawAddr)
 		if ip == nil {
 			return nil, fmt.Errorf("invalid user-specified address: \"%q\"", rawAddr)

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -760,7 +760,7 @@ func TestSpecificAddress(t *testing.T) {
 	svc1 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				purelbv2.DesiredGroupAnnotation: defaultPoolName,
+				purelbv2.DesiredGroupAnnotation:   defaultPoolName,
 				purelbv2.DesiredAddressAnnotation: "1.2.3.8",
 			},
 		},
@@ -965,10 +965,10 @@ func TestServiceAddresses(t *testing.T) {
 	// Test the preferred way to assign a specific address (i.e., our
 	// annotation). This overrides LoadBalancerIP.
 	svc1.ObjectMeta = metav1.ObjectMeta{
-			Annotations: map[string]string{
-				purelbv2.DesiredAddressAnnotation: addr2,
-			},
-		}
+		Annotations: map[string]string{
+			purelbv2.DesiredAddressAnnotation: addr2,
+		},
+	}
 	ips, err = alloc.serviceAddresses(svc1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(ips))
@@ -976,10 +976,10 @@ func TestServiceAddresses(t *testing.T) {
 
 	// Test multiple addresses
 	svc1.ObjectMeta = metav1.ObjectMeta{
-			Annotations: map[string]string{
-				purelbv2.DesiredAddressAnnotation: addr1 + "," + addr2,
-			},
-		}
+		Annotations: map[string]string{
+			purelbv2.DesiredAddressAnnotation: addr1 + "," + addr2,
+		},
+	}
 	ips, err = alloc.serviceAddresses(svc1)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(ips))
@@ -1217,7 +1217,7 @@ func TestBalancePoolsMultiPoolMutualExclusion(t *testing.T) {
 						{Pool: "10.0.0.1-10.0.0.5", Subnet: "10.0.0.0/24"},
 						{Pool: "10.0.1.1-10.0.1.5", Subnet: "10.0.1.0/24"},
 					},
-					MultiPool: true,
+					MultiPool:    true,
 					BalancePools: true,
 				},
 			},
@@ -1353,41 +1353,41 @@ func TestIncrementalMultiPoolNoOp(t *testing.T) {
 // fakeStatusPool implements just enough of Pool for buildStatus tests.
 // Each field is set per-case to exercise a specific buildStatus branch.
 type fakeStatusPool struct {
-	name              string
-	poolType          string
-	ipamSource        string
-	displayAddresses  []string
-	inUseV4           int
-	inUseV6           int
-	sizeV4            uint64
-	sizeV6            uint64
-	hasKnownCapacity  bool
+	name             string
+	poolType         string
+	ipamSource       string
+	displayAddresses []string
+	inUseV4          int
+	inUseV6          int
+	sizeV4           uint64
+	sizeV6           uint64
+	hasKnownCapacity bool
 }
 
-func (f *fakeStatusPool) String() string                                  { return f.name }
-func (f *fakeStatusPool) PoolType() string                                { return f.poolType }
-func (f *fakeStatusPool) IPAMSource() string                              { return f.ipamSource }
-func (f *fakeStatusPool) DisplayAddresses() []string                      { return f.displayAddresses }
-func (f *fakeStatusPool) InUseV4() int                                    { return f.inUseV4 }
-func (f *fakeStatusPool) InUseV6() int                                    { return f.inUseV6 }
-func (f *fakeStatusPool) SizeV4() uint64                                  { return f.sizeV4 }
-func (f *fakeStatusPool) SizeV6() uint64                                  { return f.sizeV6 }
-func (f *fakeStatusPool) HasKnownCapacity() bool                          { return f.hasKnownCapacity }
-func (f *fakeStatusPool) InUse() int                                      { return f.inUseV4 + f.inUseV6 }
-func (f *fakeStatusPool) Size() uint64                                    { return f.sizeV4 + f.sizeV6 }
-func (f *fakeStatusPool) Notify(context.Context, *v1.Service) error       { return nil }
+func (f *fakeStatusPool) String() string                                    { return f.name }
+func (f *fakeStatusPool) PoolType() string                                  { return f.poolType }
+func (f *fakeStatusPool) IPAMSource() string                                { return f.ipamSource }
+func (f *fakeStatusPool) DisplayAddresses() []string                        { return f.displayAddresses }
+func (f *fakeStatusPool) InUseV4() int                                      { return f.inUseV4 }
+func (f *fakeStatusPool) InUseV6() int                                      { return f.inUseV6 }
+func (f *fakeStatusPool) SizeV4() uint64                                    { return f.sizeV4 }
+func (f *fakeStatusPool) SizeV6() uint64                                    { return f.sizeV6 }
+func (f *fakeStatusPool) HasKnownCapacity() bool                            { return f.hasKnownCapacity }
+func (f *fakeStatusPool) InUse() int                                        { return f.inUseV4 + f.inUseV6 }
+func (f *fakeStatusPool) Size() uint64                                      { return f.sizeV4 + f.sizeV6 }
+func (f *fakeStatusPool) Notify(context.Context, *v1.Service) error         { return nil }
 func (f *fakeStatusPool) Assign(context.Context, net.IP, *v1.Service) error { return nil }
-func (f *fakeStatusPool) AssignNext(context.Context, *v1.Service) error   { return nil }
-func (f *fakeStatusPool) Release(context.Context, string) error           { return nil }
-func (f *fakeStatusPool) ReleaseIP(context.Context, string, net.IP) error { return nil }
+func (f *fakeStatusPool) AssignNext(context.Context, *v1.Service) error     { return nil }
+func (f *fakeStatusPool) Release(context.Context, string) error             { return nil }
+func (f *fakeStatusPool) ReleaseIP(context.Context, string, net.IP) error   { return nil }
 func (f *fakeStatusPool) AssignNextPerRange(context.Context, *v1.Service, []string) error {
 	return nil
 }
-func (f *fakeStatusPool) Overlaps(Pool) bool { return false }
+func (f *fakeStatusPool) Overlaps(Pool) bool   { return false }
 func (f *fakeStatusPool) Contains(net.IP) bool { return false }
-func (f *fakeStatusPool) SkipIPv6DAD() bool   { return false }
-func (f *fakeStatusPool) MultiPool() bool     { return false }
-func (f *fakeStatusPool) BalancePools() bool  { return false }
+func (f *fakeStatusPool) SkipIPv6DAD() bool    { return false }
+func (f *fakeStatusPool) MultiPool() bool      { return false }
+func (f *fakeStatusPool) BalancePools() bool   { return false }
 
 // ptrI64 returns a pointer to v. Used for inline expected-value
 // construction in table-driven tests.
@@ -1537,13 +1537,23 @@ func TestStatusEqual(t *testing.T) {
 		{
 			name: "Available* separate-allocation-same-value match (this is the key cache-elision case)",
 			a:    base,
-			b:    func() purelbv2.ServiceGroupStatus { c := base; v4, v6 := int64(251), int64(0); c.AvailableIPv4 = &v4; c.AvailableIPv6 = &v6; return c }(),
+			b: func() purelbv2.ServiceGroupStatus {
+				c := base
+				v4, v6 := int64(251), int64(0)
+				c.AvailableIPv4 = &v4
+				c.AvailableIPv6 = &v6
+				return c
+			}(),
 			want: true,
 		},
 		{
 			name: "Addresses length differs",
 			a:    base,
-			b:    func() purelbv2.ServiceGroupStatus { c := base; c.Addresses = []string{"192.168.1.0/24", "extra"}; return c }(),
+			b: func() purelbv2.ServiceGroupStatus {
+				c := base
+				c.Addresses = []string{"192.168.1.0/24", "extra"}
+				return c
+			}(),
 			want: false,
 		},
 		{

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	ipamv1 "purelb.io/api/ipam/v1"
@@ -47,6 +48,7 @@ func TestNotifyExisting(t *testing.T) {
 		"default": mustLocalPool(t, "default", "192.168.1.2/31"),
 	}
 	alloc.state.Store(&allocatorState{pools: pools})
+	st := alloc.Snapshot()
 	ip1 := net.ParseIP("192.168.1.2")
 	ip2 := net.ParseIP("192.168.1.3")
 
@@ -60,7 +62,7 @@ func TestNotifyExisting(t *testing.T) {
 
 	// Allocate an address to svc2 - it should get ip2 since ip1 is in
 	// use by svc1
-	err := alloc.Allocate(pools, &svc2)
+	err := alloc.Allocate(st, &svc2)
 	assert.Nil(t, err, "Allocating an address failed")
 	assert.Equal(t, ip2.String(), svc2.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
 }
@@ -75,6 +77,7 @@ func TestAssignment(t *testing.T) {
 		"test3": mustLocalPool(t, "test3", "1000::4:0/120"),
 	}
 	alloc.state.Store(&allocatorState{pools: pools})
+	st := alloc.Snapshot()
 
 	tests := []struct {
 		desc       string
@@ -297,7 +300,7 @@ func TestAssignment(t *testing.T) {
 		ip := net.ParseIP(test.ip)
 		assert.NotNil(t, ip, "invalid IP %q in test %q", test.ip, test.desc)
 		service.Annotations[purelbv2.DesiredAddressAnnotation] = test.ip
-		_, err := alloc.allocateSpecificIP(pools, &service)
+		_, err := alloc.allocateSpecificIP(st, &service)
 		if test.wantErr {
 			assert.NotNil(t, err, "%q should have caused an error, but did not", test.desc)
 		} else {
@@ -319,6 +322,7 @@ func TestPoolAllocation(t *testing.T) {
 		"test2":        mustLocalPool(t, "test2", "10.20.30.0/24"),
 	}
 	alloc.state.Store(&allocatorState{pools: pools})
+	_ = alloc.Snapshot()
 
 	validIP4s := map[string]bool{
 		"1.2.3.4": true,
@@ -554,11 +558,12 @@ func TestAllocate(t *testing.T) {
 		"test1V6": mustLocalPool(t, "test1V6", "1000::4/127"),
 	}
 	alloc.state.Store(&allocatorState{pools: pools})
+	st := alloc.Snapshot()
 
 	// Allocate specific IP succeeds
 	svc = service("t1", ports("tcp/80"), "")
 	svc.Annotations[purelbv2.DesiredAddressAnnotation] = "1000::4"
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.Nil(t, err, "specific IP allocation failed")
 	assert.Equal(t, "test1V6", svc.Annotations[purelbv2.PoolAnnotation], "IP allocated from wrong pool")
 	assert.Equal(t, "1000::4", svc.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -566,13 +571,13 @@ func TestAllocate(t *testing.T) {
 	// Allocate specific IP fails if IP is already assigned
 	svc = service("t2", ports("tcp/80"), "")
 	svc.Annotations[purelbv2.DesiredAddressAnnotation] = "1000::4"
-	err = alloc.Allocate(pools, &svc)
+	err = alloc.Allocate(st, &svc)
 	assert.Error(t, err, "specific IP allocation should have failed")
 
 	// Allocate from specific pool succeeds
 	svc = service("t3", ports("tcp/80"), "")
 	svc.Annotations[purelbv2.DesiredGroupAnnotation] = "test1V6"
-	err = alloc.Allocate(pools, &svc)
+	err = alloc.Allocate(st, &svc)
 	assert.Nil(t, err, "specific IP allocation failed")
 	assert.Equal(t, "test1V6", svc.Annotations[purelbv2.PoolAnnotation], "IP allocated from wrong pool")
 	assert.Equal(t, "1000::5", svc.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -580,22 +585,23 @@ func TestAllocate(t *testing.T) {
 	// Pool is empty so allocation fails
 	svc = service("t4", ports("tcp/80"), "")
 	svc.Annotations[purelbv2.DesiredGroupAnnotation] = "test1V6"
-	err = alloc.Allocate(pools, &svc)
+	err = alloc.Allocate(st, &svc)
 	assert.Error(t, err, "allocation from exhausted pool should have failed")
 
 	// There's no "default" pool so allocation fails if the pool isn't
 	// specified
 	svc = service("t5", ports("tcp/80"), "")
-	err = alloc.Allocate(pools, &svc)
+	err = alloc.Allocate(st, &svc)
 	assert.Error(t, err, "default pool IP allocation should have failed")
 
 	// Add a "default" pool
 	pools[defaultPoolName] = mustLocalPool(t, "default", "1.2.3.4/30")
 	alloc.state.Store(&allocatorState{pools: pools})
+	st = alloc.Snapshot()
 
 	// Now that there's a "default" pool, allocation succeeds
 	svc = service("t6", ports("tcp/80"), "")
-	err = alloc.Allocate(pools, &svc)
+	err = alloc.Allocate(st, &svc)
 	assert.Nil(t, err, "default pool IP allocation failed")
 	assert.Equal(t, defaultPoolName, svc.Annotations[purelbv2.PoolAnnotation], "IP allocated from wrong pool")
 	assert.Equal(t, "1.2.3.4", svc.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -618,7 +624,8 @@ func TestPoolMetrics(t *testing.T) {
 	alloc := New(allocatorTestLogger)
 	alloc.SetClient(&testK8S{t: t})
 	alloc.SetPools([]*purelbv2.ServiceGroup{&testSG})
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
+	pools := st.pools
 
 	tests := []struct {
 		desc       string
@@ -706,7 +713,7 @@ func TestPoolMetrics(t *testing.T) {
 		}
 
 		service.Annotations[purelbv2.DesiredAddressAnnotation] = test.ip
-		err := alloc.Allocate(pools, &service)
+		err := alloc.Allocate(st, &service)
 		assert.Nil(t, err, "%q: Assign(%q, %q)", test.desc, test.svc, test.ip)
 		assert.Equal(t, testSG.ObjectMeta.Name, service.Annotations[purelbv2.PoolAnnotation], "incorrect pool assigned")
 		assert.Equal(t, test.ipsInUse, ptu.ToFloat64(poolActive.WithLabelValues(testSG.ObjectMeta.Name)), "incorrect pool active IP count after allocation")
@@ -746,7 +753,7 @@ func TestSpecificAddress(t *testing.T) {
 	if alloc.SetPools(groups) != nil {
 		t.Fatal("SetConfig failed")
 	}
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Fail to allocate a specific address that's not in the default
 	// pool
@@ -758,12 +765,12 @@ func TestSpecificAddress(t *testing.T) {
 			},
 		},
 	}
-	err := alloc.Allocate(pools, svc1)
+	err := alloc.Allocate(st, svc1)
 	assert.Error(t, err, "address allocated but shouldn't be")
 
 	// Allocate a specific address in the default pool
 	svc1.Annotations[purelbv2.DesiredAddressAnnotation] = "1.2.3.0"
-	err = alloc.Allocate(pools, svc1)
+	err = alloc.Allocate(st, svc1)
 	assert.Nil(t, err, "error allocating address")
 	assert.Equal(t, defaultPoolName, svc1.Annotations[purelbv2.PoolAnnotation], "incorrect pool chosen")
 	assert.Equal(t, svc1.Annotations[purelbv2.DesiredAddressAnnotation], svc1.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -795,7 +802,7 @@ func TestSharingSimple(t *testing.T) {
 	if alloc.SetPools(groups) != nil {
 		t.Fatal("SetConfig failed")
 	}
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	svc1 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -807,7 +814,7 @@ func TestSharingSimple(t *testing.T) {
 		},
 		Spec: spec,
 	}
-	err := alloc.Allocate(pools, svc1)
+	err := alloc.Allocate(st, svc1)
 	assert.Nil(t, err, "error allocating address")
 	assert.Equal(t, defaultPoolName, svc1.Annotations[purelbv2.PoolAnnotation], "incorrect pool chosen")
 	assert.Equal(t, "1.2.3.0", svc1.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -823,7 +830,7 @@ func TestSharingSimple(t *testing.T) {
 		},
 		Spec: spec,
 	}
-	err = alloc.Allocate(pools, svc2)
+	err = alloc.Allocate(st, svc2)
 	assert.Nil(t, err, "error allocating address")
 	assert.Equal(t, defaultPoolName, svc2.Annotations[purelbv2.PoolAnnotation], "incorrect pool chosen")
 	assert.Equal(t, "1.2.3.1", svc2.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -839,7 +846,7 @@ func TestSharingSimple(t *testing.T) {
 		},
 		Spec: spec,
 	}
-	err = alloc.Allocate(pools, svc3)
+	err = alloc.Allocate(st, svc3)
 	assert.Nil(t, err, "error allocating address")
 	assert.Equal(t, defaultPoolName, svc3.Annotations[purelbv2.PoolAnnotation], "incorrect pool chosen")
 	assert.Equal(t, "1.2.3.0", svc3.Status.LoadBalancer.Ingress[0].IP, "IP wasn't assigned to service ingress")
@@ -1100,12 +1107,12 @@ func TestAllocateMultiPool(t *testing.T) {
 		}),
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Multi-pool allocation via pool default
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.NoError(t, err, "multi-pool allocation should succeed")
 	assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "should get 2 IPs")
 	assert.Equal(t, defaultPoolName, svc.Annotations[purelbv2.PoolAnnotation])
@@ -1131,13 +1138,13 @@ func TestAllocateMultiPoolAnnotationOverride(t *testing.T) {
 		},
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Annotation triggers multi-pool even though pool doesn't have it
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 	svc.Annotations[purelbv2.MultiPoolAnnotation] = "true"
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.NoError(t, err, "annotation-triggered multi-pool should succeed")
 	assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "should get 2 IPs via annotation override")
 }
@@ -1153,12 +1160,12 @@ func TestMultiPoolRejectsSharingKey(t *testing.T) {
 		}),
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Multi-pool + sharing key should error
 	svc := service("svc1", ports("tcp/80"), "share-me")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.Error(t, err, "multi-pool + sharing should be rejected")
 	assert.Contains(t, err.Error(), "sharing")
 }
@@ -1182,11 +1189,11 @@ func TestMultiPoolBackwardCompat(t *testing.T) {
 		},
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress), "non-multi-pool should get exactly 1 IP")
 }
@@ -1217,12 +1224,12 @@ func TestBalancePoolsMultiPoolMutualExclusion(t *testing.T) {
 		},
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
 
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.Error(t, err, "multi-pool and balancePools should be mutually exclusive")
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
@@ -1251,13 +1258,13 @@ func TestSkipIPv6DADAnnotation(t *testing.T) {
 		},
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Allocate from pool with skipIPv6DAD=true — annotation should be set
 	svc := service("svc-dad", ports("tcp/80"), "")
 	svc.Annotations[purelbv2.DesiredGroupAnnotation] = "dad-skip"
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.NoError(t, err)
 	assert.Equal(t, "true", svc.Annotations[purelbv2.SkipIPv6DADAnnotation],
 		"skip-ipv6-dad annotation should be set when pool has skipIPv6DAD=true")
@@ -1266,7 +1273,7 @@ func TestSkipIPv6DADAnnotation(t *testing.T) {
 	svc2 := service("svc-no-dad", ports("tcp/80"), "")
 	svc2.Annotations[purelbv2.DesiredGroupAnnotation] = "no-dad-skip"
 	svc2.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err = alloc.Allocate(pools, &svc2)
+	err = alloc.Allocate(st, &svc2)
 	assert.NoError(t, err)
 	_, hasAnnotation := svc2.Annotations[purelbv2.SkipIPv6DADAnnotation]
 	assert.False(t, hasAnnotation,
@@ -1288,17 +1295,17 @@ func TestIncrementalMultiPool(t *testing.T) {
 		}),
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Initial allocation — gets 2 IPs (subnets 1 and 2 active)
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	err := alloc.Allocate(pools, &svc)
+	err := alloc.Allocate(st, &svc)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "initial: should get 2 IPs")
 
 	// IncrementalMultiPool with same subnets — no-op
-	added, err := alloc.IncrementalMultiPool(pools, &svc)
+	added, err := alloc.IncrementalMultiPool(st, &svc)
 	assert.NoError(t, err)
 	assert.False(t, added, "no new subnets, should be no-op")
 	assert.Equal(t, 2, len(svc.Status.LoadBalancer.Ingress), "still 2 IPs")
@@ -1307,7 +1314,7 @@ func TestIncrementalMultiPool(t *testing.T) {
 	alloc.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24", "192.168.2.0/24", "192.168.3.0/24"}), "purelb")
 
 	// IncrementalMultiPool should add a 3rd IP
-	added, err = alloc.IncrementalMultiPool(pools, &svc)
+	added, err = alloc.IncrementalMultiPool(st, &svc)
 	assert.NoError(t, err)
 	assert.True(t, added, "new subnet available, should add IP")
 	assert.Equal(t, 3, len(svc.Status.LoadBalancer.Ingress), "should now have 3 IPs")
@@ -1324,16 +1331,16 @@ func TestIncrementalMultiPoolNoOp(t *testing.T) {
 		}),
 	}
 	assert.NoError(t, alloc.SetPools(groups))
-	pools := alloc.Pools()
+	st := alloc.Snapshot()
 
 	// Allocate — gets 1 IP (only 1 range)
 	svc := service("svc1", ports("tcp/80"), "")
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
-	assert.NoError(t, alloc.Allocate(pools, &svc))
+	assert.NoError(t, alloc.Allocate(st, &svc))
 	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress))
 
 	// IncrementalMultiPool with all ranges covered — no-op
-	added, err := alloc.IncrementalMultiPool(pools, &svc)
+	added, err := alloc.IncrementalMultiPool(st, &svc)
 	assert.NoError(t, err)
 	assert.False(t, added, "all ranges covered, should be no-op")
 	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress))
@@ -1947,4 +1954,173 @@ func TestPublishAllSGStatus_PoolWithoutServiceGroup(t *testing.T) {
 	})
 	assert.NoError(t, alloc.PublishAllSGStatus(context.Background()))
 	assert.Empty(t, writer.updates)
+}
+
+// TestIncrementalMultiPoolIgnoresTamperedAnnotation: purelb.io/allocated-from
+// lives on the Service, so its owner can point it at any pool in the cluster.
+// The pool must be resolved from the addresses the Service actually holds.
+func TestIncrementalMultiPoolIgnoresTamperedAnnotation(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.SetClient(&testK8S{t: t})
+	alloc.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24", "192.168.2.0/24"}), "purelb")
+
+	groups := []*purelbv2.ServiceGroup{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: defaultPoolName},
+			Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+				V4Pools: []purelbv2.AddressPool{{Pool: "192.168.1.0/31", Subnet: "192.168.1.0/24"}},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "victim"},
+			Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+				MultiPool: true,
+				V4Pools: []purelbv2.AddressPool{
+					{Pool: "192.168.2.0/31", Subnet: "192.168.2.0/24"},
+					{Pool: "192.168.3.0/31", Subnet: "192.168.3.0/24"},
+				},
+			}},
+		},
+	}
+	require.NoError(t, alloc.SetPools(groups))
+	st := alloc.Snapshot()
+	pools := st.pools
+
+	// A Service legitimately holding an address from "default", with the
+	// annotation tampered to name the victim pool.
+	svc := service("tenant", ports("tcp/80"), "")
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
+	require.NoError(t, alloc.Allocate(st, &svc))
+	require.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress))
+	svc.Annotations[purelbv2.PoolAnnotation] = "victim"
+
+	added, err := alloc.IncrementalMultiPool(st, &svc)
+	assert.NoError(t, err, "resolving by containment lands on the pool actually held, which is a no-op")
+	assert.False(t, added)
+	assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress), "must not gain victim addresses")
+	assert.Equal(t, "192.168.1.0", svc.Status.LoadBalancer.Ingress[0].IP,
+		"the address held must be unchanged")
+	assert.Equal(t, defaultPoolName, svc.Annotations[purelbv2.PoolAnnotation],
+		"the tampered annotation must be corrected to the pool actually held")
+	assert.Equal(t, 0, pools["victim"].InUse(), "the victim pool must be untouched")
+}
+
+// TestAllocateFromPoolRollsBackPartialDualStack: AssignNext commits each
+// family as it goes and returns on the first failure. Without a rollback the
+// committed family stays in .status, gets persisted and announced, but is
+// never branded -- so populateFromExisting skips it and it is re-allocatable
+// after a restart. Family ORDER matters: [IPv4, IPv6] against a v4-only pool
+// is the leaking direction; the reverse aborts before committing anything.
+func TestAllocateFromPoolRollsBackPartialDualStack(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.SetClient(&testK8S{t: t})
+
+	groups := []*purelbv2.ServiceGroup{{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultPoolName},
+		Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+			V4Pools: []purelbv2.AddressPool{{Pool: "192.168.1.0/31", Subnet: "192.168.1.0/24"}},
+		}},
+	}}
+	require.NoError(t, alloc.SetPools(groups))
+	st := alloc.Snapshot()
+	pools := st.pools
+	pool := pools[defaultPoolName]
+
+	svc := service("dual", ports("tcp/80"), "")
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+
+	err := alloc.Allocate(st, &svc)
+	assert.Error(t, err, "v6 is unavailable in a v4-only pool")
+	assert.Empty(t, svc.Status.LoadBalancer.Ingress,
+		"the v4 committed before the v6 failed must be rolled back, not left announced and unbranded")
+	assert.Equal(t, 0, pool.InUse(), "the rolled-back address must be free for reuse")
+}
+
+// TestAllocateFromPoolRollbackKeepsPreExisting: the rollback must undo only
+// what this call added. A SingleStack->DualStack transition enters with an
+// address already held, and that address must survive a failed top-up.
+func TestAllocateFromPoolRollbackKeepsPreExisting(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.SetClient(&testK8S{t: t})
+
+	groups := []*purelbv2.ServiceGroup{{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultPoolName},
+		Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+			V4Pools: []purelbv2.AddressPool{{Pool: "192.168.1.0/31", Subnet: "192.168.1.0/24"}},
+		}},
+	}}
+	require.NoError(t, alloc.SetPools(groups))
+	st := alloc.Snapshot()
+	pools := st.pools
+	pool := pools[defaultPoolName]
+
+	// Allocate v4 only, successfully.
+	svc := service("grow", ports("tcp/80"), "")
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
+	require.NoError(t, alloc.Allocate(st, &svc))
+	require.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress))
+	held := svc.Status.LoadBalancer.Ingress[0].IP
+
+	// Now ask for dual-stack from the same v4-only pool.
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+	err := alloc.Allocate(st, &svc)
+	assert.Error(t, err)
+	require.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress), "pre-existing address must survive")
+	assert.Equal(t, held, svc.Status.LoadBalancer.Ingress[0].IP)
+	assert.Equal(t, 1, pool.InUse(), "pre-existing address must stay registered")
+}
+
+// capturingK8S records Warning event messages so a test can assert on their
+// exact text, which testK8S only logs.
+type capturingK8S struct{ warnings []string }
+
+func (c *capturingK8S) Infof(_ runtime.Object, _, _ string, _ ...interface{}) {}
+func (c *capturingK8S) Errorf(_ runtime.Object, _, msg string, args ...interface{}) {
+	c.warnings = append(c.warnings, fmt.Sprintf(msg, args...))
+}
+func (c *capturingK8S) ForceSync() {}
+
+// TestParseGroupsOverlapMessageIsStable: when a ServiceGroup overlaps more
+// than one already-accepted pool, the rejection message must always name the
+// same partner. parseGroups used to walk the pools map to find it, so with
+// Go's randomised map iteration the text changed between reconciles -- the
+// event recorder could not aggregate it and a fresh Event appeared on every
+// resync, forever.
+func TestParseGroupsOverlapMessageIsStable(t *testing.T) {
+	groups := []*purelbv2.ServiceGroup{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "aaa"},
+			Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+				V4Pools: []purelbv2.AddressPool{{Pool: "192.168.1.0-192.168.1.10", Subnet: "192.168.0.0/16"}},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "bbb"},
+			Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+				V4Pools: []purelbv2.AddressPool{{Pool: "192.168.2.0-192.168.2.10", Subnet: "192.168.0.0/16"}},
+			}},
+		},
+		{
+			// Overlaps BOTH aaa and bbb, so there are two candidate partners
+			// and the map walk had something to be non-deterministic about.
+			ObjectMeta: metav1.ObjectMeta{Name: "ccc"},
+			Spec: purelbv2.ServiceGroupSpec{Local: &purelbv2.ServiceGroupLocalSpec{
+				V4Pools: []purelbv2.AddressPool{{Pool: "192.168.1.0-192.168.2.10", Subnet: "192.168.0.0/16"}},
+			}},
+		},
+	}
+
+	var seen []string
+	for i := 0; i < 20; i++ {
+		client := &capturingK8S{}
+		alloc := New(allocatorTestLogger)
+		alloc.SetClient(client)
+		require.NoError(t, alloc.SetPools(groups))
+		require.Len(t, client.warnings, 1, "exactly one group should be rejected")
+		seen = append(seen, client.warnings[0])
+	}
+	for i, msg := range seen {
+		assert.Equal(t, seen[0], msg, "overlap message differed on run %d", i)
+	}
+	assert.Contains(t, seen[0], `"aaa"`, "should name the lowest-sorting partner, not a random one")
 }

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -294,7 +294,7 @@ func TestAssignment(t *testing.T) {
 	for _, test := range tests {
 		service := service(test.svc, test.ports, test.sharingKey)
 		if test.ip == "" {
-			alloc.Unassign(pools, namespacedName(&service))
+			alloc.Unassign(pools, namespacedName(&service), "")
 			continue
 		}
 		ip := net.ParseIP(test.ip)
@@ -526,7 +526,7 @@ func TestPoolAllocation(t *testing.T) {
 	for _, test := range tests {
 		service := service(test.svc, test.ports, test.sharingKey)
 		if test.unassign {
-			alloc.Unassign(pools, namespacedName(&service))
+			alloc.Unassign(pools, namespacedName(&service), "")
 			continue
 		}
 		pool := "test"
@@ -707,7 +707,7 @@ func TestPoolMetrics(t *testing.T) {
 	for _, test := range tests {
 		service := service(test.svc, test.ports, test.sharingKey)
 		if test.ip == "" {
-			alloc.Unassign(pools, namespacedName(&service))
+			alloc.Unassign(pools, namespacedName(&service), "")
 			assert.Equal(t, test.ipsInUse, ptu.ToFloat64(poolActive.WithLabelValues(testSG.ObjectMeta.Name)), "incorrect pool active IP count after unassign")
 			continue
 		}

--- a/internal/allocator/controller.go
+++ b/internal/allocator/controller.go
@@ -34,7 +34,7 @@ type Controller interface {
 	SetClient(*k8s.Client)
 	SetConfig(*purelbv2.Config) k8s.SyncState
 	SetBalancer(*v1.Service, []*discoveryv1.EndpointSlice) k8s.SyncState
-	DeleteBalancer(string) k8s.SyncState
+	DeleteBalancer(name, pool string) k8s.SyncState
 	MarkSynced()
 	Shutdown()
 }
@@ -79,9 +79,12 @@ func (c *controller) SetClient(client *k8s.Client) {
 	c.ips.SetActiveSubnets(client.ActiveSubnets, c.installNamespace)
 }
 
-func (c *controller) DeleteBalancer(name string) k8s.SyncState {
+// DeleteBalancer releases a deleted Service's address. pool is the
+// ServiceGroup it was allocated from, or "" when that could not be
+// determined; see Unassign for what "" costs.
+func (c *controller) DeleteBalancer(name, pool string) k8s.SyncState {
 	pools := c.ips.Pools()
-	if err := c.ips.Unassign(pools, name); err != nil {
+	if err := c.ips.Unassign(pools, name, pool); err != nil {
 		logging.Info(c.logger, "op", "deleteBalancer", "error", err)
 		return k8s.SyncStateError
 	}

--- a/internal/allocator/controller.go
+++ b/internal/allocator/controller.go
@@ -16,7 +16,6 @@
 package allocator
 
 import (
-	"os"
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,8 +27,6 @@ import (
 
 	"github.com/go-kit/log"
 )
-
-const namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 // Controller provides an event-handling interface for the k8s client
 // to use.
@@ -43,20 +40,25 @@ type Controller interface {
 }
 
 type controller struct {
-	client    k8s.ServiceEvent
-	synced    bool
-	ips       *Allocator
-	groupURL  *string
-	logger    log.Logger
-	isDefault atomic.Bool
+	client k8s.ServiceEvent
+	synced bool
+	ips    *Allocator
+	// installNamespace is the namespace PureLB runs in, resolved once by
+	// the caller so that this controller and the CR controller cannot
+	// disagree about it. Empty when it could not be determined.
+	installNamespace string
+	groupURL         *string
+	logger           log.Logger
+	isDefault        atomic.Bool
 }
 
 // NewController configures a new controller. If error is non-nil then
 // the controller object shouldn't be used.
-func NewController(l log.Logger, ips *Allocator) (Controller, error) {
+func NewController(l log.Logger, ips *Allocator, installNamespace string) (Controller, error) {
 	con := &controller{
-		logger: l,
-		ips:    ips,
+		logger:           l,
+		ips:              ips,
+		installNamespace: installNamespace,
 	}
 
 	return con, nil
@@ -69,12 +71,12 @@ func (c *controller) SetClient(client *k8s.Client) {
 	c.ips.SetListServices(client.ListServices)
 	client.SetPoolStatusPublisher(c.ips.PublishAllSGStatus)
 
-	data, err := os.ReadFile(namespacePath)
-	if err != nil {
-		logging.Info(c.logger, "op", "setClient", "error", err, "msg", "failed to read namespace, multi-pool allocation will not work")
+	if c.installNamespace == "" {
+		logging.Info(c.logger, "op", "setClient",
+			"msg", "install namespace unknown, multi-pool allocation will not work")
 		return
 	}
-	c.ips.SetActiveSubnets(client.ActiveSubnets, string(data))
+	c.ips.SetActiveSubnets(client.ActiveSubnets, c.installNamespace)
 }
 
 func (c *controller) DeleteBalancer(name string) k8s.SyncState {
@@ -88,6 +90,39 @@ func (c *controller) DeleteBalancer(name string) k8s.SyncState {
 	return k8s.SyncStateReprocessAll
 }
 
+// reportOutOfScope surfaces ServiceGroups that were listed but ignored
+// because they live outside the install namespace.
+//
+// This runs in the allocator only. The filtering happens in a code path both
+// binaries share, so emitting events there would produce one per node per
+// reconcile; the node agent logs its own copy locally instead.
+func (c *controller) reportOutOfScope(dropped []*purelbv2.ServiceGroup) {
+	serviceGroupsOutOfScope.Reset()
+	for _, g := range dropped {
+		kind := "local"
+		switch {
+		case g.Spec.Remote != nil:
+			kind = "remote"
+		case g.Spec.External != nil:
+			kind = "external"
+		}
+		serviceGroupsOutOfScope.WithLabelValues(g.Namespace, g.Name, kind).Set(1)
+
+		// A remote group vanishing withdraws addresses from every node; a
+		// local one only makes its pool unallocatable. Name the difference,
+		// because it decides how urgently an operator has to act.
+		impact := "its pool is not allocatable"
+		if kind == "remote" {
+			impact = "addresses allocated from it are withdrawn from every node"
+		}
+		c.client.Errorf(g, "ServiceGroupOutOfScope",
+			"Ignored: ServiceGroups are read only from the PureLB install namespace, and %s is not it. This group is %s, so %s. Move it: kubectl get servicegroup %s -n %s -o yaml | sed 's/namespace: %s/namespace: <install-namespace>/' | kubectl apply -f -",
+			g.Namespace, kind, impact, g.Name, g.Namespace, g.Namespace)
+		logging.Info(c.logger, "op", "setConfig", "event", "serviceGroupOutOfScope",
+			"sg", g.Namespace+"/"+g.Name, "type", kind, "msg", "ignored: not in the install namespace")
+	}
+}
+
 func (c *controller) SetConfig(cfg *purelbv2.Config) k8s.SyncState {
 	defer logging.Debug(c.logger, "op", "setConfig", "msg", "config updated")
 
@@ -95,6 +130,8 @@ func (c *controller) SetConfig(cfg *purelbv2.Config) k8s.SyncState {
 		logging.Info(c.logger, "op", "setConfig", "error", "no PureLB configuration in cluster", "msg", "PureLB will not function")
 		return k8s.SyncStateError
 	}
+
+	c.reportOutOfScope(cfg.DroppedGroups)
 
 	if err := c.ips.SetPools(cfg.Groups); err != nil {
 		logging.Info(c.logger, "op", "setConfig", "error", err)

--- a/internal/allocator/controller_test.go
+++ b/internal/allocator/controller_test.go
@@ -431,7 +431,7 @@ func TestMultiPoolDeleteRecycles(t *testing.T) {
 	assert.Empty(t, svc2.Status.LoadBalancer.Ingress, "pool exhausted, no IPs")
 
 	// Delete first service — should free both IPs
-	assert.Equal(t, k8s.SyncStateReprocessAll, c.DeleteBalancer(namespacedName(svc1)))
+	assert.Equal(t, k8s.SyncStateReprocessAll, c.DeleteBalancer(namespacedName(svc1), ""))
 
 	// Now second service should succeed
 	assert.Equal(t, k8s.SyncStateSuccess, c.SetBalancer(svc2, nil))
@@ -786,7 +786,7 @@ func TestDeleteRecyclesIP(t *testing.T) {
 	k.reset()
 
 	// Deleting the first LB should tell us to reprocess all services.
-	assert.Equal(t, k8s.SyncStateReprocessAll, c.DeleteBalancer(namespacedName(svc1)), "DeleteBalancer didn't tell us to reprocess all balancers")
+	assert.Equal(t, k8s.SyncStateReprocessAll, c.DeleteBalancer(namespacedName(svc1), ""), "DeleteBalancer didn't tell us to reprocess all balancers")
 
 	// Setting svc2 should now allocate correctly.
 	assert.Equal(t, k8s.SyncStateSuccess, c.SetBalancer(svc2, nil), "SetBalancer svc2 failed")
@@ -900,7 +900,7 @@ func TestConcurrentSetPoolsAndSetBalancer(t *testing.T) {
 		for i := 0; i < iterations; i++ {
 			svc := service(fmt.Sprintf("svc-%d", i), ports("tcp/80"), "")
 			c.SetBalancer(&svc, nil)
-			c.DeleteBalancer(fmt.Sprintf("default/svc-%d", i))
+			c.DeleteBalancer(fmt.Sprintf("default/svc-%d", i), "")
 		}
 	}()
 

--- a/internal/allocator/controller_test.go
+++ b/internal/allocator/controller_test.go
@@ -168,9 +168,9 @@ func newMultiPoolController(t *testing.T, v4pools []purelbv2.AddressPool, v6pool
 	a.SetActiveSubnets(mockActiveSubnets(activeSubnets), "purelb")
 
 	c := &controller{
-		logger:    l,
-		ips:       a,
-		client:    k,
+		logger: l,
+		ips:    a,
+		client: k,
 	}
 	c.isDefault.Store(true)
 
@@ -205,9 +205,9 @@ func newMixedController(t *testing.T) (*controller, *testK8S) {
 	a.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24", "192.168.2.0/24"}), "purelb")
 
 	c := &controller{
-		logger:    l,
-		ips:       a,
-		client:    k,
+		logger: l,
+		ips:    a,
+		client: k,
 	}
 	c.isDefault.Store(true)
 
@@ -589,9 +589,9 @@ func TestMultiPoolConfigReprocess(t *testing.T) {
 	a.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24", "192.168.2.0/24"}), "purelb")
 
 	c := &controller{
-		logger:    l,
-		ips:       a,
-		client:    k,
+		logger: l,
+		ips:    a,
+		client: k,
 	}
 	c.isDefault.Store(true)
 
@@ -644,9 +644,9 @@ func TestMultiPoolExplicitLBClass(t *testing.T) {
 	a.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24", "192.168.2.0/24"}), "purelb")
 
 	c := &controller{
-		logger:    l,
-		ips:       a,
-		client:    k,
+		logger: l,
+		ips:    a,
+		client: k,
 		// isDefault defaults to false (not the default announcer)
 	}
 
@@ -688,9 +688,9 @@ func TestMultiPoolNotDefaultAnnouncer(t *testing.T) {
 	a.SetActiveSubnets(mockActiveSubnets([]string{"192.168.1.0/24"}), "purelb")
 
 	c := &controller{
-		logger:    l,
-		ips:       a,
-		client:    k,
+		logger: l,
+		ips:    a,
+		client: k,
 		// isDefault defaults to false (not the default announcer)
 	}
 

--- a/internal/allocator/localpool.go
+++ b/internal/allocator/localpool.go
@@ -26,8 +26,8 @@ import (
 	"github.com/vishvananda/netlink/nl"
 	v1 "k8s.io/api/core/v1"
 
-	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 	"purelb.io/internal/logging"
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
 
 // LocalPool is the configuration of an IP address pool.
@@ -251,7 +251,7 @@ func (p LocalPool) available(ip net.IP, service *v1.Service) error {
 }
 
 // AssignNext assigns the next available IP to service.
-func (p LocalPool) AssignNext(_ context.Context, service *v1.Service) error {
+func (p LocalPool) AssignNext(ctx context.Context, service *v1.Service) error {
 	families, err := p.whichFamilies(service)
 	if err != nil {
 		return err
@@ -260,22 +260,22 @@ func (p LocalPool) AssignNext(_ context.Context, service *v1.Service) error {
 	if len(families) == 0 {
 		// Any address is OK so try V6 first then V4 and assign the first
 		// one that succeeds
-		if err = p.assignFamily(nl.FAMILY_V6, service); err == nil {
+		if err = p.assignFamily(ctx, nl.FAMILY_V6, service); err == nil {
 			return err
 		}
-		return p.assignFamily(nl.FAMILY_V4, service)
+		return p.assignFamily(ctx, nl.FAMILY_V4, service)
 	}
 
 	// We have a specific set of families to assign
 	for _, family := range families {
-		if err := p.assignFamily(family, service); err != nil {
+		if err := p.assignFamily(ctx, family, service); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (p LocalPool) assignFamily(family int, service *v1.Service) error {
+func (p LocalPool) assignFamily(ctx context.Context, family int, service *v1.Service) error {
 	// Check if the service already has an address for this family
 	// This supports IP family transitions (e.g., SingleStack → DualStack)
 	// where we want to keep existing addresses and only allocate missing ones
@@ -299,7 +299,7 @@ func (p LocalPool) assignFamily(family int, service *v1.Service) error {
 	// Balanced allocation: pick least-used range.
 	// Skip for services with sharing keys — they must use the bound IP.
 	if p.balancePools && SharingKey(service) == "" {
-		return p.assignFamilyBalancePools(family, service)
+		return p.assignFamilyBalancePools(ctx, family, service)
 	}
 
 	var lastErr error
@@ -310,7 +310,7 @@ func (p LocalPool) assignFamily(family int, service *v1.Service) error {
 	boundIP := p.ipForSharingKey(sharingKey, family)
 
 	for pos := p.first(family); pos != nil; pos = p.next(pos) {
-		if err := p.Assign(context.Background(), pos, service); err == nil {
+		if err := p.Assign(ctx, pos, service); err == nil {
 			// we found an available address
 			return nil
 		} else {
@@ -750,7 +750,7 @@ func (p LocalPool) countAllocationsPerRange(ranges []*purelbv2.IPRange) []int {
 // assignFamilyBalancePools allocates an IP from the range with the fewest
 // current allocations, distributing services evenly across subnets.
 // Falls through to subsequent ranges if the preferred range is exhausted.
-func (p LocalPool) assignFamilyBalancePools(family int, service *v1.Service) error {
+func (p LocalPool) assignFamilyBalancePools(ctx context.Context, family int, service *v1.Service) error {
 	var ranges []*purelbv2.IPRange
 	if family == nl.FAMILY_V6 {
 		ranges = p.v6Ranges
@@ -777,7 +777,7 @@ func (p LocalPool) assignFamilyBalancePools(family int, service *v1.Service) err
 
 	// Try ranges in least-allocated order
 	for _, idx := range indices {
-		if err := p.assignFromRange(ranges[idx], service); err == nil {
+		if err := p.assignFromRange(ctx, ranges[idx], service); err == nil {
 			logging.Info(p.logger, "op", "assignFamilyBalancePools", "service", namespacedName(service),
 				"range", ranges[idx], "msg", "balancePools allocation selected range")
 			balancePoolsAllocations.WithLabelValues(p.name).Inc()
@@ -793,10 +793,10 @@ func (p LocalPool) assignFamilyBalancePools(family int, service *v1.Service) err
 // assignFromRange tries to assign the next available IP from a single range
 // to the service. Returns nil on success, error if the range is exhausted
 // or all IPs have conflicts.
-func (p LocalPool) assignFromRange(ipRange *purelbv2.IPRange, service *v1.Service) error {
+func (p LocalPool) assignFromRange(ctx context.Context, ipRange *purelbv2.IPRange, service *v1.Service) error {
 	var lastErr error
 	for ip := ipRange.First(); ip != nil; ip = ipRange.Next(ip) {
-		if err := p.Assign(context.Background(), ip, service); err == nil {
+		if err := p.Assign(ctx, ip, service); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -860,7 +860,7 @@ func (p LocalPool) AssignNextPerRange(ctx context.Context, svc *v1.Service, acti
 				continue
 			}
 
-			if err := p.assignFromRange(ipRange, svc); err != nil {
+			if err := p.assignFromRange(ctx, ipRange, svc); err != nil {
 				p.logger.Log("op", "assignNextPerRange", "range", ipRange,
 					"subnet", subnets[i], "error", err, "msg", "range exhausted, continuing")
 				allocationRejected.WithLabelValues(p.name, "exhausted").Inc()

--- a/internal/allocator/localpool.go
+++ b/internal/allocator/localpool.go
@@ -662,14 +662,20 @@ func (p LocalPool) IPAMSource() string {
 }
 
 // InUseV4 returns the number of IPv4 addresses currently allocated.
+//
+// The family is decided by looking for a colon rather than by parsing.
+// Keys in addressesInUse are produced by net.IP.String(), which renders
+// IPv4 -- including the IPv4-mapped form -- as a dotted quad and IPv6 with
+// colons, so the test is exact. It matters because buildStatus calls this
+// on every allocation and every release, for every pool, and a ParseIP per
+// address meant an allocation and a full parse each time.
+//
+// Still counted from the map rather than cached, so it cannot drift out of
+// step with the allocations it describes.
 func (p LocalPool) InUseV4() int {
 	n := 0
 	for ipStr := range p.addressesInUse {
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			continue
-		}
-		if ip.To4() != nil {
+		if !strings.Contains(ipStr, ":") {
 			n++
 		}
 	}
@@ -677,14 +683,11 @@ func (p LocalPool) InUseV4() int {
 }
 
 // InUseV6 returns the number of IPv6 addresses currently allocated.
+// Same colon test as InUseV4; see there for why.
 func (p LocalPool) InUseV6() int {
 	n := 0
 	for ipStr := range p.addressesInUse {
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			continue
-		}
-		if ip.To4() == nil {
+		if strings.Contains(ipStr, ":") {
 			n++
 		}
 	}

--- a/internal/allocator/localpool_test.go
+++ b/internal/allocator/localpool_test.go
@@ -41,8 +41,8 @@ func TestEmptyPool(t *testing.T) {
 	var svc v1.Service
 	p := LocalPool{}
 	assert.Equal(t, uint64(0), p.Size(), "incorrect pool size")
-	assert.Error(t, p.assignFamily(nl.FAMILY_V6, &svc))
-	assert.Error(t, p.assignFamily(nl.FAMILY_V4, &svc))
+	assert.Error(t, p.assignFamily(context.Background(), nl.FAMILY_V6, &svc))
+	assert.Error(t, p.assignFamily(context.Background(), nl.FAMILY_V4, &svc))
 	assert.Error(t, p.AssignNext(context.Background(), &svc))
 }
 

--- a/internal/allocator/localpool_test.go
+++ b/internal/allocator/localpool_test.go
@@ -893,3 +893,28 @@ func TestBalancePoolsWithSharingKeyBypass(t *testing.T) {
 	ip2 := net.ParseIP(svc2.Status.LoadBalancer.Ingress[0].IP)
 	assert.True(t, ip1.Equal(ip2), "sharing key services must share the same IP")
 }
+
+// TestInUseByFamilyColonTest pins the assumption behind counting families
+// with a colon test instead of net.ParseIP: keys in addressesInUse come
+// from net.IP.String(), which renders IPv4 -- including the IPv4-mapped
+// 16-byte form -- as a dotted quad, and only IPv6 as colon-separated.
+func TestInUseByFamilyColonTest(t *testing.T) {
+	cases := []struct {
+		ip     net.IP
+		isIPv6 bool
+	}{
+		{net.ParseIP("192.168.1.1"), false},
+		{net.ParseIP("0.0.0.0"), false},
+		{net.ParseIP("255.255.255.255"), false},
+		{net.IPv4(10, 0, 0, 1), false},             // 16-byte IPv4-mapped
+		{net.ParseIP("::ffff:192.168.1.1"), false}, // explicit v4-mapped form
+		{net.ParseIP("2001:db8::1"), true},
+		{net.ParseIP("::1"), true},
+		{net.ParseIP("fe80::1"), true},
+	}
+	for _, c := range cases {
+		key := c.ip.String()
+		assert.Equal(t, c.isIPv6, strings.Contains(key, ":"),
+			"family test disagrees with net.IP for key %q", key)
+	}
+}

--- a/internal/allocator/pool.go
+++ b/internal/allocator/pool.go
@@ -153,6 +153,21 @@ func (a *Allocator) parsePool(name string, group purelbv2.ServiceGroupSpec) (Poo
 			purelbv2.PoolTypeRemote, false,
 			group.Remote.MultiPool, group.Remote.BalancePools)
 	} else if group.External != nil {
+		// The CRD constrains announce to local|remote and marks it required,
+		// so this normally cannot fire. It is checked anyway because the
+		// consequence of an empty value is silent and remote: PoolType()
+		// returns it verbatim, so purelb.io/pool-type is written empty, and
+		// the node agent then cannot tell whether to put the address on a
+		// local interface or on the dummy interface -- it announces nothing,
+		// with nothing in the allocator to say why. A ServiceGroup applied
+		// against a stale or pruned CRD is exactly how that arrives.
+		switch group.External.Announce {
+		case purelbv2.PoolTypeLocal, purelbv2.PoolTypeRemote:
+		default:
+			return nil, fmt.Errorf("external pool announce must be %q or %q, got %q (is the ServiceGroup CRD up to date?)",
+				purelbv2.PoolTypeLocal, purelbv2.PoolTypeRemote, group.External.Announce)
+		}
+
 		socket := group.External.Socket
 		if socket == "" {
 			socket = defaultSidecarSocket

--- a/internal/allocator/poolselect.go
+++ b/internal/allocator/poolselect.go
@@ -1,0 +1,131 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	v1 "k8s.io/api/core/v1"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// Provenance values reported alongside a resolved pool. viaAmbiguous is
+// distinct from viaDefault so that a Service which landed on "default" only
+// because its namespace could not resolve one is visible without the caller
+// re-deriving why.
+const (
+	viaAnnotation = "annotation"
+	viaNamespace  = "namespace"
+	viaDefault    = "default"
+	viaAmbiguous  = "default (ambiguous binding)"
+)
+
+// Sentinel errors. The metric taxonomy in stats.go tags failures by reason,
+// but the only failure sites are a single `if err != nil` in Allocate and one
+// in SetBalancer -- without sentinels the caller would have to string-match,
+// which is exactly how the verbatim `unknown pool %q` text gets broken.
+var (
+	// ErrUnknownPool means no ServiceGroup of that name produced a pool.
+	ErrUnknownPool = errors.New("unknown pool")
+	// ErrNoUsablePool means the ServiceGroup exists but failed to parse, so
+	// it has no pool. Distinct from ErrUnknownPool because telling an
+	// operator their ServiceGroup does not exist when it plainly does sends
+	// them looking in the wrong place.
+	ErrNoUsablePool = errors.New("no usable pool")
+	// ErrNamespaceDenied means the boundary refused this combination.
+	ErrNamespaceDenied = errors.New("namespace denied")
+	// ErrAmbiguousDefault means several ServiceGroups serve the namespace and
+	// none or more than one is marked as its default.
+	ErrAmbiguousDefault = errors.New("ambiguous namespace default")
+)
+
+// resolve returns the pool svc must allocate from and the provenance of the
+// choice.
+//
+// Precedence: an explicit purelb.io/service-group annotation, then the
+// namespace's default, then the pool named "default" -- which is exactly the
+// behaviour that predates this feature, so a cluster with no spec.namespaces
+// anywhere is unaffected.
+func (st *allocatorState) resolve(svc *v1.Service) (Pool, string, error) {
+	ns := svc.Namespace
+	b, bound := st.nsToPools[ns]
+
+	// An annotation may name any ELIGIBLE ServiceGroup, including one that
+	// is not the namespace's default. That is how a tenant reaches its BGP
+	// pool when L2 is the default.
+	if name, has := svc.Annotations[purelbv2.DesiredGroupAnnotation]; has {
+		p, err := st.checked(ns, name)
+		return p, viaAnnotation, err
+	}
+
+	if bound && b.def != "" {
+		p, err := st.checked(ns, b.def)
+		return p, viaNamespace, err
+	}
+
+	// Several ServiceGroups serve this namespace and none is marked as its
+	// default. Enforcing => deny, because falling through to "default" would
+	// breach the boundary the namespace just declared. Not enforcing => fall
+	// through, which is what this namespace did before any binding existed,
+	// so an additive config cannot break it.
+	if bound && b.enforce {
+		return nil, viaNamespace, fmt.Errorf("%w: %s", ErrAmbiguousDefault, b.defErr)
+	}
+	via := viaDefault
+	if bound {
+		via = viaAmbiguous
+	}
+	p, err := st.checked(ns, defaultPoolName)
+	return p, via, err
+}
+
+// checked resolves one ServiceGroup by name and applies both halves of the
+// boundary.
+//
+// Both halves derive from the NAMESPACE, not from the requested
+// ServiceGroup's own EnforceNamespaces. Reading exclusion off the target
+// would leave a half-open fence: enforcing on a tenant's L2 pool would leave
+// its BGP pool reachable from every other namespace in the cluster.
+func (st *allocatorState) checked(ns, name string) (Pool, error) {
+	pool, has := st.pools[name]
+	if !has {
+		// Distinguish "no such ServiceGroup" from "it exists but produced no
+		// pool"; the index binds from the spec, so a name here can belong to
+		// a group that failed parseGroups.
+		if _, exists := st.sgByName[name]; exists {
+			return nil, fmt.Errorf("%w: ServiceGroup %q failed to parse", ErrNoUsablePool, name)
+		}
+		return nil, fmt.Errorf("%w %q", ErrUnknownPool, name)
+	}
+
+	// Exclusion: a ServiceGroup serving any confined namespace refuses
+	// Services from outside the namespaces it serves.
+	if st.confinedGroups[name] && !purelbv2.ServesNamespace(st.sgByName[name], ns) {
+		return nil, fmt.Errorf("%w: ServiceGroup %q serves a confined namespace and does not serve %q",
+			ErrNamespaceDenied, name, ns)
+	}
+
+	// Confinement: a confined namespace may use only the ServiceGroups that
+	// serve it.
+	if b, bound := st.nsToPools[ns]; bound && b.enforce && !slices.Contains(b.eligible, name) {
+		return nil, fmt.Errorf("%w: namespace %q may only use %v, not ServiceGroup %q",
+			ErrNamespaceDenied, ns, b.eligible, name)
+	}
+
+	return pool, nil
+}

--- a/internal/allocator/poolselect.go
+++ b/internal/allocator/poolselect.go
@@ -15,10 +15,13 @@
 package allocator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
@@ -53,6 +56,59 @@ var (
 	// none or more than one is marked as its default.
 	ErrAmbiguousDefault = errors.New("ambiguous namespace default")
 )
+
+// allocationFailureReason maps an allocation error to a bounded metric
+// label. The sentinels above exist so this can classify without string
+// matching; anything unrecognised lands in "other" rather than minting a
+// new series, because the error text can contain a Service's own
+// annotation values.
+func allocationFailureReason(err error) string {
+	switch {
+	case errors.Is(err, ErrNamespaceDenied):
+		return "namespace_denied"
+	case errors.Is(err, ErrAmbiguousDefault):
+		return "ambiguous_namespace_default"
+	case errors.Is(err, ErrNoUsablePool):
+		return "no_usable_pool"
+	case errors.Is(err, ErrUnknownPool):
+		return "unknown_pool"
+	default:
+		return "other"
+	}
+}
+
+// recordAllocationFailure counts a failed allocation by reason.
+//
+// The pool label is the requested ServiceGroup only when the Service named
+// one, and even then it is bounded by the annotation being a ServiceGroup
+// name; when nothing was named there is no pool to attribute the failure
+// to, so it is recorded as "<none>". Never the raw error text, which would
+// let a Service mint unbounded Prometheus series.
+func recordAllocationFailure(svc *v1.Service, err error) {
+	pool := svc.Annotations[purelbv2.DesiredGroupAnnotation]
+	if pool == "" {
+		pool = "<none>"
+	}
+	allocationRejected.WithLabelValues(pool, allocationFailureReason(err)).Inc()
+}
+
+// isRetryableAllocationErr reports whether re-running the same allocation
+// later could plausibly succeed.
+//
+// Only transport-level failures against an external IPAM sidecar qualify.
+// Everything the allocator decides for itself -- exhaustion, sharing
+// conflicts, namespace boundaries, unparseable addresses -- is a property
+// of the request or the config and will fail identically on every retry.
+func isRetryableAllocationErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	}
+	return false
+}
 
 // resolve returns the pool svc must allocate from and the provenance of the
 // choice.

--- a/internal/allocator/poolselect_test.go
+++ b/internal/allocator/poolselect_test.go
@@ -16,10 +16,14 @@ package allocator
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -266,4 +270,68 @@ func TestBoundNamespacesInStatus(t *testing.T) {
 	assert.Equal(t, []string{"tenant-a", "tenant-a-staging"},
 		writer.updates[len(writer.updates)-1].Status.BoundNamespaces,
 		"statusEqual must not elide a pure spec.namespaces edit")
+}
+
+// TestAllocationFailureReason locks in the metric taxonomy. The sentinels
+// exist so failures can be classified without string matching; before this
+// they were defined and never consumed, so a namespace boundary refusing a
+// tenant's Services produced no metric at all.
+func TestAllocationFailureReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"namespace denied", fmt.Errorf("%w: nope", ErrNamespaceDenied), "namespace_denied"},
+		{"ambiguous default", fmt.Errorf("%w: nope", ErrAmbiguousDefault), "ambiguous_namespace_default"},
+		{"no usable pool", fmt.Errorf("%w: nope", ErrNoUsablePool), "no_usable_pool"},
+		{"unknown pool", fmt.Errorf("%w %q", ErrUnknownPool, "x"), "unknown_pool"},
+		{"unclassified", errors.New("pool exhausted"), "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, allocationFailureReason(tt.err))
+		})
+	}
+}
+
+// TestIsRetryableAllocationErr covers the requeue decision. Getting this
+// wrong in either direction is costly: retrying a permanent failure spins
+// the goroutine that allocates every address in the cluster, and not
+// retrying a transient one leaves a correct Service pending indefinitely.
+func TestIsRetryableAllocationErr(t *testing.T) {
+	retryable := []struct {
+		name string
+		err  error
+	}{
+		{"sidecar down", status.Error(codes.Unavailable, "connection refused")},
+		{"sidecar too slow", status.Error(codes.DeadlineExceeded, "timeout")},
+		{"sidecar out of capacity right now", status.Error(codes.ResourceExhausted, "busy")},
+		{"sidecar aborted", status.Error(codes.Aborted, "conflict")},
+		{"our context timed out", context.DeadlineExceeded},
+		{"our context cancelled", context.Canceled},
+	}
+	for _, tt := range retryable {
+		t.Run("retry/"+tt.name, func(t *testing.T) {
+			assert.True(t, isRetryableAllocationErr(tt.err))
+		})
+	}
+
+	permanent := []struct {
+		name string
+		err  error
+	}{
+		{"namespace boundary", fmt.Errorf("%w: nope", ErrNamespaceDenied)},
+		{"ambiguous default", fmt.Errorf("%w: nope", ErrAmbiguousDefault)},
+		{"unknown pool", fmt.Errorf("%w %q", ErrUnknownPool, "x")},
+		{"pool exhausted", errors.New("no available IPs")},
+		{"sharing conflict", errors.New("sharing key does not match")},
+		{"sidecar rejected the request", status.Error(codes.InvalidArgument, "bad pool")},
+		{"sidecar has no such pool", status.Error(codes.NotFound, "no pool")},
+	}
+	for _, tt := range permanent {
+		t.Run("no-retry/"+tt.name, func(t *testing.T) {
+			assert.False(t, isRetryableAllocationErr(tt.err))
+		})
+	}
 }

--- a/internal/allocator/poolselect_test.go
+++ b/internal/allocator/poolselect_test.go
@@ -1,0 +1,269 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// nsGroup builds a ServiceGroup with one v4 range and the namespace-binding
+// fields under test.
+func nsGroup(name, cidr string, namespaces []string, enforce, isDefault bool) *purelbv2.ServiceGroup {
+	return &purelbv2.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: purelbv2.ServiceGroupSpec{
+			Namespaces:        namespaces,
+			EnforceNamespaces: enforce,
+			NamespaceDefault:  isDefault,
+			Local: &purelbv2.ServiceGroupLocalSpec{
+				V4Pools: []purelbv2.AddressPool{{Pool: cidr, Subnet: "192.168.0.0/16"}},
+			},
+		},
+	}
+}
+
+func nsState(t *testing.T, groups ...*purelbv2.ServiceGroup) *Allocator {
+	t.Helper()
+	alloc := New(allocatorTestLogger)
+	alloc.SetClient(&testK8S{t: t})
+	require.NoError(t, alloc.SetPools(groups))
+	return alloc
+}
+
+func svcIn(namespace, name, group string) *v1.Service {
+	s := service(name, ports("tcp/80"), "")
+	s.Namespace = namespace
+	if group != "" {
+		s.Annotations[purelbv2.DesiredGroupAnnotation] = group
+	}
+	return &s
+}
+
+// TestResolveFallsBackToDefault is the zero-behaviour-change guard: with no
+// spec.namespaces anywhere, every Service resolves exactly as it did before
+// this feature existed.
+func TestResolveFallsBackToDefault(t *testing.T) {
+	alloc := nsState(t, nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false))
+	st := alloc.Snapshot()
+
+	pool, via, err := st.resolve(svcIn("anywhere", "s", ""))
+	require.NoError(t, err)
+	assert.Equal(t, defaultPoolName, pool.String())
+	assert.Equal(t, viaDefault, via)
+}
+
+// TestResolveNamespaceDefaulting: a listed namespace gets its ServiceGroup
+// with no annotation, and -- with enforcement off -- an annotation still
+// overrides in both directions.
+func TestResolveNamespaceDefaulting(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a"}, false, false),
+	)
+	st := alloc.Snapshot()
+
+	pool, via, err := st.resolve(svcIn("tenant-a", "s", ""))
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a-pool", pool.String())
+	assert.Equal(t, viaNamespace, via)
+
+	// Not enforcing, so the annotation may still take a bound Service out...
+	pool, _, err = st.resolve(svcIn("tenant-a", "s", defaultPoolName))
+	require.NoError(t, err, "defaulting mode must not fence a bound namespace in")
+	assert.Equal(t, defaultPoolName, pool.String())
+
+	// ...and may bring an unbound Service in.
+	pool, _, err = st.resolve(svcIn("tenant-b", "s", "tenant-a-pool"))
+	require.NoError(t, err, "defaulting mode must not fence outsiders out")
+	assert.Equal(t, "tenant-a-pool", pool.String())
+}
+
+// TestResolveEnforcementFencesBothDirections: with enforcement on, an
+// outsider cannot get in (exclusion) and a bound Service cannot get out
+// (confinement).
+func TestResolveEnforcementFencesBothDirections(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a"}, true, false),
+	)
+	st := alloc.Snapshot()
+
+	_, _, err := st.resolve(svcIn("tenant-b", "s", "tenant-a-pool"))
+	assert.ErrorIs(t, err, ErrNamespaceDenied, "exclusion: outsider must not reach the group")
+
+	_, _, err = st.resolve(svcIn("tenant-a", "s", defaultPoolName))
+	assert.ErrorIs(t, err, ErrNamespaceDenied, "confinement: bound Service must not leave")
+
+	// An unbound namespace is unaffected by someone else's enforcement.
+	pool, _, err := st.resolve(svcIn("tenant-b", "s", ""))
+	require.NoError(t, err)
+	assert.Equal(t, defaultPoolName, pool.String())
+}
+
+// TestMixedEnforceFencesBothGroups is the half-open-fence regression guard.
+// Exclusion derives from namespace confinement, not from the target group's
+// own flag -- so enforcing on a tenant's L2 pool must also fence its BGP
+// pool, which does not set the flag. A future "fix" reading the target's own
+// EnforceNamespaces has to break this test on purpose.
+func TestMixedEnforceFencesBothGroups(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-l2", "192.168.2.0/30", []string{"tenant-a"}, true, true),
+		nsGroup("tenant-a-bgp", "192.168.3.0/30", []string{"tenant-a"}, false, false),
+	)
+	st := alloc.Snapshot()
+
+	_, _, err := st.resolve(svcIn("tenant-b", "s", "tenant-a-bgp"))
+	assert.ErrorIs(t, err, ErrNamespaceDenied,
+		"the non-enforcing group of a confined namespace must still refuse outsiders")
+
+	// The tenant itself still reaches both of its own ServiceGroups.
+	pool, _, err := st.resolve(svcIn("tenant-a", "s", "tenant-a-bgp"))
+	require.NoError(t, err, "an eligible non-default group must stay reachable by annotation")
+	assert.Equal(t, "tenant-a-bgp", pool.String())
+}
+
+// TestMultipleEligibleGroupsL2AndBGP: a ServiceGroup is exactly one of
+// local/remote/external, so an L2 + BGP tenant needs two. The unannotated
+// Service gets the marked default; an annotation reaches the other.
+func TestMultipleEligibleGroupsL2AndBGP(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-l2", "192.168.2.0/30", []string{"tenant-a"}, true, true),
+		nsGroup("tenant-a-bgp", "192.168.3.0/30", []string{"tenant-a"}, true, false),
+	)
+	st := alloc.Snapshot()
+
+	pool, via, err := st.resolve(svcIn("tenant-a", "s", ""))
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a-l2", pool.String(), "the marked default wins")
+	assert.Equal(t, viaNamespace, via)
+
+	pool, _, err = st.resolve(svcIn("tenant-a", "s", "tenant-a-bgp"))
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a-bgp", pool.String())
+}
+
+// TestAmbiguousDefaultIsModeDependent: with two eligible groups and none
+// marked, an enforcing namespace denies (falling back would breach the
+// boundary it declared) while a non-enforcing one degrades to "default" --
+// so an additive, non-enforcing config can never take a namespace down.
+func TestAmbiguousDefaultIsModeDependent(t *testing.T) {
+	enforcing := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("a-one", "192.168.2.0/30", []string{"tenant-a"}, true, false),
+		nsGroup("a-two", "192.168.3.0/30", []string{"tenant-a"}, true, false),
+	).Snapshot()
+	_, _, err := enforcing.resolve(svcIn("tenant-a", "s", ""))
+	assert.ErrorIs(t, err, ErrAmbiguousDefault)
+
+	relaxed := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("a-one", "192.168.2.0/30", []string{"tenant-a"}, false, false),
+		nsGroup("a-two", "192.168.3.0/30", []string{"tenant-a"}, false, false),
+	).Snapshot()
+	pool, via, err := relaxed.resolve(svcIn("tenant-a", "s", ""))
+	require.NoError(t, err, "a non-enforcing config must not break")
+	assert.Equal(t, defaultPoolName, pool.String())
+	assert.Equal(t, viaAmbiguous, via, "provenance must record that this was a fallback, not a choice")
+}
+
+// TestDuplicateNamespaceEntryIsNotAmbiguity: +listType=set is deliberately
+// not used, so the API server accepts `namespaces: [a, a]`. Without a dedupe
+// one ServiceGroup would appear twice in eligible, look like two groups
+// competing, and deny its own namespace.
+func TestDuplicateNamespaceEntryIsNotAmbiguity(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a", "tenant-a"}, true, false),
+	)
+	pool, via, err := alloc.Snapshot().resolve(svcIn("tenant-a", "s", ""))
+	require.NoError(t, err, "a repeated namespace entry must not read as two competing groups")
+	assert.Equal(t, "tenant-a-pool", pool.String())
+	assert.Equal(t, viaNamespace, via)
+}
+
+// TestResolveUnknownPoolMessageUnchanged pins the wording operators grep for.
+func TestResolveUnknownPoolMessageUnchanged(t *testing.T) {
+	alloc := nsState(t, nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false))
+	_, _, err := alloc.Snapshot().resolve(svcIn("ns", "s", "nonexistent-pool"))
+	assert.ErrorIs(t, err, ErrUnknownPool)
+	assert.Contains(t, err.Error(), `unknown pool "nonexistent-pool"`)
+}
+
+// TestPinnedAddressRespectsBoundary: an address is a way of naming a
+// ServiceGroup, so pinning must not bypass the boundary that naming it would
+// hit. kube-vip ships exactly this gap.
+func TestPinnedAddressRespectsBoundary(t *testing.T) {
+	alloc := nsState(t,
+		nsGroup(defaultPoolName, "192.168.1.0/30", nil, false, false),
+		nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a"}, true, false),
+	)
+	st := alloc.Snapshot()
+
+	// tenant-b pins an address that lives inside tenant-a's fenced pool.
+	svc := svcIn("tenant-b", "thief", "")
+	svc.Annotations[purelbv2.DesiredAddressAnnotation] = "192.168.2.1"
+	_, err := alloc.allocateSpecificIP(st, svc)
+	assert.ErrorIs(t, err, ErrNamespaceDenied, "pinning must not bypass exclusion")
+	assert.Empty(t, svc.Status.LoadBalancer.Ingress)
+
+	// And the pre-flight must run before anything is released: a Service
+	// that already held an address keeps it when the request is refused.
+	held := svcIn("tenant-b", "incumbent", "")
+	require.NoError(t, alloc.Allocate(st, held))
+	require.Len(t, held.Status.LoadBalancer.Ingress, 1)
+	before := held.Status.LoadBalancer.Ingress[0].IP
+
+	held.Annotations[purelbv2.DesiredAddressAnnotation] = "192.168.2.1"
+	_, err = alloc.allocateSpecificIP(st, held)
+	assert.ErrorIs(t, err, ErrNamespaceDenied)
+	require.Len(t, held.Status.LoadBalancer.Ingress, 1,
+		"the refusal must happen before Unassign, or the Service is left released but still advertised")
+	assert.Equal(t, before, held.Status.LoadBalancer.Ingress[0].IP)
+}
+
+// TestBoundNamespacesInStatus: the field must actually change when the spec
+// does. statusEqual is a hand-maintained field list, so a status field it
+// does not compare is written once and then frozen -- the confirmation
+// signal would show the old list while the allocator acted on the new one.
+func TestBoundNamespacesInStatus(t *testing.T) {
+	alloc := New(allocatorTestLogger)
+	alloc.SetClient(&testK8S{t: t})
+	writer := &fakeStatusWriter{}
+	alloc.SetServiceGroupStatusWriter(writer)
+
+	g := nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a"}, false, false)
+	require.NoError(t, alloc.SetPools([]*purelbv2.ServiceGroup{g}))
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	require.NotEmpty(t, writer.updates)
+	assert.Equal(t, []string{"tenant-a"}, writer.updates[len(writer.updates)-1].Status.BoundNamespaces)
+
+	// Change only spec.namespaces -- no other status field moves.
+	g2 := nsGroup("tenant-a-pool", "192.168.2.0/30", []string{"tenant-a", "tenant-a-staging"}, false, false)
+	require.NoError(t, alloc.SetPools([]*purelbv2.ServiceGroup{g2}))
+	require.NoError(t, alloc.PublishAllSGStatus(context.Background()))
+	assert.Equal(t, []string{"tenant-a", "tenant-a-staging"},
+		writer.updates[len(writer.updates)-1].Status.BoundNamespaces,
+		"statusEqual must not elide a pure spec.namespaces edit")
+}

--- a/internal/allocator/service.go
+++ b/internal/allocator/service.go
@@ -236,9 +236,15 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 			if len(excessIPs) > 0 {
 				logging.Info(l, "op", "ipFamilyTransition", "action", "releaseExcess", "excessIPs", excessIPs)
 
-				// Release the excess IPs from the pool
-				if err := c.ips.ReleaseIPs(pools, nsName, excessIPs); err != nil {
+				// Release the excess IPs from the pool. The pool named by the
+				// Service is passed as a fallback for external pools, whose
+				// addresses cannot be found by address (SidecarPool.Contains
+				// is false) -- without it the address would be dropped from
+				// .status while the external IPAM still held it.
+				if err := c.ips.ReleaseIPs(pools, nsName, excessIPs, svc.Annotations[purelbv2.PoolAnnotation]); err != nil {
 					logging.Info(l, "op", "releaseExcess", "error", err)
+					c.client.Errorf(svc, "ReleaseFailed",
+						"Failed to release addresses after IP family transition: %s", err)
 					// Continue anyway - we'll update the ingress to remove them
 				}
 
@@ -265,6 +271,21 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 	if err := c.ips.Allocate(st, svc); err != nil {
 		logging.Info(l, "op", "allocateIP", "error", err, "msg", "IP allocation failed")
 		c.client.Errorf(svc, "AllocationFailed", "Failed to allocate IP for %q: %s", nsName, err)
+		recordAllocationFailure(svc, err)
+
+		// Requeue only what retrying can fix. A pool that is exhausted, a
+		// namespace boundary, a sharing conflict or a malformed address will
+		// fail identically forever, and requeuing those spins the goroutine
+		// that allocates every address in the cluster. A sidecar that is
+		// down or timing out is the opposite: the Service is correct and
+		// only the moment was wrong, and without a requeue it stays pending
+		// until some unrelated event happens to re-enqueue it. The work
+		// queue's rate limiter caps the backoff, and Forget resets it on the
+		// next success, so even a permanently dead sidecar settles into
+		// occasional retries rather than a spin.
+		if isRetryableAllocationErr(err) {
+			return k8s.SyncStateError
+		}
 		return k8s.SyncStateSuccess
 	}
 

--- a/internal/allocator/service.go
+++ b/internal/allocator/service.go
@@ -163,7 +163,7 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 			if len(svc.Status.LoadBalancer.Ingress) > 0 {
 				logging.Info(l, "op", "unassign", "reason", "type is not LoadBalancer", "ingress", svc.Status.LoadBalancer.Ingress)
 				c.client.Infof(svc, "AddressReleased", fmt.Sprintf("Service is Type %s, not LoadBalancer", svc.Spec.Type))
-				if err := c.ips.Unassign(pools, nsName); err != nil {
+				if err := c.ips.Unassign(pools, nsName, svc.Annotations[purelbv2.PoolAnnotation]); err != nil {
 					logging.Info(l, "op", "unassign", "error", err)
 					return k8s.SyncStateError
 				}

--- a/internal/allocator/service.go
+++ b/internal/allocator/service.go
@@ -86,21 +86,21 @@ func analyzeIPFamilyTransition(svc *v1.Service) (missingFamilies []v1.IPFamily, 
 
 // isMultiPoolService determines if a service should use multi-pool allocation
 // by checking the service annotation first, then the pool's default.
-func (c *controller) isMultiPoolService(pools map[string]Pool, svc *v1.Service) bool {
+func (c *controller) isMultiPoolService(st *allocatorState, svc *v1.Service) bool {
 	// Check the annotation first - it overrides everything
 	if ann, ok := svc.Annotations[purelbv2.MultiPoolAnnotation]; ok {
 		return ann == "true"
 	}
 
-	// Look up the pool to check its default
-	poolName := defaultPoolName
-	if userPool, has := svc.Annotations[purelbv2.DesiredGroupAnnotation]; has {
-		poolName = userPool
+	// Resolve the pool the same way Allocate will, so the two cannot
+	// disagree about which ServiceGroup this Service belongs to. A denial
+	// here is not reported: Allocate reaches the same conclusion and owns
+	// the event.
+	pool, _, err := st.resolve(svc)
+	if err != nil {
+		return false
 	}
-	if pool, has := pools[poolName]; has {
-		return pool.MultiPool()
-	}
-	return false
+	return pool.MultiPool()
 }
 
 // SetBalancer is the main entry point that handles LoadBalancer
@@ -148,7 +148,8 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 	// Load pool snapshot once for this entire processing cycle.
 	// All allocator methods use this same snapshot, ensuring a
 	// consistent view even if G2 swaps pools mid-cycle.
-	pools := c.ips.Pools()
+	st := c.ips.Snapshot()
+	pools := st.pools
 
 	// If the service isn't a LoadBalancer then we might need to clean
 	// up. It might have been a load balancer before and the user might
@@ -189,7 +190,7 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 
 	// Determine if this is a multi-pool service. We need the pool to check,
 	// so look it up from the annotation or default.
-	multiPool := c.isMultiPoolService(pools, svc)
+	multiPool := c.isMultiPoolService(st, svc)
 
 	// Multi-pool services: if already allocated by us, notify existing IPs
 	// and try incremental allocation from any newly available ranges.
@@ -200,9 +201,13 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 			if err := c.ips.NotifyExisting(pools, svc); err != nil {
 				logging.Info(l, "op", "notifyExisting", "error", err, "ingress", svc.Status.LoadBalancer.Ingress)
 			}
-			added, err := c.ips.IncrementalMultiPool(pools, svc)
+			added, err := c.ips.IncrementalMultiPool(st, svc)
 			if err != nil {
+				// Surface the refusal. This path used to log only, which
+				// made a rejected multi-pool request indistinguishable from
+				// a steady-state no-op in both events and metrics.
 				logging.Info(l, "op", "incrementalMultiPool", "error", err)
+				c.client.Errorf(svc, "AllocationFailed", "Incremental multi-pool allocation refused for %q: %s", nsName, err)
 			}
 			if added {
 				logging.Info(l, "op", "incrementalMultiPool", "msg", "allocated from new ranges")
@@ -257,7 +262,7 @@ func (c *controller) SetBalancer(svc *v1.Service, _ []*discoveryv1.EndpointSlice
 		}
 	}
 
-	if err := c.ips.Allocate(pools, svc); err != nil {
+	if err := c.ips.Allocate(st, svc); err != nil {
 		logging.Info(l, "op", "allocateIP", "error", err, "msg", "IP allocation failed")
 		c.client.Errorf(svc, "AllocationFailed", "Failed to allocate IP for %q: %s", nsName, err)
 		return k8s.SyncStateSuccess

--- a/internal/allocator/sidecarpool.go
+++ b/internal/allocator/sidecarpool.go
@@ -221,8 +221,8 @@ func (p *SidecarPool) DisplayAddresses() []string {
 	return nil
 }
 
-func (p *SidecarPool) InUse() int    { return p.InUseV4() + p.InUseV6() }
-func (p *SidecarPool) Size() uint64  { return p.SizeV4() + p.SizeV6() }
+func (p *SidecarPool) InUse() int   { return p.InUseV4() + p.InUseV6() }
+func (p *SidecarPool) Size() uint64 { return p.SizeV4() + p.SizeV6() }
 
 // wantsFamily reports whether svc requests the given IP family. A service
 // with no explicit IPFamilies (rare for LoadBalancer) is treated as

--- a/internal/allocator/sidecarpool_test.go
+++ b/internal/allocator/sidecarpool_test.go
@@ -257,3 +257,64 @@ func TestParsePool_ExternalDefaultSocket(t *testing.T) {
 	assert.True(t, ok, "empty Socket must fall back to defaultSidecarSocket")
 	a.closeAllSidecarConns()
 }
+
+// TestUnassignTargetsNamedExternalPool covers the pool-targeting rule in
+// Unassign. Getting it wrong in either direction is costly: skipping too
+// eagerly leaks an address in a system PureLB does not own, and skipping
+// never means one gRPC per configured sidecar on every Service deletion.
+func TestUnassignTargetsNamedExternalPool(t *testing.T) {
+	newPool := func(t *testing.T, name string, calls *int) *SidecarPool {
+		f := &fakeIPAM{releaseFunc: func(*ipamv1.ReleaseRequest) (*ipamv1.ReleaseResponse, error) {
+			*calls++
+			return &ipamv1.ReleaseResponse{}, nil
+		}}
+		conn := startFakeIPAM(t, f)
+		return NewSidecarPool(name, log.NewNopLogger(),
+			purelbv2.ServiceGroupExternalSpec{Provider: "test", Announce: "local"}, conn)
+	}
+
+	t.Run("named pool is released, the other external pool is not asked", func(t *testing.T) {
+		var mineCalls, theirsCalls int
+		a := New(log.NewNopLogger())
+		pools := map[string]Pool{
+			"mine":   newPool(t, "mine", &mineCalls),
+			"theirs": newPool(t, "theirs", &theirsCalls),
+		}
+		require.NoError(t, a.Unassign(pools, "ns/svc", "mine"))
+		assert.Equal(t, 1, mineCalls, "the pool that held the address must be released")
+		assert.Equal(t, 0, theirsCalls, "an unrelated sidecar must not be contacted")
+	})
+
+	t.Run("unknown pool falls back to asking every pool", func(t *testing.T) {
+		var aCalls, bCalls int
+		a := New(log.NewNopLogger())
+		pools := map[string]Pool{
+			"a": newPool(t, "a", &aCalls),
+			"b": newPool(t, "b", &bCalls),
+		}
+		// "" means the pool could not be determined -- an un-annotated
+		// Service, or a tombstone whose payload was lost. Releasing from
+		// none of them would leak, so every pool is asked.
+		require.NoError(t, a.Unassign(pools, "ns/svc", ""))
+		assert.Equal(t, 1, aCalls)
+		assert.Equal(t, 1, bCalls)
+	})
+
+	t.Run("a stale name does not skip local pools", func(t *testing.T) {
+		var extCalls int
+		a := New(log.NewNopLogger())
+		local, err := NewLocalPool("local", log.NewNopLogger(),
+			&purelbv2.AddressPool{Pool: "192.0.2.0/24", Subnet: "192.0.2.0/24", Aggregation: "default"},
+			nil, nil, nil, purelbv2.PoolTypeLocal, false, false, false)
+		require.NoError(t, err)
+		pools := map[string]Pool{
+			"local": local,
+			"ext":   newPool(t, "ext", &extCalls),
+		}
+		// The annotation is user-editable, so it must never be able to stop
+		// a local pool from releasing; only the (network-cost) external
+		// pools are skipped on the strength of it.
+		require.NoError(t, a.Unassign(pools, "ns/svc", "ext"))
+		assert.Equal(t, 1, extCalls, "the named external pool is still released")
+	})
+}

--- a/internal/allocator/sidecarpool_test.go
+++ b/internal/allocator/sidecarpool_test.go
@@ -318,3 +318,34 @@ func TestUnassignTargetsNamedExternalPool(t *testing.T) {
 		assert.Equal(t, 1, extCalls, "the named external pool is still released")
 	})
 }
+
+// TestParsePoolValidatesExternalAnnounce covers the defence against a stale
+// or pruned ServiceGroup CRD. The CRD constrains announce to local|remote,
+// but if that constraint is missing the value reaches PoolType() verbatim,
+// purelb.io/pool-type is written empty, and the node agent has no way to
+// decide between a local interface and the dummy interface -- so it
+// announces nothing and the allocator says nothing. Failing the parse turns
+// that into a visible ParseFailed event on the ServiceGroup.
+func TestParsePoolValidatesExternalAnnounce(t *testing.T) {
+	a := New(log.NewNopLogger())
+
+	for _, announce := range []string{"", "Local", "REMOTE", "bgp", "dummy"} {
+		t.Run("rejected/"+announce, func(t *testing.T) {
+			_, err := a.parsePool("ext", purelbv2.ServiceGroupSpec{
+				External: &purelbv2.ServiceGroupExternalSpec{Provider: "p", Announce: announce},
+			})
+			assert.Error(t, err, "announce %q must not produce a pool", announce)
+		})
+	}
+
+	for _, announce := range []string{purelbv2.PoolTypeLocal, purelbv2.PoolTypeRemote} {
+		t.Run("accepted/"+announce, func(t *testing.T) {
+			p, err := a.parsePool("ext", purelbv2.ServiceGroupSpec{
+				External: &purelbv2.ServiceGroupExternalSpec{Provider: "p", Announce: announce},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, announce, p.PoolType(),
+				"pool-type annotation is written from PoolType(); it must match announce")
+		})
+	}
+}

--- a/internal/allocator/stats.go
+++ b/internal/allocator/stats.go
@@ -10,7 +10,8 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the sp
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package allocator
 

--- a/internal/allocator/stats.go
+++ b/internal/allocator/stats.go
@@ -39,6 +39,19 @@ var (
 		Help:      "Number of addresses allocated from the pool",
 	}, labelNames)
 
+	// serviceGroupsOutOfScope reports ServiceGroups that exist but are
+	// ignored because they live outside the install namespace. Labelled by
+	// name and type as well as namespace: without the name an alert says a
+	// namespace has one but not which, and without the type you cannot tell
+	// "pool unavailable" from "addresses actively withdrawn", which is the
+	// difference between a local and a remote group.
+	serviceGroupsOutOfScope = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: purelbv2.MetricsNamespace,
+		Subsystem: "servicegroups",
+		Name:      "out_of_scope",
+		Help:      "ServiceGroups ignored because they are not in the PureLB install namespace",
+	}, []string{"namespace", "name", "type"})
+
 	allocationRejected = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: purelbv2.MetricsNamespace,
 		Subsystem: subsystem,
@@ -101,6 +114,7 @@ var (
 func init() {
 	prometheus.MustRegister(poolCapacity)
 	prometheus.MustRegister(poolActive)
+	prometheus.MustRegister(serviceGroupsOutOfScope)
 	prometheus.MustRegister(allocationRejected)
 	prometheus.MustRegister(multipoolAllocations)
 	prometheus.MustRegister(multipoolPartial)

--- a/internal/election/election.go
+++ b/internal/election/election.go
@@ -253,10 +253,10 @@ func (e *Election) Start() error {
 // shutdown sequence: marks unhealthy, stops renewals, and deletes the lease.
 //
 // For more granular control during graceful shutdown, use:
-//   1. MarkUnhealthy() - causes Winner() to return ""
-//   2. [caller triggers address withdrawal via ForceSync]
-//   3. StopRenewals() - stops the renewal goroutine
-//   4. DeleteOurLease() - removes our lease from the cluster
+//  1. MarkUnhealthy() - causes Winner() to return ""
+//  2. [caller triggers address withdrawal via ForceSync]
+//  3. StopRenewals() - stops the renewal goroutine
+//  4. DeleteOurLease() - removes our lease from the cluster
 func (e *Election) Shutdown() {
 	logging.Info(e.config.Logger, "op", "election", "action", "shutdown", "msg", "starting graceful shutdown")
 

--- a/internal/election/election_test.go
+++ b/internal/election/election_test.go
@@ -609,8 +609,8 @@ func TestWinnerWithOverlappingSubnets(t *testing.T) {
 	e.state.Store(&electionState{
 		liveNodes: []string{"node-a", "node-b"},
 		subnetToNodes: map[string][]string{
-			"10.0.0.0/8":   {"node-a"},
-			"10.0.1.0/24":  {"node-b"},
+			"10.0.0.0/8":  {"node-a"},
+			"10.0.1.0/24": {"node-b"},
 		},
 		nodeToSubnets: map[string][]string{
 			"node-a": {"10.0.0.0/8"},

--- a/internal/election/selector.go
+++ b/internal/election/selector.go
@@ -110,7 +110,7 @@ func GetSelectedSubnets(sel *InterfaceSelector, logger log.Logger) ([]string, er
 		return []string{}, nil
 	}
 
-	names := selectedInterfaceNames(sel)
+	names := selectedInterfaceNames(sel, logger)
 
 	// Log the selected names (not just the resulting subnets) so an
 	// under-anchored regex that catches veth/bridge interfaces is
@@ -138,7 +138,7 @@ func GetSelectedSubnets(sel *InterfaceSelector, logger log.Logger) ([]string, er
 // result is deduplicated and sorted: ifindex enumeration order is
 // boot-dependent, and deterministic order keeps logs and scans stable
 // across reboots.
-func selectedInterfaceNames(sel *InterfaceSelector) []string {
+func selectedInterfaceNames(sel *InterfaceSelector, logger log.Logger) []string {
 	nameSet := make(map[string]struct{})
 
 	for _, name := range sel.Interfaces {
@@ -149,7 +149,14 @@ func selectedInterfaceNames(sel *InterfaceSelector) []string {
 	}
 
 	if sel.Regex != nil {
-		if interfaces, err := net.Interfaces(); err == nil {
+		interfaces, err := net.Interfaces()
+		if err != nil {
+			// Silently returning fewer names here shrinks the subnets this
+			// node advertises, which loses it elections and withdraws VIPs.
+			// That must not look like a clean "no match".
+			logging.Info(logger, "op", "selectedInterfaceNames", "error", err,
+				"msg", "could not enumerate interfaces; regex-selected interfaces are missing from this lease")
+		} else {
 			candidates := make([]string, 0, len(interfaces))
 			for _, intf := range interfaces {
 				if intf.Flags&net.FlagLoopback != 0 {
@@ -180,7 +187,7 @@ func matchInterfaceNames(regex *regexp.Regexp, exclude string, names []string) [
 		if name == exclude {
 			continue
 		}
-		if regex.Match([]byte(name)) {
+		if regex.MatchString(name) {
 			matched = append(matched, name)
 		}
 	}

--- a/internal/election/selector.go
+++ b/internal/election/selector.go
@@ -26,12 +26,10 @@ import (
 	purelbv2 "purelb.io/pkg/apis/purelb/v2"
 )
 
-// lastSelectedInterfaces tracks the previously selected interface
-// names so we can log at info level on first selection or change,
-// debug on repeats. Like lastSubnets, it is safe only because the
-// election closure is the single caller (Start happens-before the
-// renewLoop goroutine).
-var lastSelectedInterfaces string
+// lastSelectedInterfaces tracks the previously selected interface names so
+// we can log at info level on first selection or change, debug on repeats.
+// See logThrottle in subnets.go for why this is atomic.
+var lastSelectedInterfaces logThrottle
 
 // InterfaceSelector describes which interfaces feed the election's
 // subnet detection. It is derived from the same LBNodeAgent Local spec
@@ -117,8 +115,7 @@ func GetSelectedSubnets(sel *InterfaceSelector, logger log.Logger) ([]string, er
 	// visible at info level.
 	if logger != nil {
 		formatted := fmt.Sprintf("%v(useDefault=%t)", names, sel.UseDefault)
-		if formatted != lastSelectedInterfaces {
-			lastSelectedInterfaces = formatted
+		if lastSelectedInterfaces.changed(formatted) {
 			logging.Info(logger, "op", "getSelectedSubnets", "interfaces", formatted,
 				"msg", "interface selection changed")
 		} else {

--- a/internal/election/selector_test.go
+++ b/internal/election/selector_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,12 +193,12 @@ func TestSelectedInterfaceNames(t *testing.T) {
 	t.Run("sorted deterministic order", func(t *testing.T) {
 		names := selectedInterfaceNames(&InterfaceSelector{
 			Interfaces: []string{"zzz0", "aaa0", "mmm0"},
-		})
+		}, log.NewNopLogger())
 		assert.Equal(t, []string{"aaa0", "mmm0", "zzz0"}, names)
 	})
 
 	t.Run("empty names dropped", func(t *testing.T) {
-		names := selectedInterfaceNames(&InterfaceSelector{Interfaces: []string{"", "eth1"}})
+		names := selectedInterfaceNames(&InterfaceSelector{Interfaces: []string{"", "eth1"}}, log.NewNopLogger())
 		assert.Equal(t, []string{"eth1"}, names)
 	})
 }

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -25,13 +25,32 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 
+	"sync/atomic"
+
 	"purelb.io/internal/logging"
 	"purelb.io/internal/netutil"
 )
 
+// logThrottle remembers the last value reported at info level so that
+// unchanged repeats drop to debug.
+//
+// Atomic rather than a plain string: these are package-level and the
+// exported functions that use them are reachable from any goroutine. Today
+// the election's renewLoop is the only caller, but that is a property of
+// the caller, not of this package, and a plain global would make the next
+// caller a silent data race rather than a compile error.
+type logThrottle struct{ last atomic.Pointer[string] }
+
+// changed reports whether v differs from the previously recorded value,
+// recording v either way.
+func (t *logThrottle) changed(v string) bool {
+	prev := t.last.Swap(&v)
+	return prev == nil || *prev != v
+}
+
 // lastSubnets tracks the previous subnet detection result so we can
 // log at info level on first detection or change, debug on repeats.
-var lastSubnets string
+var lastSubnets logThrottle
 
 // SubnetsAnnotation is the annotation key used on leases to store
 // the node's local subnets.
@@ -121,8 +140,7 @@ func GetLocalSubnets(interfaces []string, includeDefault bool, logger log.Logger
 	// Log at info on first detection or change, debug on repeats.
 	if logger != nil {
 		formatted := FormatSubnetsAnnotation(result)
-		if formatted != lastSubnets {
-			lastSubnets = formatted
+		if lastSubnets.changed(formatted) {
 			logging.Info(logger, "op", "getLocalSubnets", "subnets", formatted,
 				"count", len(result), "msg", "subnet detection complete")
 		} else {

--- a/internal/election/subnets.go
+++ b/internal/election/subnets.go
@@ -43,7 +43,6 @@ const SubnetsAnnotation = "purelb.io/subnets"
 // recreation where an old pod might delete a new pod's lease.
 const InstanceAnnotation = "purelb.io/instance"
 
-
 // GetLocalSubnets returns all subnets from the specified interfaces.
 // If includeDefault is true, the interface with the default route is
 // also included. The returned subnets are in CIDR notation (e.g.,
@@ -214,7 +213,6 @@ func networkAddress(ipnet *net.IPNet) string {
 	ones, _ := ipnet.Mask.Size()
 	return fmt.Sprintf("%s/%d", network.String(), ones)
 }
-
 
 // FormatSubnetsAnnotation formats a slice of subnets into the annotation
 // value format (comma-separated).

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -18,6 +18,8 @@ package k8s
 import (
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -48,6 +50,10 @@ type Controller struct {
 	kubeclientset kubernetes.Interface
 	// purelbclientset is a clientset for our own API group
 	purelbclientset clientset.Interface
+
+	// installNamespace is the namespace PureLB is installed in, as resolved
+	// by InstallNamespace. Empty when it could not be determined.
+	installNamespace string
 
 	sgsSynced   cache.InformerSynced
 	configCB    func(*purelbv2.Config) SyncState
@@ -80,6 +86,7 @@ type Controller struct {
 // to PureLB custom resources.
 func NewCRController(
 	logger log.Logger,
+	installNamespace string,
 	configCB func(*purelbv2.Config) SyncState,
 	forceSync func(),
 	publishPoolStatus func(),
@@ -100,6 +107,7 @@ func NewCRController(
 
 	controller := &Controller{
 		logger:            logger,
+		installNamespace:  installNamespace,
 		configCB:          configCB,
 		forceSync:         forceSync,
 		publishPoolStatus: publishPoolStatus,
@@ -210,6 +218,49 @@ func (c *Controller) processNextWorkItem() bool {
 }
 
 // syncHandler notifies the callback that there's a new config.  We
+// scopeToInstallNamespace splits groups into those PureLB will use and those
+// it ignores because they live outside the install namespace.
+//
+// A ServiceGroup's namespace has never meant anything: it selects where
+// .status is written and nothing else. A group in "tenant-a" contributes a
+// pool to the same cluster-wide table as one in the install namespace, while
+// pools are keyed by name alone -- so out-of-namespace groups bought no
+// isolation and cost cross-namespace name collisions and a route to claim the
+// "default" pool. They are no longer read.
+//
+// Two deliberate fail-open branches. Both exist because getting this wrong
+// silently removes every pool, and an allocator that reports healthy while
+// failing every allocation is worse than one that ignores a misplaced object.
+func (c *Controller) scopeToInstallNamespace(groups []*purelbv2.ServiceGroup) (kept, dropped []*purelbv2.ServiceGroup) {
+	// 1. Namespace unknown: filter nothing. Better to honour a misplaced
+	//    ServiceGroup than to discard every correctly-placed one.
+	if c.installNamespace == "" {
+		c.logger.Log("op", "scopeServiceGroups", "event", "installNamespaceUnknown",
+			"msg", "install namespace could not be determined; ServiceGroups are not being scoped. Set --namespace or PURELB_NAMESPACE")
+		return groups, nil
+	}
+
+	for _, g := range groups {
+		if g.Namespace == c.installNamespace {
+			kept = append(kept, g)
+		} else {
+			dropped = append(dropped, g)
+		}
+	}
+
+	// 2. Every group dropped: the namespace is wrong, not the cluster.
+	//    Nobody installs PureLB and then places all of their ServiceGroups
+	//    somewhere else, so treat this as a misconfigured namespace.
+	if len(kept) == 0 && len(dropped) > 0 {
+		c.logger.Log("op", "scopeServiceGroups", "event", "installNamespaceSuspect",
+			"installNamespace", c.installNamespace, "wouldDrop", len(dropped),
+			"msg", "scoping would discard every ServiceGroup; keeping them all and continuing. Check --namespace or PURELB_NAMESPACE")
+		return groups, nil
+	}
+
+	return kept, dropped
+}
+
 // process the config as a single unit so anytime we get a
 // notification that something changed we read everything.
 func (c *Controller) syncHandler() error {
@@ -223,6 +274,26 @@ func (c *Controller) syncHandler() error {
 		c.logger.Log("error listing ServiceGroups", err)
 		return err
 	}
+	// The lister walks the indexer's map, so its order varies between calls.
+	// parseGroups is order-sensitive -- it rejects the LATER of two
+	// overlapping-range ServiceGroups -- so without a stable order which one
+	// survives flips from one reconcile to the next. Sort by
+	// (namespace, name): a total order, because that pair is unique for any
+	// Kubernetes object. Sorting by name alone would leave two same-named
+	// ServiceGroups in different namespaces tied, and sort.Slice is not
+	// stable, so the flapping would persist.
+	//
+	// Sorting in place is safe: List appends into a fresh slice on every
+	// call, so both the header and the backing array are per-call and the
+	// shared cache objects are never touched. Do not "fix" this with a
+	// defensive clone.
+	slices.SortFunc(cfg.Groups, func(a, b *purelbv2.ServiceGroup) int {
+		if n := strings.Compare(a.Namespace, b.Namespace); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	cfg.Groups, cfg.DroppedGroups = c.scopeToInstallNamespace(cfg.Groups)
 	cfg.Agents, err = c.lbnaLister.LBNodeAgents("").List(labels.Everything())
 	if err != nil {
 		c.logger.Log("error listing node agents", err)

--- a/internal/k8s/cr-controller.go
+++ b/internal/k8s/cr-controller.go
@@ -112,13 +112,13 @@ func NewCRController(
 		forceSync:         forceSync,
 		publishPoolStatus: publishPoolStatus,
 		kubeclientset:     kubeclientset,
-		purelbclientset: purelbclientset,
-		lbnaLister:      lbnaInformer.Lister(),
-		lbnasSynced:     lbnaInformer.Informer().HasSynced,
-		sgLister:        sgInformer.Lister(),
-		sgsSynced:       sgInformer.Informer().HasSynced,
-		workqueue:       workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "ServiceGroups"}),
-		recorder:        recorder,
+		purelbclientset:   purelbclientset,
+		lbnaLister:        lbnaInformer.Lister(),
+		lbnasSynced:       lbnaInformer.Informer().HasSynced,
+		sgLister:          sgInformer.Lister(),
+		sgsSynced:         sgInformer.Informer().HasSynced,
+		workqueue:         workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "ServiceGroups"}),
+		recorder:          recorder,
 	}
 
 	// Set up event handlers for when resources change

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -74,10 +74,10 @@ type Client struct {
 	// API calls should use shorter timeouts to allow graceful shutdown.
 	shuttingDown atomic.Bool
 
-	svcIndexer       cache.Indexer
-	svcInformer      cache.Controller
-	epSliceIndexer   cache.Indexer
-	epSliceInformer  cache.Controller
+	svcIndexer      cache.Indexer
+	svcInformer     cache.Controller
+	epSliceIndexer  cache.Indexer
+	epSliceInformer cache.Controller
 
 	crInformerFactory externalversions.SharedInformerFactory
 	crController      Controller

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -85,7 +85,7 @@ type Client struct {
 	syncFuncs []cache.InformerSynced
 
 	serviceChanged func(*corev1.Service, []*discoveryv1.EndpointSlice) SyncState
-	serviceDeleted func(string) SyncState
+	serviceDeleted func(name, pool string) SyncState
 	configChanged  func(*purelbv2.Config) SyncState
 	synced         func()
 	shutdown       func()
@@ -258,7 +258,7 @@ type Config struct {
 	Kubeconfig         string
 
 	ServiceChanged func(*corev1.Service, []*discoveryv1.EndpointSlice) SyncState
-	ServiceDeleted func(string) SyncState
+	ServiceDeleted func(name, pool string) SyncState
 	ConfigChanged  func(*purelbv2.Config) SyncState
 	Synced         func()
 	Shutdown       func()
@@ -278,6 +278,26 @@ func (svcKey) isQueueItem() {}
 type synced string
 
 func (synced) isQueueItem() {}
+
+// svcDeleted carries a Service deletion together with the pool it was
+// allocated from.
+//
+// The pool cannot be recovered later: sync detects deletion by the object
+// being absent from the indexer, at which point its annotations are gone.
+// Capturing purelb.io/allocated-from here lets the consumer release from
+// the one pool that actually held the address instead of asking every
+// pool, which for external IPAM means a gRPC to every configured sidecar
+// on every deletion.
+//
+// pool is "" when it could not be determined (an un-annotated Service, or
+// a tombstone whose payload was lost); consumers must treat that as
+// "unknown" and fall back to asking every pool.
+type svcDeleted struct {
+	name string
+	pool string
+}
+
+func (svcDeleted) isQueueItem() {}
 
 // poolStatus asks the consumer to republish .status for every
 // configured address pool. A singleton: all instances compare equal, so
@@ -363,9 +383,23 @@ func New(cfg *Config) (*Client, error) {
 		},
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
-				c.queue.Add(svcKey(key))
+			if err != nil {
+				return
 			}
+			// Read the pool off the object while we still have it. A
+			// DeletedFinalStateUnknown tombstone still carries the last
+			// known Service, so unwrap it rather than losing the pool.
+			svc, ok := obj.(*corev1.Service)
+			if !ok {
+				if tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+					svc, ok = tombstone.Obj.(*corev1.Service)
+				}
+			}
+			var pool string
+			if ok && svc != nil {
+				pool = svc.Annotations[purelbv2.PoolAnnotation]
+			}
+			c.queue.Add(svcDeleted{name: key, pool: pool})
 		},
 	}
 	svcWatcher := cache.NewListWatchFromClient(c.client.CoreV1().RESTClient(), "services", corev1.NamespaceAll, fields.Everything())
@@ -777,7 +811,7 @@ func (c *Client) sync(key queueItem) SyncState {
 		}
 		if !exists {
 			// l.Log("op", "getService", "msg", "doesn't exist")
-			return c.serviceDeleted(svcName)
+			return c.serviceDeleted(svcName, "")
 		}
 		// DeepCopy: svcIndexer returns the shared informer cache object.
 		// The announcer mutates the Service it is handed (annotations, and
@@ -829,6 +863,9 @@ func (c *Client) sync(key queueItem) SyncState {
 		// before this point.
 		c.EnqueuePoolStatus()
 		return SyncStateSuccess
+
+	case svcDeleted:
+		return c.serviceDeleted(k.name, k.pool)
 
 	case poolStatus:
 		if c.publishPoolStatus == nil {

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -218,9 +219,38 @@ const (
 	SyncStateReprocessAll
 )
 
+// saNamespacePath is where the ServiceAccount token projection puts the
+// namespace a Pod is running in.
+const saNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// InstallNamespace determines the namespace PureLB is installed in. An
+// explicit flag or PURELB_NAMESPACE wins; otherwise it falls back to the
+// ServiceAccount projection, which keeps deployments working whose manifests
+// predate the downward-API env var.
+//
+// An empty result is deliberately not fatal. Both binaries derive config from
+// this value, and refusing to start on a missing namespace would turn a
+// cosmetic packaging gap into an outage; callers degrade instead. Whitespace
+// is trimmed because the projected file has no trailing newline guarantee.
+func InstallNamespace(logger log.Logger, flagValue string) string {
+	if ns := strings.TrimSpace(flagValue); ns != "" {
+		return ns
+	}
+	data, err := os.ReadFile(saNamespacePath)
+	if err != nil {
+		logger.Log("op", "startup", "error", err,
+			"msg", "could not determine install namespace; set --namespace or PURELB_NAMESPACE")
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // Config specifies the configuration of the Kubernetes
 // client/watcher.
 type Config struct {
+	// Namespace is the namespace PureLB is installed in, as resolved by
+	// InstallNamespace. May be empty if it could not be determined.
+	Namespace          string
 	ProcessName        string
 	NodeName           string
 	ReadEndpointSlices bool
@@ -302,7 +332,7 @@ func New(cfg *Config) (*Client, error) {
 	// nodeSelector evaluation and gives config delivery a self-healing
 	// floor if a delivery was lost.
 	c.crInformerFactory = externalversions.NewSharedInformerFactory(crClient, time.Minute*10)
-	c.crController = *NewCRController(c.logger, cfg.ConfigChanged, c.ForceSync, c.EnqueuePoolStatus, clientset, crClient, c.crInformerFactory)
+	c.crController = *NewCRController(c.logger, cfg.Namespace, cfg.ConfigChanged, c.ForceSync, c.EnqueuePoolStatus, clientset, crClient, c.crInformerFactory)
 
 	// Service Watcher
 

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -60,9 +60,9 @@ func TestAnnouncingOnlyUpdate(t *testing.T) {
 			wantSkip: false,
 		},
 		{
-			name: "announcing-IPv4 changed -> skip",
-			old:  base(),
-			new:  withAnn(base(), "purelb.io/announcing-IPv4", "node-b,eth0,10.0.0.1"),
+			name:     "announcing-IPv4 changed -> skip",
+			old:      base(),
+			new:      withAnn(base(), "purelb.io/announcing-IPv4", "node-b,eth0,10.0.0.1"),
 			wantSkip: true,
 		},
 		{
@@ -76,9 +76,9 @@ func TestAnnouncingOnlyUpdate(t *testing.T) {
 			wantSkip: true,
 		},
 		{
-			name: "announcing-IPv6 added alongside existing v4 -> skip",
-			old:  base(),
-			new:  withAnn(base(), "purelb.io/announcing-IPv6", "node-a,eth0,2001:db8::1"),
+			name:     "announcing-IPv6 added alongside existing v4 -> skip",
+			old:      base(),
+			new:      withAnn(base(), "purelb.io/announcing-IPv6", "node-a,eth0,2001:db8::1"),
 			wantSkip: true,
 		},
 		{
@@ -290,20 +290,26 @@ func (m *mockIndexer) ListKeys() []string {
 }
 
 // Unused methods required by cache.Indexer interface
-func (m *mockIndexer) Add(obj interface{}) error                              { return nil }
-func (m *mockIndexer) Update(obj interface{}) error                           { return nil }
-func (m *mockIndexer) Delete(obj interface{}) error                           { return nil }
-func (m *mockIndexer) List() []interface{}                                    { return nil }
-func (m *mockIndexer) Get(obj interface{}) (item interface{}, exists bool, err error) { return nil, false, nil }
-func (m *mockIndexer) GetByKey(key string) (item interface{}, exists bool, err error) { return nil, false, nil }
-func (m *mockIndexer) Replace([]interface{}, string) error                    { return nil }
-func (m *mockIndexer) Resync() error                                          { return nil }
-func (m *mockIndexer) Index(indexName string, obj interface{}) ([]interface{}, error) { return nil, nil }
-func (m *mockIndexer) IndexKeys(indexName, indexedValue string) ([]string, error)     { return nil, nil }
-func (m *mockIndexer) ListIndexFuncValues(indexName string) []string          { return nil }
-func (m *mockIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error)  { return nil, nil }
-func (m *mockIndexer) GetIndexers() cache.Indexers                            { return nil }
-func (m *mockIndexer) AddIndexers(newIndexers cache.Indexers) error           { return nil }
+func (m *mockIndexer) Add(obj interface{}) error    { return nil }
+func (m *mockIndexer) Update(obj interface{}) error { return nil }
+func (m *mockIndexer) Delete(obj interface{}) error { return nil }
+func (m *mockIndexer) List() []interface{}          { return nil }
+func (m *mockIndexer) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+func (m *mockIndexer) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+func (m *mockIndexer) Replace([]interface{}, string) error { return nil }
+func (m *mockIndexer) Resync() error                       { return nil }
+func (m *mockIndexer) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	return nil, nil
+}
+func (m *mockIndexer) IndexKeys(indexName, indexedValue string) ([]string, error)    { return nil, nil }
+func (m *mockIndexer) ListIndexFuncValues(indexName string) []string                 { return nil }
+func (m *mockIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) { return nil, nil }
+func (m *mockIndexer) GetIndexers() cache.Indexers                                   { return nil }
+func (m *mockIndexer) AddIndexers(newIndexers cache.Indexers) error                  { return nil }
 
 // TestEnqueuePoolStatus_NoPublisher verifies that a consumer which owns
 // no address pools (lbnodeagent) never puts a dead item on the queue.

--- a/internal/k8s/namespace_test.go
+++ b/internal/k8s/namespace_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	purelbv2 "purelb.io/pkg/apis/purelb/v2"
+)
+
+// TestInstallNamespace_FlagWins: an explicit flag or PURELB_NAMESPACE takes
+// precedence over the ServiceAccount projection, so an operator can override
+// a wrong or absent projection without rebuilding anything.
+func TestInstallNamespace_FlagWins(t *testing.T) {
+	assert.Equal(t, "purelb-system", InstallNamespace(log.NewNopLogger(), "purelb-system"))
+}
+
+// TestInstallNamespace_TrimsWhitespace: the projected file carries no
+// trailing-newline guarantee, and an untrimmed value would compare unequal to
+// every ServiceGroup namespace -- which, once the value is used for scoping,
+// silently matches nothing.
+func TestInstallNamespace_TrimsWhitespace(t *testing.T) {
+	assert.Equal(t, "purelb-system", InstallNamespace(log.NewNopLogger(), "  purelb-system\n"))
+}
+
+// TestInstallNamespace_EmptyIsNotFatal: with no flag and no projection the
+// result is empty and the process continues. Callers must degrade rather than
+// refuse to start -- guessing wrong here is worse than admitting ignorance,
+// and refusing to start turns a packaging gap into an outage.
+func TestInstallNamespace_EmptyIsNotFatal(t *testing.T) {
+	// The SA path does not exist outside a cluster, so this exercises the
+	// fallback failure branch.
+	assert.Equal(t, "", InstallNamespace(log.NewNopLogger(), "   "))
+}
+
+func sg(namespace, name string) *purelbv2.ServiceGroup {
+	return &purelbv2.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+}
+
+func names(groups []*purelbv2.ServiceGroup) []string {
+	out := make([]string, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, g.Namespace+"/"+g.Name)
+	}
+	return out
+}
+
+// TestScopeToInstallNamespace_KeepsOnlyInstallNamespace is the ordinary case:
+// ServiceGroups elsewhere are ignored and reported, not silently discarded.
+func TestScopeToInstallNamespace_KeepsOnlyInstallNamespace(t *testing.T) {
+	c := &Controller{logger: log.NewNopLogger(), installNamespace: "purelb-system"}
+	kept, dropped := c.scopeToInstallNamespace([]*purelbv2.ServiceGroup{
+		sg("purelb-system", "default"),
+		sg("tenant-a", "stray"),
+		sg("purelb-system", "tenant-a-pool"),
+	})
+	assert.Equal(t, []string{"purelb-system/default", "purelb-system/tenant-a-pool"}, names(kept))
+	assert.Equal(t, []string{"tenant-a/stray"}, names(dropped),
+		"out-of-scope groups must be carried for reporting, not dropped on the floor")
+}
+
+// TestScopeToInstallNamespace_UnknownNamespaceFiltersNothing: with no install
+// namespace, filtering would discard every ServiceGroup and every Service
+// would then fail `unknown pool "default"` while the allocator reported
+// healthy. Honouring a misplaced group is the lesser failure.
+func TestScopeToInstallNamespace_UnknownNamespaceFiltersNothing(t *testing.T) {
+	c := &Controller{logger: log.NewNopLogger(), installNamespace: ""}
+	in := []*purelbv2.ServiceGroup{sg("tenant-a", "one"), sg("tenant-b", "two")}
+	kept, dropped := c.scopeToInstallNamespace(in)
+	assert.Equal(t, names(in), names(kept), "must fail open when the namespace is unknown")
+	assert.Empty(t, dropped)
+}
+
+// TestScopeToInstallNamespace_RefusesToDropEverything: nobody installs PureLB
+// and then puts all of their ServiceGroups somewhere else, so dropping 100%
+// means the configured namespace is wrong, not the cluster.
+func TestScopeToInstallNamespace_RefusesToDropEverything(t *testing.T) {
+	c := &Controller{logger: log.NewNopLogger(), installNamespace: "typo-system"}
+	in := []*purelbv2.ServiceGroup{sg("purelb-system", "default"), sg("purelb-system", "other")}
+	kept, dropped := c.scopeToInstallNamespace(in)
+	assert.Equal(t, names(in), names(kept), "must keep everything rather than empty the pool table")
+	assert.Empty(t, dropped)
+}
+
+// TestScopeToInstallNamespace_NoGroupsIsNotSuspect: an empty cluster is a
+// legitimate state and must not trip the refuse-to-drop-everything branch.
+func TestScopeToInstallNamespace_NoGroupsIsNotSuspect(t *testing.T) {
+	c := &Controller{logger: log.NewNopLogger(), installNamespace: "purelb-system"}
+	kept, dropped := c.scopeToInstallNamespace(nil)
+	assert.Empty(t, kept)
+	assert.Empty(t, dropped)
+}

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -17,9 +17,11 @@ package local
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/netip"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -858,17 +860,26 @@ func addrFamilyName(lbIP net.IP) (lbIPFamily string) {
 // poolFor returns the name and AddressPool that contains lbIP.
 // It checks both local and remote ServiceGroups.
 // If error is not nil then no pool was found.
+//
+// Group names are walked in sorted order rather than map order. The
+// allocator rejects overlapping ServiceGroups in parseGroups, but the
+// announcer builds its maps from the unfiltered config and applies no such
+// rule, so if two groups do overlap it is this function that decides which
+// subnet and aggregation a remote address is announced with. A Go map walk
+// would pick a different one per call, making the announced prefix flap
+// between reconciles on the same node. Sorted order makes the choice
+// arbitrary but stable, and identical on every node.
 func (a *announcer) poolFor(cfg *announcerConfig, lbIP net.IP) (string, *purelbv2.AddressPool, error) {
 	// Check local groups first
-	for groupName, group := range cfg.groups {
-		pool, err := group.PoolForAddress(lbIP)
+	for _, groupName := range slices.Sorted(maps.Keys(cfg.groups)) {
+		pool, err := cfg.groups[groupName].PoolForAddress(lbIP)
 		if err == nil {
 			return groupName, pool, nil
 		}
 	}
 	// Check remote groups
-	for groupName, group := range cfg.remoteGroups {
-		pool, err := group.PoolForAddress(lbIP)
+	for _, groupName := range slices.Sorted(maps.Keys(cfg.remoteGroups)) {
+		pool, err := cfg.remoteGroups[groupName].PoolForAddress(lbIP)
 		if err == nil {
 			return groupName, pool, nil
 		}

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -122,13 +122,31 @@ type announcer struct {
 
 // addressRenewal holds the state needed to periodically refresh an address
 // before its lifetime expires.
+//
+// timer is atomic because it is written by the renewal timer's own
+// goroutine (renewAddress re-arming itself) and read by the service-sync
+// goroutine (scheduleRenewal, cancelRenewal, WithdrawAll, all calling
+// Stop). The cancelled flag does not make a plain field safe: cancelRenewal
+// and WithdrawAll set it before Stop and renewAddress re-checks it before
+// re-arming, which narrows the window to the couple of instructions between
+// that check and the assignment but does not close it -- and scheduleRenewal
+// Stops the old timer without touching cancelled at all, leaving the window
+// wide open.
 type addressRenewal struct {
 	ipNet     net.IPNet
 	link      netlink.Link
 	opts      AddressOptions
-	timer     *time.Timer
+	timer     atomic.Pointer[time.Timer]
 	interval  time.Duration
 	cancelled atomic.Bool // Set when renewal is cancelled to prevent race with timer
+}
+
+// stopTimer stops this renewal's timer if one has been armed. Safe to call
+// from any goroutine and safe before the first arm.
+func (r *addressRenewal) stopTimer() {
+	if t := r.timer.Load(); t != nil {
+		t.Stop()
+	}
 }
 
 var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -705,7 +723,7 @@ func (a *announcer) WithdrawAll() {
 	a.addressRenewals.Range(func(key, val interface{}) bool {
 		renewal := val.(*addressRenewal)
 		renewal.cancelled.Store(true)
-		renewal.timer.Stop()
+		renewal.stopTimer()
 		return true
 	})
 
@@ -1024,14 +1042,19 @@ func (a *announcer) scheduleRenewal(svcName string, lbIPNet net.IPNet, link netl
 		interval: interval,
 	}
 
-	// Cancel existing timer if any
+	// Cancel existing timer if any. Mark it cancelled as well as stopping
+	// it: an in-flight renewAddress for the old renewal re-checks that flag
+	// before re-arming, so without this the superseded timer can arm itself
+	// again after being Stopped and go on firing untracked.
 	if old, loaded := a.addressRenewals.LoadAndDelete(key); loaded {
-		old.(*addressRenewal).timer.Stop()
+		oldRenewal := old.(*addressRenewal)
+		oldRenewal.cancelled.Store(true)
+		oldRenewal.stopTimer()
 	}
 
-	renewal.timer = time.AfterFunc(interval, func() {
+	renewal.timer.Store(time.AfterFunc(interval, func() {
 		a.renewAddress(key)
-	})
+	}))
 
 	a.addressRenewals.Store(key, renewal)
 	logging.Debug(a.logger, "op", "scheduleRenewal", "key", key, "interval", interval)
@@ -1065,9 +1088,9 @@ func (a *announcer) renewAddress(key string) {
 	}
 
 	// Reschedule for next renewal
-	renewal.timer = time.AfterFunc(renewal.interval, func() {
+	renewal.timer.Store(time.AfterFunc(renewal.interval, func() {
 		a.renewAddress(key)
-	})
+	}))
 }
 
 // cancelRenewal stops the renewal timer for a specific service/IP combination.
@@ -1078,7 +1101,7 @@ func (a *announcer) cancelRenewal(svcName, ip string) {
 		// Mark as cancelled first, then stop timer
 		// This prevents a race where timer fires between LoadAndDelete and Stop
 		renewal.cancelled.Store(true)
-		renewal.timer.Stop()
+		renewal.stopTimer()
 		logging.Debug(a.logger, "op", "cancelRenewal", "key", key)
 	}
 }

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -645,14 +645,21 @@ func (a *announcer) DeleteBalancer(nsName, reason string, _ net.IP) error {
 	// delete this service from our announcement database
 	delete(a.svcIngresses, nsName)
 
+	// Every address is attempted before returning, and failures are
+	// reported: a swallowed error here leaves the VIP on the NIC after the
+	// Service is gone, with nothing left to trigger another withdrawal.
+	var errs []error
 	for _, ingress := range ingress {
 		lbIP := net.ParseIP(ingress.IP)
 		if lbIP == nil {
-			return fmt.Errorf("invalid LoadBalancer IP: %s, belongs to %s", ingress.IP, nsName)
+			errs = append(errs, fmt.Errorf("invalid LoadBalancer IP: %s, belongs to %s", ingress.IP, nsName))
+			continue
 		}
-		a.deleteAddress(nsName, reason, lbIP)
+		if err := a.deleteAddress(nsName, reason, lbIP); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // deleteAddress deletes the IP address associated with the

--- a/internal/local/announcer_local.go
+++ b/internal/local/announcer_local.go
@@ -40,26 +40,69 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-type announcer struct {
-	client       k8s.ServiceEvent
-	logger       log.Logger
-	myNode       string
-	config       *purelbv2.LBNodeAgentLocalSpec
+// announcerConfig is everything one SetConfig delivery produces, held as
+// an immutable unit.
+//
+// These five values used to be independent mutable fields on announcer,
+// written by SetConfig on the CR-controller goroutine and read by
+// SetBalancer's call tree on the service-sync goroutine with no
+// synchronization. That raced two ways: SetConfig blanked the spec
+// pointer before rebuilding it, so a reader between the nil-guard and any
+// later dereference took a nil-pointer panic; and groups/remoteGroups
+// were assigned empty and then filled, so a reader iterating them hit
+// "concurrent map iteration and map write" -- a Go runtime fatal error,
+// which no recover() can catch.
+//
+// Publishing them together as one immutable snapshot means a reader sees
+// generation N or N+1, never a mixture and never a half-built map. This
+// is the same discipline the allocator uses for allocatorState.
+//
+// Nothing in here may be mutated after the atomic Store that publishes
+// it. Build a fresh one instead; deliveries are rare (CR changes plus the
+// informer resync) and the snapshot is a handful of words.
+type announcerConfig struct {
+	// spec is the Local spec of the LBNodeAgent governing this node.
+	// Never nil in a published snapshot -- an absent or rejected config
+	// is represented by storing a nil *announcerConfig, not by a nil spec.
+	spec *purelbv2.LBNodeAgentLocalSpec
+
 	groups       map[string]*purelbv2.ServiceGroupLocalSpec  // groupName -> ServiceGroupLocalSpec
 	remoteGroups map[string]*purelbv2.ServiceGroupRemoteSpec // groupName -> ServiceGroupRemoteSpec
-	election     *election.Election
-	dummyInt     netlink.Link // for non-local announcements
+
+	// localNameRegex is the pattern that we use to determine if an
+	// interface is local or not. nil means "default interface".
+	localNameRegex *regexp.Regexp
+
+	// dummyInt is the interface carrying non-local announcements.
+	// addDummyInterface is idempotent and resolves by name, so a handle
+	// held by an in-flight reader across a config swap still refers to
+	// the same interface.
+	dummyInt netlink.Link
+}
+
+type announcer struct {
+	client   k8s.ServiceEvent
+	logger   log.Logger
+	myNode   string
+	election *election.Election
+
+	// cfg is the current configuration snapshot. A nil pointer means we
+	// are not configured and must not announce; see SetConfig. Loaded
+	// exactly once per SetBalancer cycle and threaded down, so a config
+	// swap mid-cycle cannot be observed halfway.
+	cfg atomic.Pointer[announcerConfig]
 
 	// svcIngresses is a map from svcName to that Service's
 	// Ingresses. Note that we may or may not advertise all of them
 	// because we might lose an election or not have any active
 	// endpoints, but in any case we need to ensure that we clean them
 	// up if the Service is deleted.
+	//
+	// Not synchronized, and does not need to be: it is written only by
+	// SetBalancer/DeleteBalancer on the service-sync goroutine, and read
+	// by WithdrawAll, which runs from Shutdown after Client.Run has
+	// returned and that goroutine has exited.
 	svcIngresses map[string][]v1.LoadBalancerIngress
-
-	// localNameRegex is the pattern that we use to determine if an
-	// interface is local or not.
-	localNameRegex *regexp.Regexp
 
 	// addressRenewals tracks addresses that need periodic renewal.
 	// Key format: "namespace/servicename:ip" to support shared IPs.
@@ -113,15 +156,27 @@ func (a *announcer) SetClient(client *k8s.Client) {
 	a.client = client
 }
 
+// SetConfig applies a config delivery. It runs on the CR-controller
+// goroutine, concurrently with SetBalancer on the service-sync goroutine.
+//
+// Everything is built into locals first and published with a single
+// atomic Store, so readers never observe a partially-applied config. In
+// particular the previous snapshot stays live and usable for the whole
+// build: this deliberately does NOT blank the config on entry the way it
+// used to. That blanking was doing two jobs -- opening the race window,
+// and encoding "no agent means announce nothing" -- and only the second
+// is wanted. Every path that means "announce nothing" now stores nil
+// explicitly, and nothing else disturbs the live config.
 func (a *announcer) SetConfig(cfg *purelbv2.Config) error {
-
-	// the default is nil which means that we don't announce
-	a.config = nil
-
 	// The election selector uses the same helper, so both sides always
 	// choose the same agent (the coherence invariant).
 	agent := purelbv2.FirstLocalAgent(cfg.Agents)
 	if agent == nil {
+		// No agent governs this node: the LBNodeAgent was deleted, or a
+		// nodeSelector deselected us. Announce nothing. This store is what
+		// the old entry-point blanking used to do implicitly; without it a
+		// deselected node would keep announcing on its last config forever.
+		a.cfg.Store(nil)
 		logging.Info(a.logger, "event", "noConfig")
 		return nil
 	}
@@ -129,51 +184,62 @@ func (a *announcer) SetConfig(cfg *purelbv2.Config) error {
 	logging.Info(a.logger, "op", "setConfig", "spec", spec, "name", agent.Namespace+"/"+agent.Name)
 
 	// stash the local ServiceGroup configs
-	a.groups = map[string]*purelbv2.ServiceGroupLocalSpec{}
-	a.remoteGroups = map[string]*purelbv2.ServiceGroupRemoteSpec{}
+	groups := map[string]*purelbv2.ServiceGroupLocalSpec{}
+	remoteGroups := map[string]*purelbv2.ServiceGroupRemoteSpec{}
 	for _, group := range cfg.Groups {
 		if group.Spec.Local != nil {
-			a.groups[group.ObjectMeta.Name] = group.Spec.Local
+			groups[group.ObjectMeta.Name] = group.Spec.Local
 		}
 		if group.Spec.Remote != nil {
-			a.remoteGroups[group.ObjectMeta.Name] = group.Spec.Remote
+			remoteGroups[group.ObjectMeta.Name] = group.Spec.Remote
 		}
 	}
 
-	if err := a.applyLocalSpec(spec); err != nil {
+	localNameRegex, err := compileLocalInterface(spec)
+	if err != nil {
+		// An invalid config must not leave the previous one announcing:
+		// the node agent reports SyncStateError upward and its election
+		// selector is emptied to match, so the lease advertises nothing.
+		a.cfg.Store(nil)
 		return err
 	}
 
 	// now that we've got a config we can create the dummy interface
-	var err error
-	if a.dummyInt, err = addDummyInterface(spec.DummyInterface); err != nil {
+	dummyInt, err := addDummyInterface(spec.DummyInterface)
+	if err != nil {
+		a.cfg.Store(nil)
 		return fmt.Errorf("error adding interface \"%s\": %s", spec.DummyInterface, err.Error())
 	}
 
-	// The dummy interface is set up so we can set the config which
-	// will allow announcements to happen.
-	a.config = spec
+	// The dummy interface is set up so we can publish the config, which
+	// will allow announcements to happen. One store, everything at once.
+	a.cfg.Store(&announcerConfig{
+		spec:           spec,
+		groups:         groups,
+		remoteGroups:   remoteGroups,
+		localNameRegex: localNameRegex,
+		dummyInt:       dummyInt,
+	})
 
 	return nil
 }
 
-// applyLocalSpec applies the netlink-free part of a Local spec: regex
-// compilation. Extracted from SetConfig so it can be unit-tested
-// without CAP_NET_ADMIN. An empty LocalInterface is treated as
-// "default" — kubebuilder defaulting can be bypassed by programmatic
-// clients, and compiling "" would yield a match-everything regex. The
-// election's SelectorFromConfig applies the identical rule.
-func (a *announcer) applyLocalSpec(spec *purelbv2.LBNodeAgentLocalSpec) error {
+// compileLocalInterface compiles the netlink-free part of a Local spec:
+// the localInterface regex. Kept separate from SetConfig so it can be
+// unit-tested without CAP_NET_ADMIN. A nil return means "use the default
+// interface". An empty LocalInterface is treated as "default" —
+// kubebuilder defaulting can be bypassed by programmatic clients, and
+// compiling "" would yield a match-everything regex. The election's
+// SelectorFromConfig applies the identical rule.
+func compileLocalInterface(spec *purelbv2.LBNodeAgentLocalSpec) (*regexp.Regexp, error) {
 	if spec.LocalInterface == "default" || spec.LocalInterface == "" {
-		a.localNameRegex = nil
-		return nil
+		return nil, nil
 	}
 	regex, err := regexp.Compile(spec.LocalInterface)
 	if err != nil {
-		return fmt.Errorf("error compiling regex \"%s\": %s", spec.LocalInterface, err.Error())
+		return nil, fmt.Errorf("error compiling regex \"%s\": %s", spec.LocalInterface, err.Error())
 	}
-	a.localNameRegex = regex
-	return nil
+	return regex, nil
 }
 
 func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.EndpointSlice) error {
@@ -188,8 +254,13 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 	nsName := svc.Namespace + "/" + svc.Name
 	l := log.With(a.logger, "service", nsName)
 
+	// Take the config snapshot ONCE for this whole cycle and thread it
+	// down. Re-reading a.cfg per dereference is what allowed a concurrent
+	// SetConfig to nil the spec out from under an in-flight announcement.
+	cfg := a.cfg.Load()
+
 	// if we haven't been configured then we won't announce
-	if a.config == nil {
+	if cfg == nil {
 		logging.Info(l, "event", "noConfig")
 		// We are not announcing anything: withdraw any address we may
 		// still hold and drop any slot that still names us. nodeSelector
@@ -226,14 +297,14 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			continue
 		}
 
-		if a.localNameRegex != nil {
+		if cfg.localNameRegex != nil {
 			// The user specified an announcement interface regex so use it to
 			// try to find a local interface
-			lbIPNet, localif, err := findLocal(a.localNameRegex, a.config.DummyInterface, lbIP)
+			lbIPNet, localif, err := findLocal(cfg.localNameRegex, cfg.spec.DummyInterface, lbIP)
 			if err != nil {
 				// The regex didn't resolve; try the explicitly-configured
 				// extra interfaces (spec.interfaces) before falling through.
-				if xNet, xIf, xErr := a.tryExtraInterfaces(lbIP); xErr == nil {
+				if xNet, xIf, xErr := a.tryExtraInterfaces(cfg, lbIP); xErr == nil {
 					lbIPNet, localif, err = xNet, xIf, nil
 				} else if errors.Is(xErr, errIndeterminate) {
 					err = xErr
@@ -241,12 +312,12 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			}
 			if err == nil {
 				// We found a local interface, announce the address on it
-				if err := a.announceLocal(svc, preferred, localif, lbIP, lbIPNet); err != nil {
+				if err := a.announceLocal(cfg, svc, preferred, localif, lbIP, lbIPNet); err != nil {
 					retErr = err
 				}
-			} else if a.isRemotePool(lbIP) {
+			} else if a.isRemotePool(cfg, lbIP) {
 				// lbIP is from a remote pool, so add it to dummyInt
-				if err := a.announceRemote(svc, epSlices, a.dummyInt, lbIP); err != nil {
+				if err := a.announceRemote(cfg, svc, epSlices, lbIP); err != nil {
 					retErr = err
 				}
 			} else if errors.Is(err, errIndeterminate) {
@@ -275,7 +346,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			var localif netlink.Link
 			announceInt, err := netutil.DefaultInterface(purelbv2.AddrFamily(lbIP))
 			if err != nil {
-				if len(a.config.Interfaces) == 0 {
+				if len(cfg.spec.Interfaces) == 0 {
 					// No fallback interfaces configured: keep the historical
 					// hard-error path.
 					logging.Info(l, "event", "announceError", "err", err)
@@ -289,7 +360,7 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 				// The default interface didn't resolve; try the
 				// explicitly-configured extra interfaces (spec.interfaces)
 				// before falling through.
-				if xNet, xIf, xErr := a.tryExtraInterfaces(lbIP); xErr == nil {
+				if xNet, xIf, xErr := a.tryExtraInterfaces(cfg, lbIP); xErr == nil {
 					lbIPNet, localif, err = xNet, xIf, nil
 				} else if errors.Is(xErr, errIndeterminate) {
 					err = xErr
@@ -297,12 +368,12 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 			}
 			if err == nil {
 				// We found a local interface, announce the address on it
-				if err := a.announceLocal(svc, preferred, localif, lbIP, lbIPNet); err != nil {
+				if err := a.announceLocal(cfg, svc, preferred, localif, lbIP, lbIPNet); err != nil {
 					retErr = err
 				}
-			} else if a.isRemotePool(lbIP) {
+			} else if a.isRemotePool(cfg, lbIP) {
 				// lbIP is from a remote pool, so add it to dummyInt
-				if err := a.announceRemote(svc, epSlices, a.dummyInt, lbIP); err != nil {
+				if err := a.announceRemote(cfg, svc, epSlices, lbIP); err != nil {
 					retErr = err
 				}
 			} else if errors.Is(err, errIndeterminate) {
@@ -340,10 +411,10 @@ func (a *announcer) SetBalancer(svc *v1.Service, epSlices []*discoveryv1.Endpoin
 // errIndeterminate when a candidate's address dump was partial and
 // none succeeded, so the caller can avoid withdrawing on uncertain
 // evidence.
-func (a *announcer) tryExtraInterfaces(lbIP net.IP) (net.IPNet, netlink.Link, error) {
+func (a *announcer) tryExtraInterfaces(cfg *announcerConfig, lbIP net.IP) (net.IPNet, netlink.Link, error) {
 	indeterminate := false
-	for _, name := range a.config.Interfaces {
-		if name == "" || name == a.config.DummyInterface {
+	for _, name := range cfg.spec.Interfaces {
+		if name == "" || name == cfg.spec.DummyInterface {
 			continue
 		}
 		nlIntf, err := netlink.LinkByName(name)
@@ -366,7 +437,7 @@ func (a *announcer) tryExtraInterfaces(lbIP net.IP) (net.IPNet, netlink.Link, er
 	return net.IPNet{}, nil, fmt.Errorf("no extra interface matched")
 }
 
-func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceInt netlink.Link, lbIP net.IP, lbIPNet net.IPNet) error {
+func (a *announcer) announceLocal(cfg *announcerConfig, svc *v1.Service, preferred []string, announceInt netlink.Link, lbIP net.IP, lbIPNet net.IPNet) error {
 	l := log.With(a.logger, "service", svc.Name)
 	nsName := svc.Namespace + "/" + svc.Name
 
@@ -420,7 +491,7 @@ func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceI
 	logging.Info(l, "msg", "electionWon", "node", a.myNode, "service", nsName, "memberCount", a.election.MemberCount())
 	a.client.Infof(svc, "AnnouncingLocal", "Node %s announcing %s on interface %s", a.myNode, lbIP, announceInt.Attrs().Name)
 
-	opts := a.getLocalAddressOptions()
+	opts := getLocalAddressOptions(cfg)
 	// IPv6 has no IFA_F_SECONDARY equivalent, so flannel can pick VIPs as the
 	// node's public IPv6 address, breaking overlay routing. Setting PreferedLft=0
 	// marks the address as deprecated (IFA_F_DEPRECATED), which flannel's
@@ -459,12 +530,16 @@ func (a *announcer) announceLocal(svc *v1.Service, preferred []string, announceI
 	// DAD, whose probes are sourced from :: and update no neighbor
 	// caches (and the skip-DAD annotation suppresses even those) — so
 	// without the NA a moved IPv6 VIP converges only via NUD timeouts.
-	a.sendGARPSequence(lbIP, announceInt.Attrs().Name)
+	a.sendGARPSequence(cfg, lbIP, announceInt.Attrs().Name)
 
 	return nil
 }
 
-func (a *announcer) announceRemote(svc *v1.Service, epSlices []*discoveryv1.EndpointSlice, announceInt netlink.Link, lbIP net.IP) error {
+// The announcement interface is always cfg.dummyInt. It used to also be
+// passed in as a parameter that the body then ignored in favour of the
+// field -- exactly the kind of "which one is live?" ambiguity that made
+// the config race hard to see -- so the parameter is gone.
+func (a *announcer) announceRemote(cfg *announcerConfig, svc *v1.Service, epSlices []*discoveryv1.EndpointSlice, lbIP net.IP) error {
 	l := log.With(a.logger, "service", svc.Name)
 	nsName := svc.Namespace + "/" + svc.Name
 
@@ -501,25 +576,25 @@ func (a *announcer) announceRemote(svc *v1.Service, epSlices []*discoveryv1.Endp
 
 	// Find the group from which this address was allocated, which
 	// gives us the subnet and aggregation that we need.
-	groupName, group, err := a.poolFor(lbIP)
+	groupName, group, err := a.poolFor(cfg, lbIP)
 	if err != nil {
 		return err
 	}
 
-	logging.Info(l, "msg", "announcingNonLocal", "node", a.myNode, "service", nsName, "interface", a.dummyInt.Attrs().Name, "group", groupName)
-	a.client.Infof(svc, "AnnouncingNonLocal", "Announcing %s from node %s interface %s", lbIP, a.myNode, a.dummyInt.Attrs().Name)
+	logging.Info(l, "msg", "announcingNonLocal", "node", a.myNode, "service", nsName, "interface", cfg.dummyInt.Attrs().Name, "group", groupName)
+	a.client.Infof(svc, "AnnouncingNonLocal", "Announcing %s from node %s interface %s", lbIP, a.myNode, cfg.dummyInt.Attrs().Name)
 
 	// Add this address to the dummy interface so routing software
 	// (e.g., bird) will announce routes for it.
 	logging.Debug(l, "msg", "subnet", "node", a.myNode, "service", nsName, "pool", group)
-	opts := a.getDummyAddressOptions()
-	lbIPNet, err := addVirtualInt(lbIP, a.dummyInt, group.Subnet, group.Aggregation, opts)
+	opts := getDummyAddressOptions(cfg)
+	lbIPNet, err := addVirtualInt(lbIP, cfg.dummyInt, group.Subnet, group.Aggregation, opts)
 	if err != nil {
 		return err
 	}
 	RecordAddressAddition()
 	a.announced.Store(renewalKey(nsName, lbIP.String()), struct{}{})
-	a.scheduleRenewal(nsName, lbIPNet, a.dummyInt, opts)
+	a.scheduleRenewal(nsName, lbIPNet, cfg.dummyInt, opts)
 
 	// The announcing annotation for remote pools is derived by consumers
 	// from pool-type=remote + the LBNodeAgent CR's dummy interface name.
@@ -615,8 +690,12 @@ func (a *announcer) Shutdown() {
 	// Withdraw all announcements first
 	a.WithdrawAll()
 
-	// remove the "dummy" interface
-	removeInterface(a.dummyInt)
+	// remove the "dummy" interface. Guarded: if no config was ever
+	// accepted there is no interface to remove, and removeInterface would
+	// call Attrs() on a nil Link and panic on the way out.
+	if cfg := a.cfg.Load(); cfg != nil && cfg.dummyInt != nil {
+		removeInterface(cfg.dummyInt)
+	}
 }
 
 // WithdrawAll withdraws all announcements without removing the dummy interface.
@@ -754,16 +833,16 @@ func addrFamilyName(lbIP net.IP) (lbIPFamily string) {
 // poolFor returns the name and AddressPool that contains lbIP.
 // It checks both local and remote ServiceGroups.
 // If error is not nil then no pool was found.
-func (a *announcer) poolFor(lbIP net.IP) (string, *purelbv2.AddressPool, error) {
+func (a *announcer) poolFor(cfg *announcerConfig, lbIP net.IP) (string, *purelbv2.AddressPool, error) {
 	// Check local groups first
-	for groupName, group := range a.groups {
+	for groupName, group := range cfg.groups {
 		pool, err := group.PoolForAddress(lbIP)
 		if err == nil {
 			return groupName, pool, nil
 		}
 	}
 	// Check remote groups
-	for groupName, group := range a.remoteGroups {
+	for groupName, group := range cfg.remoteGroups {
 		pool, err := group.PoolForAddress(lbIP)
 		if err == nil {
 			return groupName, pool, nil
@@ -775,8 +854,8 @@ func (a *announcer) poolFor(lbIP net.IP) (string, *purelbv2.AddressPool, error) 
 // isRemotePool returns true if the IP address belongs to a remote pool.
 // Remote pools should be announced on kube-lb0, while local pools should
 // only be announced on matching local interfaces (or not at all if no match).
-func (a *announcer) isRemotePool(lbIP net.IP) bool {
-	for _, group := range a.remoteGroups {
+func (a *announcer) isRemotePool(cfg *announcerConfig, lbIP net.IP) bool {
+	for _, group := range cfg.remoteGroups {
 		_, err := group.PoolForAddress(lbIP)
 		if err == nil {
 			return true
@@ -1007,15 +1086,15 @@ func (a *announcer) cancelRenewal(svcName, ip string) {
 // getLocalAddressOptions returns the AddressOptions for addresses added to
 // the local interface. Defaults to finite lifetime (300s) with NoPrefixRoute
 // to prevent CNI plugins like Flannel from selecting VIPs as node addresses.
-func (a *announcer) getLocalAddressOptions() AddressOptions {
+func getLocalAddressOptions(c *announcerConfig) AddressOptions {
 	opts := AddressOptions{
 		ValidLft:      300, // default 5 minutes
 		PreferedLft:   300,
 		NoPrefixRoute: true,
 	}
 
-	if a.config != nil && a.config.AddressConfig != nil && a.config.AddressConfig.LocalInterface != nil {
-		cfg := a.config.AddressConfig.LocalInterface
+	if c != nil && c.spec.AddressConfig != nil && c.spec.AddressConfig.LocalInterface != nil {
+		cfg := c.spec.AddressConfig.LocalInterface
 		if cfg.ValidLifetime != nil {
 			v := *cfg.ValidLifetime
 			// Enforce minimum 60s if non-zero to prevent DoS via tiny lifetime
@@ -1046,12 +1125,12 @@ func (a *announcer) getLocalAddressOptions() AddressOptions {
 // Advertisements for IPv6 (its protocol counterpart — same config
 // gate, delay, count, interval and verify-before-send semantics).
 // The sequence runs in a goroutine to avoid blocking the main announcement.
-func (a *announcer) sendGARPSequence(lbIP net.IP, ifName string) {
-	if a.config == nil || a.config.GARPConfig == nil {
+func (a *announcer) sendGARPSequence(c *announcerConfig, lbIP net.IP, ifName string) {
+	if c == nil || c.spec.GARPConfig == nil {
 		return // GARP not configured
 	}
 
-	cfg := a.config.GARPConfig
+	cfg := c.spec.GARPConfig
 
 	// Check if enabled (defaults to true when GARPConfig is set)
 	if cfg.Enabled != nil && !*cfg.Enabled {
@@ -1150,15 +1229,15 @@ func (a *announcer) sendGARPSequence(lbIP net.IP, ifName string) {
 // getDummyAddressOptions returns the AddressOptions for addresses added to
 // the dummy interface. Defaults to permanent (0) since these don't conflict
 // with CNI plugins and permanent addresses provide routing stability.
-func (a *announcer) getDummyAddressOptions() AddressOptions {
+func getDummyAddressOptions(c *announcerConfig) AddressOptions {
 	opts := AddressOptions{
 		ValidLft:      0, // default permanent
 		PreferedLft:   0,
 		NoPrefixRoute: false,
 	}
 
-	if a.config != nil && a.config.AddressConfig != nil && a.config.AddressConfig.DummyInterface != nil {
-		cfg := a.config.AddressConfig.DummyInterface
+	if c != nil && c.spec.AddressConfig != nil && c.spec.AddressConfig.DummyInterface != nil {
+		cfg := c.spec.AddressConfig.DummyInterface
 		if cfg.ValidLifetime != nil {
 			v := *cfg.ValidLifetime
 			// Enforce minimum 60s if non-zero

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mdlayher/ndp"
 	ptu "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -266,12 +267,8 @@ func TestOtherAnnouncerOf_IgnoresUnannouncedServices(t *testing.T) {
 }
 
 func TestGetLocalAddressOptions_Defaults(t *testing.T) {
-	a := &announcer{
-		logger: log.NewNopLogger(),
-		config: nil, // No config
-	}
-
-	opts := a.getLocalAddressOptions()
+	// nil snapshot == not configured; the helper must still yield defaults.
+	opts := getLocalAddressOptions(nil)
 
 	assert.Equal(t, 300, opts.ValidLft, "default ValidLft should be 300")
 	assert.Equal(t, 300, opts.PreferedLft, "default PreferedLft should be 300")
@@ -355,9 +352,8 @@ func TestGetLocalAddressOptions_WithConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &announcer{
-				logger: log.NewNopLogger(),
-				config: &purelbv2.LBNodeAgentLocalSpec{
+			c := &announcerConfig{
+				spec: &purelbv2.LBNodeAgentLocalSpec{
 					AddressConfig: &purelbv2.AddressConfig{
 						LocalInterface: &purelbv2.InterfaceAddressConfig{
 							ValidLifetime:     tt.validLifetime,
@@ -368,7 +364,7 @@ func TestGetLocalAddressOptions_WithConfig(t *testing.T) {
 				},
 			}
 
-			opts := a.getLocalAddressOptions()
+			opts := getLocalAddressOptions(c)
 
 			assert.Equal(t, tt.expectedValid, opts.ValidLft, "ValidLft mismatch")
 			assert.Equal(t, tt.expectedPreferred, opts.PreferedLft, "PreferedLft mismatch")
@@ -378,12 +374,8 @@ func TestGetLocalAddressOptions_WithConfig(t *testing.T) {
 }
 
 func TestGetDummyAddressOptions_Defaults(t *testing.T) {
-	a := &announcer{
-		logger: log.NewNopLogger(),
-		config: nil, // No config
-	}
-
-	opts := a.getDummyAddressOptions()
+	// nil snapshot == not configured; the helper must still yield defaults.
+	opts := getDummyAddressOptions(nil)
 
 	assert.Equal(t, 0, opts.ValidLft, "default ValidLft should be 0 (permanent)")
 	assert.Equal(t, 0, opts.PreferedLft, "default PreferedLft should be 0 (permanent)")
@@ -431,9 +423,8 @@ func TestGetDummyAddressOptions_WithConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &announcer{
-				logger: log.NewNopLogger(),
-				config: &purelbv2.LBNodeAgentLocalSpec{
+			c := &announcerConfig{
+				spec: &purelbv2.LBNodeAgentLocalSpec{
 					AddressConfig: &purelbv2.AddressConfig{
 						DummyInterface: &purelbv2.InterfaceAddressConfig{
 							ValidLifetime:     tt.validLifetime,
@@ -444,7 +435,7 @@ func TestGetDummyAddressOptions_WithConfig(t *testing.T) {
 				},
 			}
 
-			opts := a.getDummyAddressOptions()
+			opts := getDummyAddressOptions(c)
 
 			assert.Equal(t, tt.expectedValid, opts.ValidLft, "ValidLft mismatch")
 			assert.Equal(t, tt.expectedPreferred, opts.PreferedLft, "PreferedLft mismatch")
@@ -482,26 +473,25 @@ func TestGetAddressOptions_NilConfigLevels(t *testing.T) {
 		},
 	}
 
+	// A nil spec never appears in a published snapshot -- "not configured"
+	// is a nil *announcerConfig -- so that case maps to a nil snapshot.
+	snapshot := func(spec *purelbv2.LBNodeAgentLocalSpec) *announcerConfig {
+		if spec == nil {
+			return nil
+		}
+		return &announcerConfig{spec: spec}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name+" local", func(t *testing.T) {
-			a := &announcer{
-				logger: log.NewNopLogger(),
-				config: tt.config,
-			}
-
 			// Should not panic
-			opts := a.getLocalAddressOptions()
+			opts := getLocalAddressOptions(snapshot(tt.config))
 			assert.Equal(t, 300, opts.ValidLft, "default ValidLft")
 		})
 
 		t.Run(tt.name+" dummy", func(t *testing.T) {
-			a := &announcer{
-				logger: log.NewNopLogger(),
-				config: tt.config,
-			}
-
 			// Should not panic
-			opts := a.getDummyAddressOptions()
+			opts := getDummyAddressOptions(snapshot(tt.config))
 			assert.Equal(t, 0, opts.ValidLft, "default ValidLft")
 		})
 	}
@@ -768,7 +758,7 @@ func TestSkipDADFromServiceAnnotation(t *testing.T) {
 // =================================================================
 
 // ptrBool returns &b. Required because EndpointConditions fields are pointers.
-func ptrBool(b bool) *bool { return &b }
+func ptrBool(b bool) *bool    { return &b }
 func ptrStr(s string) *string { return &s }
 
 // makeSlice builds a single-slice EndpointSlice list for tests. Each
@@ -875,32 +865,32 @@ func TestBuildPreferredNodes(t *testing.T) {
 	})
 }
 
-func TestApplyLocalSpec(t *testing.T) {
-	t.Run("default clears regex", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(), localNameRegex: regexp.MustCompile("stale")}
-		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "default"}))
-		assert.Nil(t, a.localNameRegex)
+func TestCompileLocalInterface(t *testing.T) {
+	t.Run("default yields no regex", func(t *testing.T) {
+		re, err := compileLocalInterface(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "default"})
+		assert.NoError(t, err)
+		assert.Nil(t, re)
 	})
 
 	t.Run("empty treated as default", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(), localNameRegex: regexp.MustCompile("stale")}
-		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: ""}))
-		assert.Nil(t, a.localNameRegex)
+		re, err := compileLocalInterface(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: ""})
+		assert.NoError(t, err)
+		assert.Nil(t, re)
 	})
 
 	t.Run("regex compiled", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger()}
-		assert.NoError(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^(eth1|eth2)$"}))
-		if assert.NotNil(t, a.localNameRegex) {
-			assert.True(t, a.localNameRegex.MatchString("eth1"))
-			assert.False(t, a.localNameRegex.MatchString("eth10"))
+		re, err := compileLocalInterface(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^(eth1|eth2)$"})
+		assert.NoError(t, err)
+		if assert.NotNil(t, re) {
+			assert.True(t, re.MatchString("eth1"))
+			assert.False(t, re.MatchString("eth10"))
 		}
 	})
 
 	t.Run("invalid regex errors", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger()}
-		assert.Error(t, a.applyLocalSpec(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "["}))
-		assert.Nil(t, a.localNameRegex)
+		re, err := compileLocalInterface(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "["})
+		assert.Error(t, err)
+		assert.Nil(t, re)
 	})
 }
 
@@ -939,10 +929,16 @@ func TestTryExtraInterfaces(t *testing.T) {
 		return false
 	}
 
+	a := &announcer{logger: log.NewNopLogger()}
+	// tryExtraInterfaces reads its spec from the snapshot it is handed, not
+	// from announcer state, so each case just builds the snapshot it wants.
+	cfgFor := func(spec *purelbv2.LBNodeAgentLocalSpec) *announcerConfig {
+		return &announcerConfig{spec: spec}
+	}
+
 	t.Run("resolves IPv4 on explicit interface", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(),
-			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}}
-		ipnet, link, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		ipnet, link, err := a.tryExtraInterfaces(
+			cfgFor(&purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}), net.ParseIP("127.0.0.1"))
 		assert.NoError(t, err)
 		assert.Equal(t, "lo", link.Attrs().Name)
 		assert.Equal(t, "127.0.0.1/8", ipnet.String())
@@ -952,32 +948,31 @@ func TestTryExtraInterfaces(t *testing.T) {
 		if !loV6() {
 			t.Skip("loopback has no IPv6 address")
 		}
-		a := &announcer{logger: log.NewNopLogger(),
-			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}}
-		_, link, err := a.tryExtraInterfaces(net.ParseIP("::1"))
+		_, link, err := a.tryExtraInterfaces(
+			cfgFor(&purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}}), net.ParseIP("::1"))
 		assert.NoError(t, err)
 		assert.Equal(t, "lo", link.Attrs().Name)
 	})
 
 	t.Run("dummy interface name skipped", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(),
-			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}, DummyInterface: "lo"}}
-		_, _, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		_, _, err := a.tryExtraInterfaces(
+			cfgFor(&purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"lo"}, DummyInterface: "lo"}),
+			net.ParseIP("127.0.0.1"))
 		assert.Error(t, err)
 	})
 
 	t.Run("missing interface skipped without error abort", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(),
-			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0", "lo"}}}
-		_, link, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		_, link, err := a.tryExtraInterfaces(
+			cfgFor(&purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0", "lo"}}),
+			net.ParseIP("127.0.0.1"))
 		assert.NoError(t, err)
 		assert.Equal(t, "lo", link.Attrs().Name)
 	})
 
 	t.Run("no candidate matches", func(t *testing.T) {
-		a := &announcer{logger: log.NewNopLogger(),
-			config: &purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0"}}}
-		_, _, err := a.tryExtraInterfaces(net.ParseIP("127.0.0.1"))
+		_, _, err := a.tryExtraInterfaces(
+			cfgFor(&purelbv2.LBNodeAgentLocalSpec{Interfaces: []string{"purelb-does-not-exist0"}}),
+			net.ParseIP("127.0.0.1"))
 		assert.Error(t, err)
 		assert.False(t, errors.Is(err, errIndeterminate))
 	})
@@ -987,15 +982,28 @@ func TestTryExtraInterfaces(t *testing.T) {
 // TEST-NET addresses (192.0.2.0/24 is never on a real interface, so
 // deleteAddr's scan is read-only and removes nothing) with a live
 // renewal timer, ready to be driven into a withdrawal path.
+// A nil config means "not configured" and is published as a nil snapshot,
+// which is what nodeSelector deselection and config removal produce.
+// Otherwise the snapshot is assembled exactly as SetConfig would, regex
+// included, so these tests exercise the same shape the real path publishes.
 func withdrawalTestAnnouncer(config *purelbv2.LBNodeAgentLocalSpec) *announcer {
 	a := &announcer{
 		logger:       log.NewNopLogger(),
 		myNode:       "node-a",
 		client:       nopServiceEvent{},
-		config:       config,
-		groups:       map[string]*purelbv2.ServiceGroupLocalSpec{},
-		remoteGroups: map[string]*purelbv2.ServiceGroupRemoteSpec{},
 		svcIngresses: map[string][]v1.LoadBalancerIngress{},
+	}
+	if config != nil {
+		regex, err := compileLocalInterface(config)
+		if err != nil {
+			panic(err) // test fixture: a bad regex here is a test bug
+		}
+		a.cfg.Store(&announcerConfig{
+			spec:           config,
+			groups:         map[string]*purelbv2.ServiceGroupLocalSpec{},
+			remoteGroups:   map[string]*purelbv2.ServiceGroupRemoteSpec{},
+			localNameRegex: regex,
+		})
 	}
 	return a
 }
@@ -1011,8 +1019,9 @@ func announceForTest(a *announcer, nsName, ip string) {
 
 func TestSetBalancerWithdrawsOnNoLocalInterface(t *testing.T) {
 	const slotKey = "purelb.io/announcing-IPv4"
+	// withdrawalTestAnnouncer compiles LocalInterface into the snapshot, so
+	// the regex no longer has to be poked in separately.
 	a := withdrawalTestAnnouncer(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^purelb-nomatch$"})
-	a.localNameRegex = regexp.MustCompile("^purelb-nomatch$")
 
 	svc := lbSvc("192.0.2.1")
 	svc.Namespace = "default"
@@ -1048,6 +1057,134 @@ func TestSetBalancerWithdrawsOnNoConfig(t *testing.T) {
 	_, timerAlive := a.addressRenewals.Load(key)
 	assert.False(t, timerAlive, "renewal timer must be cancelled")
 	assert.Empty(t, svc.Annotations[slotKey], "announce slot must be cleared")
+}
+
+// TestSetConfigStoresNilWhenNoAgentSelectsNode covers the single most
+// dangerous line of the snapshot change. SetConfig used to blank the
+// config on entry, which implicitly meant "no agent => announce nothing".
+// Removing that blanking (it was the race window) means the no-agent path
+// has to store nil explicitly; if it ever stops doing so, a node whose
+// LBNodeAgent was deleted, or that a nodeSelector deselected, would keep
+// announcing on its last config forever.
+//
+// Reachable without CAP_NET_ADMIN because it returns before
+// addDummyInterface.
+func TestSetConfigStoresNilWhenNoAgentSelectsNode(t *testing.T) {
+	a := withdrawalTestAnnouncer(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^eth0$"})
+	assert.NotNil(t, a.cfg.Load(), "fixture should start configured")
+
+	// No agent has a Local spec: deselected, or the CR was deleted.
+	assert.NoError(t, a.SetConfig(&purelbv2.Config{Agents: nil}))
+	assert.Nil(t, a.cfg.Load(), "no governing agent must publish a nil snapshot")
+}
+
+// TestSetConfigStoresNilOnInvalidRegex checks the other fail-safe path: a
+// config the announcer rejects must not leave the previous one live, or
+// the node would announce on config the operator believes was replaced.
+func TestSetConfigStoresNilOnInvalidRegex(t *testing.T) {
+	a := withdrawalTestAnnouncer(&purelbv2.LBNodeAgentLocalSpec{LocalInterface: "^eth0$"})
+	assert.NotNil(t, a.cfg.Load(), "fixture should start configured")
+
+	err := a.SetConfig(&purelbv2.Config{Agents: []*purelbv2.LBNodeAgent{
+		{Spec: purelbv2.LBNodeAgentSpec{Local: &purelbv2.LBNodeAgentLocalSpec{LocalInterface: "["}}},
+	}})
+	assert.Error(t, err, "an uncompilable localInterface must be rejected")
+	assert.Nil(t, a.cfg.Load(), "a rejected config must publish a nil snapshot")
+}
+
+// TestSetBalancerConcurrentWithConfigSwap is the regression test for the
+// crash that restarted every node agent on the test cluster: SetConfig
+// (CR-controller goroutine) publishing config while SetBalancer
+// (service-sync goroutine) was mid-announcement.
+//
+// Before the snapshot change this reproduced two distinct failures --
+// a nil dereference of the spec pointer in tryExtraInterfaces, and
+// "concurrent map iteration and map write" on groups/remoteGroups, the
+// latter a runtime fatal error that no recover() can catch.
+//
+// The writer is the real SetConfig, not a bare a.cfg.Store: driving the
+// production writer is what makes this a regression test rather than a
+// test of the fixture. Verified by temporarily restoring the pre-fix
+// unsynchronized field, which makes this fail with a DATA RACE whose
+// stack is the one seen in the crash-looping pods --
+// tryExtraInterfaces <- SetBalancer against SetConfig.
+//
+// SetConfig ends in addDummyInterface, which needs CAP_NET_ADMIN. Both
+// outcomes are useful: unprivileged, it fails and publishes a nil
+// snapshot (exercising the fail-safe path); privileged, it publishes a
+// real one. The interface is named distinctively and removed on cleanup
+// so a root test run leaves nothing behind.
+//
+// TEST-NET-1 addresses are never present on a real interface, so the
+// netlink work the reader drives is read-only.
+func TestSetBalancerConcurrentWithConfigSwap(t *testing.T) {
+	const tmpDummy = "purelb-race-test0"
+
+	a := withdrawalTestAnnouncer(&purelbv2.LBNodeAgentLocalSpec{
+		LocalInterface: "^purelb-nomatch$",
+		Interfaces:     []string{"purelb-does-not-exist0", "lo"},
+	})
+
+	t.Cleanup(func() {
+		if link, err := netlink.LinkByName(tmpDummy); err == nil {
+			_ = removeInterface(link)
+		}
+	})
+
+	// Alternating deliveries: one that selects this node and one that
+	// deselects it, so the writer exercises both the publish and the
+	// store-nil paths the way a nodeSelector change does.
+	configured := &purelbv2.Config{Agents: []*purelbv2.LBNodeAgent{
+		{Spec: purelbv2.LBNodeAgentSpec{Local: &purelbv2.LBNodeAgentLocalSpec{
+			LocalInterface: "^purelb-nomatch$",
+			Interfaces:     []string{"purelb-does-not-exist0", "lo"},
+			DummyInterface: tmpDummy,
+		}}},
+		{Spec: purelbv2.LBNodeAgentSpec{Local: nil}},
+	}}
+	deselected := &purelbv2.Config{Agents: nil}
+
+	const iterations = 500
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Errors are expected without CAP_NET_ADMIN and are not the
+			// point; the point is that the reader never observes a
+			// half-applied config.
+			if i%4 == 3 {
+				_ = a.SetConfig(deselected)
+				continue
+			}
+			_ = a.SetConfig(configured)
+		}
+	}()
+
+	// Exactly one reader. SetBalancer writes svcIngresses, which is
+	// deliberately unsynchronized because production only ever calls it
+	// from the single service-sync goroutine; a second reader here would
+	// manufacture a map race that cannot happen in the real agent and
+	// would test the fixture rather than the fix.
+	svc := lbSvc("192.0.2.1")
+	svc.Namespace = "default"
+	svc.Name = "test-svc"
+	for i := 0; i < iterations; i++ {
+		// Errors are expected and irrelevant: nothing on this host holds
+		// a TEST-NET address. The assertion is that this neither panics
+		// nor trips the race detector.
+		_ = a.SetBalancer(svc, nil)
+	}
+
+	close(stop)
+	writer.Wait()
 }
 
 func TestWithdrawalSharedIPRefcount(t *testing.T) {

--- a/internal/local/announcer_local_test.go
+++ b/internal/local/announcer_local_test.go
@@ -540,7 +540,7 @@ func TestScheduleRenewal_FiniteLifetime(t *testing.T) {
 	assert.Equal(t, 150*time.Second, renewal.interval, "renewal interval should be 50% of lifetime")
 
 	// Clean up timer
-	renewal.timer.Stop()
+	renewal.stopTimer()
 }
 
 func TestScheduleRenewal_MinimumInterval(t *testing.T) {
@@ -566,7 +566,7 @@ func TestScheduleRenewal_MinimumInterval(t *testing.T) {
 	assert.Equal(t, 30*time.Second, renewal.interval, "renewal interval should be at minimum 30s")
 
 	// Clean up timer
-	renewal.timer.Stop()
+	renewal.stopTimer()
 }
 
 func TestScheduleRenewal_ReplacesExisting(t *testing.T) {
@@ -600,7 +600,7 @@ func TestScheduleRenewal_ReplacesExisting(t *testing.T) {
 	assert.NotEqual(t, interval1, renewal2.interval, "interval should be different after replacement")
 
 	// Clean up timer
-	renewal2.timer.Stop()
+	renewal2.stopTimer()
 }
 
 func TestCancelRenewal(t *testing.T) {
@@ -668,7 +668,7 @@ func TestScheduleRenewal_ConcurrentAccess(t *testing.T) {
 
 	// Clean up any remaining timers
 	a.addressRenewals.Range(func(key, val interface{}) bool {
-		val.(*addressRenewal).timer.Stop()
+		val.(*addressRenewal).stopTimer()
 		return true
 	})
 }
@@ -1185,6 +1185,93 @@ func TestSetBalancerConcurrentWithConfigSwap(t *testing.T) {
 
 	close(stop)
 	writer.Wait()
+}
+
+// TestRenewalTimerConcurrentWithSchedule is the regression test for the
+// addressRenewal.timer race: renewAddress re-arms the timer on the timer's
+// own goroutine while scheduleRenewal Stops it on the service-sync
+// goroutine, which happens whenever a Service is re-announced as its
+// renewal fires.
+//
+// scheduleRenewal is the pairing that was wide open, because it Stopped the
+// superseded timer without consulting cancelled. cancelRenewal and
+// WithdrawAll set cancelled before Stop and renewAddress re-checks it, which
+// narrows their window to a couple of instructions but does not close it --
+// so timer is atomic rather than flag-gated, which fixes all three at once.
+//
+// Verified to catch the defect by reverting timer to a plain *time.Timer,
+// which makes this fail with a DATA RACE pairing renewAddress's re-arm
+// against scheduleRenewal's Stop.
+//
+// A real link is used so renewAddress gets past addNetworkWithOptions;
+// unprivileged the call fails, which still falls through to the re-arm.
+// TEST-NET-1 means nothing is configured on the host either way.
+func TestRenewalTimerConcurrentWithSchedule(t *testing.T) {
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		t.Skip("no loopback interface")
+	}
+	a := &announcer{logger: log.NewNopLogger(), myNode: "node-a", client: nopServiceEvent{}}
+
+	const nsName = "default/renew-race"
+	ipnet := net.IPNet{IP: net.ParseIP("192.0.2.1"), Mask: net.CIDRMask(24, 32)}
+	key := renewalKey(nsName, ipnet.IP.String())
+	opts := AddressOptions{ValidLft: 300, PreferedLft: 300}
+
+	for i := 0; i < 300; i++ {
+		r := &addressRenewal{ipNet: ipnet, link: lo, opts: opts, interval: time.Hour}
+		r.timer.Store(time.AfterFunc(time.Hour, func() {}))
+		a.addressRenewals.Store(key, r)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() { // the fired renewal timer, re-arming itself
+			defer wg.Done()
+			a.renewAddress(key)
+		}()
+		// service-sync goroutine re-announcing the same address
+		a.scheduleRenewal(nsName, ipnet, lo, opts)
+		wg.Wait()
+	}
+
+	// Leave no timers behind for other tests in the package.
+	a.addressRenewals.Range(func(k, v interface{}) bool {
+		v.(*addressRenewal).cancelled.Store(true)
+		v.(*addressRenewal).stopTimer()
+		a.addressRenewals.Delete(k)
+		return true
+	})
+}
+
+// TestScheduleRenewalCancelsSupersededTimer covers the second half of the
+// same fix. scheduleRenewal replaces a renewal wholesale, so the superseded
+// one must be marked cancelled and not merely Stopped: an in-flight
+// renewAddress re-checks that flag before re-arming, and without it a
+// Stopped timer could arm itself again and go on firing untracked, with
+// nothing left in the map to cancel it.
+func TestScheduleRenewalCancelsSupersededTimer(t *testing.T) {
+	a := &announcer{logger: log.NewNopLogger(), myNode: "node-a", client: nopServiceEvent{}}
+
+	const nsName = "default/superseded"
+	ipnet := net.IPNet{IP: net.ParseIP("192.0.2.2"), Mask: net.CIDRMask(24, 32)}
+	key := renewalKey(nsName, ipnet.IP.String())
+	opts := AddressOptions{ValidLft: 300, PreferedLft: 300}
+
+	a.scheduleRenewal(nsName, ipnet, nil, opts)
+	first, ok := a.addressRenewals.Load(key)
+	assert.True(t, ok, "first renewal should be tracked")
+
+	a.scheduleRenewal(nsName, ipnet, nil, opts)
+	second, ok := a.addressRenewals.Load(key)
+	assert.True(t, ok, "replacement renewal should be tracked")
+	assert.NotSame(t, first, second, "scheduleRenewal should install a new renewal")
+
+	assert.True(t, first.(*addressRenewal).cancelled.Load(),
+		"superseded renewal must be marked cancelled, not just stopped")
+	assert.False(t, second.(*addressRenewal).cancelled.Load(),
+		"the live renewal must not be marked cancelled")
+
+	a.cancelRenewal(nsName, ipnet.IP.String())
 }
 
 func TestWithdrawalSharedIPRefcount(t *testing.T) {

--- a/pkg/apis/purelb/v2/config.go
+++ b/pkg/apis/purelb/v2/config.go
@@ -27,4 +27,12 @@ type Config struct {
 
 	// Agents contains all LBNodeAgent resources from the cluster.
 	Agents []*LBNodeAgent
+
+	// DroppedGroups contains ServiceGroups that were listed but excluded
+	// from Groups, so that consumers can report them. They are carried
+	// rather than discarded because the filtering happens in a code path
+	// shared by both binaries, while the events belong to exactly one of
+	// them -- emitting from the shared path would produce one event per
+	// node per reconcile.
+	DroppedGroups []*ServiceGroup
 }

--- a/pkg/apis/purelb/v2/nsselect.go
+++ b/pkg/apis/purelb/v2/nsselect.go
@@ -1,0 +1,42 @@
+// Copyright 2020-2026 Acnodal Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import "slices"
+
+// ServesNamespace reports whether a Service in namespace may allocate from
+// sg, considering spec.namespaces only.
+//
+// A ServiceGroup with no Namespaces entries serves every namespace. That is
+// the behaviour of every ServiceGroup written before the field existed, so
+// absence must never be read as "serves nothing".
+//
+// This deliberately ignores EnforceNamespaces. Whether the list is a boundary
+// or merely a default is the caller's question; this answers only whether the
+// namespace is in it.
+func ServesNamespace(sg *ServiceGroup, namespace string) bool {
+	if sg == nil || IsNamespaceCatchAll(sg) {
+		return true
+	}
+	return slices.Contains(sg.Spec.Namespaces, namespace)
+}
+
+// IsNamespaceCatchAll reports whether sg names no namespace and therefore
+// serves all of them. Exported because the kubectl plugin has to classify
+// ServiceGroups exactly as the allocator does when it explains a decision;
+// two implementations of this rule would drift.
+func IsNamespaceCatchAll(sg *ServiceGroup) bool {
+	return sg == nil || len(sg.Spec.Namespaces) == 0
+}

--- a/pkg/apis/purelb/v2/types.go
+++ b/pkg/apis/purelb/v2/types.go
@@ -41,6 +41,9 @@ import (
 // +kubebuilder:printcolumn:name="Allocated-V6",type=integer,JSONPath=`.status.allocatedIPv6`,priority=1
 // +kubebuilder:printcolumn:name="Available-V4",type=integer,JSONPath=`.status.availableIPv4`,priority=1
 // +kubebuilder:printcolumn:name="Available-V6",type=integer,JSONPath=`.status.availableIPv6`,priority=1
+// +kubebuilder:printcolumn:name="Namespaces",type=string,JSONPath=`.spec.namespaces`,priority=1
+// +kubebuilder:printcolumn:name="Enforced",type=boolean,JSONPath=`.spec.enforceNamespaces`,priority=1
+// +kubebuilder:printcolumn:name="Bound",type=string,JSONPath=`.status.boundNamespaces`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type ServiceGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -59,6 +62,8 @@ type ServiceGroup struct {
 // - External: IP addresses managed by an external IPAM system reached via a sidecar process
 //
 // +kubebuilder:validation:XValidation:rule="(has(self.local) ? 1 : 0) + (has(self.remote) ? 1 : 0) + (has(self.external) ? 1 : 0) == 1",message="exactly one of local, remote, or external must be specified"
+// +kubebuilder:validation:XValidation:rule="!self.enforceNamespaces || (has(self.namespaces) && size(self.namespaces) > 0)",message="enforceNamespaces requires a non-empty namespaces list, otherwise it silently enforces nothing"
+// +kubebuilder:validation:XValidation:rule="!self.namespaceDefault || (has(self.namespaces) && size(self.namespaces) > 0)",message="namespaceDefault requires a non-empty namespaces list, otherwise it defaults nothing"
 type ServiceGroupSpec struct {
 	// Local configures a pool of IP addresses that will be announced
 	// on the node's local interface (the interface with the default route).
@@ -78,6 +83,71 @@ type ServiceGroupSpec struct {
 	// where to dial.
 	// +optional
 	External *ServiceGroupExternalSpec `json:"external,omitempty"`
+
+	// Namespaces lists the Service namespaces this ServiceGroup serves. A
+	// Service in a listed namespace that carries no purelb.io/service-group
+	// annotation allocates from here. Empty or absent means every namespace,
+	// which is how every ServiceGroup behaved before this field existed.
+	//
+	// Several ServiceGroups may serve one namespace, and that is normal: a
+	// ServiceGroup is exactly one of local, remote or external, so a tenant
+	// wanting both L2 and BGP addresses needs two. The list therefore
+	// establishes eligibility, not ownership. Where more than one serves a
+	// namespace, NamespaceDefault picks which an unannotated Service gets.
+	//
+	// By itself this is a default, not a boundary: an annotation still
+	// overrides it in both directions. Set EnforceNamespaces to make it a
+	// boundary.
+	//
+	// A literal list rather than a label selector is deliberate. A boundary
+	// defined by labels widens the moment somebody labels a namespace,
+	// whereas a list can only widen by an explicit edit to this spec.
+	//
+	// +kubebuilder:validation:MaxItems=1024
+	// +kubebuilder:validation:items:MaxLength=63
+	// +kubebuilder:validation:items:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +optional
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// EnforceNamespaces turns Namespaces from a default into a boundary.
+	// When true, a Service outside the list cannot allocate from this group
+	// even by naming it in purelb.io/service-group or pinning one of its
+	// addresses; and a Service inside the list cannot allocate from any
+	// ServiceGroup that does not serve its namespace.
+	//
+	// Enforcement is a property of the NAMESPACE, not of a single
+	// ServiceGroup: setting this on any one of a namespace's ServiceGroups
+	// fences that namespace completely, in both directions. Otherwise
+	// fencing a tenant's L2 pool would leave its BGP pool reachable from
+	// everywhere.
+	//
+	// This is an allocation control, not RBAC. PureLB ships no admission
+	// webhook, so a refused Service is created and simply never gets an
+	// address. It is also not retroactive: addresses already held are never
+	// revoked, so enabling this enforces nothing that is already allocated.
+	//
+	// Off by default and opt-in per group, so a boundary can be adopted one
+	// namespace at a time.
+	//
+	// +kubebuilder:default=false
+	// +optional
+	EnforceNamespaces bool `json:"enforceNamespaces,omitempty"`
+
+	// NamespaceDefault marks this ServiceGroup as the one an unannotated
+	// Service gets, for every namespace in Namespaces.
+	//
+	// It matters only where two or more ServiceGroups serve the same
+	// namespace. Where only one does, it is the default and this field is
+	// ignored. Where several do and none or more than one is marked, an
+	// unannotated Service falls back to the "default" pool if the namespace
+	// is not enforcing, or is denied if it is; either way a warning names
+	// the candidates. There is deliberately no implicit tie-break: an
+	// operator running both an L2 and a BGP pool for a tenant must say which
+	// one an unannotated Service gets.
+	//
+	// +kubebuilder:default=false
+	// +optional
+	NamespaceDefault bool `json:"namespaceDefault,omitempty"`
 }
 
 // ServiceGroupLocalSpec configures a local IP address pool.
@@ -281,6 +351,22 @@ type AddressPool struct {
 // populated by the allocator as services are assigned and released.
 // Values may briefly lag the spec after a config change.
 type ServiceGroupStatus struct {
+	// BoundNamespaces is the namespace list the allocator parsed from this
+	// ServiceGroup. It confirms what PureLB actually read, which is not the
+	// same question as what the API server accepted.
+	//
+	// It is NOT a report of what is being enforced: it reflects neither
+	// EnforceNamespaces nor an unresolved NamespaceDefault, so a group can
+	// show a namespace here while unannotated Services in that namespace are
+	// being refused for ambiguity.
+	//
+	// Note it cannot detect a pruned CRD: spec.namespaces and this field ship
+	// in the same CRD, so a stale CRD removes both and the result is
+	// indistinguishable from a ServiceGroup that never set the field. Detect
+	// pruning by applying the field and reading the object back.
+	// +optional
+	BoundNamespaces []string `json:"boundNamespaces,omitempty"`
+
 	// Announce is the announcement mechanism: "Local" (IP added to the
 	// node's primary interface, for directly-attached subnets) or
 	// "Remote" (IP added to the kubelb0 dummy interface and advertised

--- a/pkg/apis/purelb/v2/types.go
+++ b/pkg/apis/purelb/v2/types.go
@@ -36,9 +36,15 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Announce",type=string,JSONPath=`.status.announce`
 // +kubebuilder:printcolumn:name="IPAM",type=string,JSONPath=`.status.ipam`
-// +kubebuilder:printcolumn:name="Addresses",type=string,JSONPath=`.status.addresses`
-// +kubebuilder:printcolumn:name="Allocated-V4",type=integer,JSONPath=`.status.allocatedIPv4`,priority=1
-// +kubebuilder:printcolumn:name="Allocated-V6",type=integer,JSONPath=`.status.allocatedIPv6`,priority=1
+// Addresses is priority=1 despite being the most detailed field: it is a
+// list, and kubectl renders a non-scalar column as raw JSON, which for a
+// dual-stack multi-range pool is ~200 characters and wraps the default
+// table on any normal terminal. The allocation counts are scalars and fit,
+// so they carry the at-a-glance signal instead; `-o wide` still shows the
+// full address list.
+// +kubebuilder:printcolumn:name="Allocated-V4",type=integer,JSONPath=`.status.allocatedIPv4`
+// +kubebuilder:printcolumn:name="Allocated-V6",type=integer,JSONPath=`.status.allocatedIPv6`
+// +kubebuilder:printcolumn:name="Addresses",type=string,JSONPath=`.status.addresses`,priority=1
 // +kubebuilder:printcolumn:name="Available-V4",type=integer,JSONPath=`.status.availableIPv4`,priority=1
 // +kubebuilder:printcolumn:name="Available-V6",type=integer,JSONPath=`.status.availableIPv6`,priority=1
 // +kubebuilder:printcolumn:name="Namespaces",type=string,JSONPath=`.spec.namespaces`,priority=1

--- a/website/content/docs/configuration/service-groups/_index.md
+++ b/website/content/docs/configuration/service-groups/_index.md
@@ -10,7 +10,97 @@ A ServiceGroup defines a pool of IP addresses that PureLB can allocate to LoadBa
 
 PureLB uses the ServiceGroup named `default` when a Service has no `purelb.io/service-group` annotation. We recommend creating one ServiceGroup named `default` for your most common use case.
 
-ServiceGroups are namespaced. We recommend placing them in `purelb-system`, but they can be created in other namespaces if RBAC requires it.
+ServiceGroups are namespaced objects, but **PureLB reads them only from its own install namespace** (normally `purelb-system`). A ServiceGroup created anywhere else is ignored entirely: its pool is not allocatable, and if it is a `remote` group, addresses already allocated from it are withdrawn from every node.
+
+{{< hint warning >}}
+**Changed in v0.17.0.** Earlier releases read ServiceGroups from every namespace. That never provided any isolation — a ServiceGroup in `tenant-a` contributed a pool to the same cluster-wide table as one in `purelb-system` — while it did allow two ServiceGroups in different namespaces to collide over a pool name, including the name `default`.
+
+Before upgrading, check for any that would be ignored:
+
+```console
+kubectl get servicegroups.purelb.io -A
+```
+
+To move one, apply it into the install namespace and delete the original. The two may safely coexist during the move, because the out-of-namespace copy is not read:
+
+```console
+kubectl get servicegroup <name> -n <other-ns> -o yaml \
+  | sed 's/namespace: <other-ns>/namespace: purelb-system/' \
+  | kubectl apply -f -
+kubectl delete servicegroup <name> -n <other-ns>
+```
+
+Addresses return on the next reconcile. PureLB logs and emits a Warning event naming any ServiceGroup it ignores, and reports them in `purelb_servicegroups_out_of_scope`.
+{{< /hint >}}
+
+## Restricting a ServiceGroup to Namespaces
+
+{{< hint danger >}}
+**The primary tenancy control is RBAC, not this feature.** Restrict `create` and `patch` on `servicegroups.purelb.io` to cluster administrators. Anyone who can write a ServiceGroup can bind their own namespace to whatever they like, or define a pool over anyone's addresses — at which point everything below is decorative. That one ClusterRole rule matters more than every field on this page.
+
+Kubernetes RBAC is verb × resource: it cannot see annotation *values*, so there is no way to express "may create Services but may not set `purelb.io/service-group: tenant-b-pool`". That is why the rest of this has to be enforced by the allocator.
+{{< /hint >}}
+
+`spec.namespaces` lists the Service namespaces a ServiceGroup serves. A Service in a listed namespace that carries no `purelb.io/service-group` annotation allocates from it. Omitting the field means every namespace, which is how every ServiceGroup behaved before v0.17.0.
+
+```yaml
+apiVersion: purelb.io/v2
+kind: ServiceGroup
+metadata:
+  name: tenant-a-pool
+  namespace: purelb-system
+spec:
+  namespaces: [tenant-a, tenant-a-staging]
+  local:
+    v4pools:
+    - subnet: 172.30.250.0/24
+      pool: 172.30.250.100-172.30.250.150
+    v6pools:
+    - subnet: 2001:470:b8f3:250::/64
+      pool: 2001:470:b8f3:250::100-2001:470:b8f3:250::150
+```
+
+**By itself this is a default, not a boundary.** An annotation still overrides it in both directions: a Service in `tenant-a` may ask for another ServiceGroup, and a Service elsewhere may ask for this one. Adding `namespaces` to a live cluster therefore changes nothing that already works.
+
+### Several ServiceGroups may serve one namespace
+
+This is normal, not a misconfiguration. A ServiceGroup is exactly one of `local`, `remote` or `external`, so a tenant that needs both L2 and BGP addresses needs **two** ServiceGroups, both listing its namespace. `spec.namespaces` establishes eligibility, not ownership.
+
+Where two or more serve a namespace, `spec.namespaceDefault` picks which one an unannotated Service gets. Where only one does, it is the default and the field is ignored.
+
+```yaml
+# tenant-a-l2                          # tenant-a-bgp
+spec:                                  spec:
+  namespaces: [tenant-a]                 namespaces: [tenant-a]
+  namespaceDefault: true                 remote:
+  local:                                   v4pools: [...]
+    v4pools: [...]
+```
+
+An unannotated Service in `tenant-a` gets `tenant-a-l2`; one annotated `purelb.io/service-group: tenant-a-bgp` gets the BGP pool.
+
+If several serve a namespace and **none** is marked, an unannotated Service falls back to the `default` pool and PureLB emits a `ConfigurationWarning` on the Service naming the candidates. Nothing breaks, but the Service may land on a different subnet than you intended — mark one.
+
+### Making it a boundary
+
+`spec.enforceNamespaces: true` turns the list from a default into a boundary. A Service outside the list cannot reach the ServiceGroup by annotation **or** by pinning one of its addresses with `purelb.io/addresses`; and a Service inside cannot allocate from any ServiceGroup that does not serve its namespace.
+
+{{< hint warning >}}
+**Enabling this enforces nothing that is already allocated.** Addresses already held are never revoked, so on the day you turn it on the boundary is not true of any existing Service. It governs new allocations only. Existing Services are re-checked when they are recreated — which may be weeks later, during an unrelated redeploy.
+{{< /hint >}}
+
+Enforcement is a property of the **namespace**, not of one ServiceGroup. Setting `enforceNamespaces` on any one of a namespace's ServiceGroups fences that namespace completely, in both directions — otherwise fencing a tenant's L2 pool would leave its BGP pool reachable from everywhere. You do not need to set it on all of them.
+
+This is an **allocation control, not RBAC**. PureLB ships no admission webhook, so a refused Service is created successfully and simply never gets an address; the reason appears as an `AllocationFailed` event on the Service.
+
+### Things to know
+
+- **Ranges must not overlap.** PureLB rejects a ServiceGroup whose addresses overlap an already-accepted one, so tenant pools partition the address space rather than sharing it.
+- **A namespace list is a trust set, not an isolation set.** Namespaces listed on the same ServiceGroup can share each other's addresses via `purelb.io/allow-shared-ip` and block each other's ports.
+- **Binding the `default` ServiceGroup while enforcing** denies every unannotated Service in every other namespace. It is legal, and almost never what you want.
+- **PureLB does not verify that a listed namespace exists.** A typo simply never matches, and the namespace you meant falls back to `default`.
+- **A namespace's ServiceGroups must between them cover the families you use.** `resolve` picks one ServiceGroup, and families are allocated within it — so a confined namespace whose pools are v4-only cannot satisfy a dual-stack Service.
+- **`status.boundNamespaces`** reports the list the allocator parsed. It confirms what PureLB read, which is not the same question as what the API server accepted.
 
 ## Local Pools
 
@@ -196,6 +286,8 @@ An IPv6-only pool reports `availableIPv4: 0`, and an IPv4-only pool reports `ava
 Changing a ServiceGroup does **not** change services that have already been allocated. Modified ServiceGroups only affect subsequently created services. This is intentional: address changes should happen service by service, not by a pool change affecting all associated services.
 
 To migrate a service to a new pool: create a new service pointing to the new ServiceGroup, redirect traffic, then delete the original service.
+
+The same applies to `spec.namespaces` and `spec.enforceNamespaces`: editing them never revokes an address. A Service that no longer matches keeps what it has until it is recreated, so a namespace can hold addresses that its current binding would refuse. To move an existing Service without dropping its VIP, pin the new address with `purelb.io/addresses` rather than deleting and recreating it.
 
 ## Complete Field Reference
 

--- a/website/content/docs/migration/_index.md
+++ b/website/content/docs/migration/_index.md
@@ -12,6 +12,10 @@ install (v0.15.x or earlier).
 If you are installing PureLB for the first time, **skip this guide** and follow
 the normal install instructions.
 
+If you are already on `purelb.io/v2` (v0.16.x) and upgrading to v0.17.0, this
+guide does not apply — see
+[v0.16.x to v0.17.0]({{< ref "/docs/migration/v0-17-0" >}}) instead.
+
 Steps 1–3 are the same no matter how PureLB was installed. **Step 4 forks** into
 a Helm path and a manifest path — follow the one matching your install. Helm was
 the default in v0.13, so it is shown first. Step 5 onward is shared again.

--- a/website/content/docs/migration/v0-17-0/_index.md
+++ b/website/content/docs/migration/v0-17-0/_index.md
@@ -1,0 +1,137 @@
+---
+title: "v0.16.x to v0.17.0"
+description: "Upgrade an existing purelb.io/v2 install to v0.17.0: removed API fields, ServiceGroup namespace scoping, and manifest changes."
+weight: 10
+---
+
+This page covers upgrading an install that is **already on `purelb.io/v2`**
+(v0.16.x) to v0.17.0.
+
+If you are coming from v0.13 or any other pre-`v2` release, follow the
+[v1 to v2 migration guide]({{< ref "/docs/migration" >}}) instead — it
+supersedes this page and installs v0.17.0 directly.
+
+## Read this first
+
+**v0.17.0 changes the `v2` API in place.** There is no version bump and no
+conversion webhook: `v2` remains the served and stored version, and fields
+have been removed from it.
+
+The practical consequence is that the *order* of the upgrade matters. Objects
+that use a removed field are rejected by the new CRDs, so find them before you
+apply anything.
+
+## Pre-upgrade check
+
+Run both queries. Empty output from each means nothing on this page needs
+action from you.
+
+```bash
+# ServiceGroups still using the removed in-tree Netbox IPAM
+kubectl get servicegroups.purelb.io -A -o json |
+  jq -r '.items[] | select(.spec.netbox != null)
+         | "netbox: \(.metadata.namespace)/\(.metadata.name)"'
+
+# ServiceGroups outside the install namespace — these stop being read.
+# Change purelb-system if you installed PureLB somewhere else.
+kubectl get servicegroups.purelb.io -A -o json |
+  jq -r '.items[] | select(.metadata.namespace != "purelb-system")
+         | "out-of-scope: \(.metadata.namespace)/\(.metadata.name)"'
+```
+
+Take a backup regardless — you will want it if you roll back:
+
+```bash
+kubectl get servicegroups.purelb.io -A -o yaml > servicegroups-pre-0.17.yaml
+kubectl get lbnodeagents.purelb.io -A -o yaml > lbnodeagents-pre-0.17.yaml
+```
+
+## Removed fields
+
+| Removed | Replacement |
+|---|---|
+| `spec.netbox` | `spec.external` — an IPAM sidecar speaking the gRPC IPAM contract |
+| `status.allocatedCount` | `status.allocatedIPv4` / `status.allocatedIPv6`, plus `availableIPv4` / `availableIPv6` |
+
+`spec.netbox` is not merely ignored. The new CRD requires exactly one of
+`local`, `remote` or `external`, so a ServiceGroup that still sets `netbox` is
+**rejected on its next write**, and the field is pruned when the object is read
+back. Convert those groups to a sidecar — see
+[External IPAM]({{< ref "/docs/configuration/external-ipam" >}}) — or delete
+them. Either way they allocate nothing once v0.17.0 is running.
+
+`status.allocatedCount` is gone rather than renamed, so anything reading it —
+dashboards, scripts, alert rules — gets nothing rather than a wrong number.
+Move those to the per-family fields.
+
+## ServiceGroups are read only from the install namespace
+
+Earlier releases read ServiceGroups from every namespace. That provided no
+isolation — a group in `tenant-a` fed the same cluster-wide pool table — while
+allowing two groups in different namespaces to collide over one pool name,
+including `default`.
+
+A ServiceGroup outside the install namespace is now ignored. Its pool is not
+allocatable and, **if it is a `remote` group, its addresses are withdrawn from
+every node.**
+
+The fix is to move the object into the install namespace. Addresses return on
+the next reconcile, and the two copies may coexist while you move it.
+
+PureLB reports ignored groups three ways: a log line, a Warning event on the
+group itself, and the metric
+`purelb_servicegroups_out_of_scope{namespace,name,type}`.
+
+This scoping depends on the allocator knowing its own namespace. It reads
+`--namespace` / `PURELB_NAMESPACE`, which the chart and the kustomize
+manifests supply via the downward API. If it cannot be determined, PureLB does
+**not** filter at all rather than risk discarding every ServiceGroup, and says
+so in its log.
+
+## Manifest and chart changes
+
+- The allocator Deployment is pinned to `replicas: 1` with
+  `strategy: Recreate`. Under the previous `RollingUpdate`, `maxSurge` rounds
+  up to 1, so every upgrade briefly ran two allocators handing out addresses
+  from the same pools. A short gap in allocation is the safer trade.
+- `PURELB_NAMESPACE` is added to the allocator via the downward API.
+- `NETBOX_USER_TOKEN` and its `netbox-client` Secret reference are removed
+  from the allocator Deployment. The Secret itself is not deleted for you.
+- The allocator ClusterRole gains `servicegroups/status` (`update`, `patch`).
+- Both ClusterRoles drop an unused `namespaces` (`get`, `list`) grant.
+
+**If you maintain your own RBAC** rather than using the shipped ClusterRoles,
+add `servicegroups/status` before upgrading. Without it every status write is
+refused: allocation and announcement keep working, but ServiceGroup `.status`
+stays empty and
+`purelb_allocator_sg_status_writes_total{outcome="forbidden"}` climbs.
+
+## Announcing annotation format
+
+`purelb.io/announcing-<family>` is now keyed by IP address. Each entry is
+`node,interface,ip`, and entries are space-separated:
+
+```yaml
+purelb.io/announcing-IPv4: "node-a,eth0,192.0.2.10 node-b,eth0,192.0.2.11"
+```
+
+Keying by IP is what lets a dual-stack or multi-pool Service record a
+different announcing node per address. The earlier one-field (`kube-lb0`) and
+two-field (`node,iface`) forms are dropped on read and do not survive the
+first write.
+
+No action is required — the node agents rewrite the annotation as they
+reconcile — but anything parsing it needs updating.
+
+## Rolling back to v0.16.x
+
+Reinstall the v0.16.x CRDs and workloads.
+
+Because `v2` changed in place, a ServiceGroup created against v0.17.0 that
+uses `spec.external` fails validation on the older CRD. Delete those objects
+before rolling back, or restore the backup you took above:
+
+```bash
+kubectl apply -f servicegroups-pre-0.17.yaml
+kubectl apply -f lbnodeagents-pre-0.17.yaml
+```

--- a/website/content/docs/overview/architecture/_index.md
+++ b/website/content/docs/overview/architecture/_index.md
@@ -49,7 +49,11 @@ BGPNodeStatus | `bgp.purelb.io/v1` | Per-node BGP status (written by k8gobgp, re
 
 ## Namespace
 
-All PureLB components run in the `purelb-system` namespace. ServiceGroups and LBNodeAgents are namespaced resources -- we recommend placing them in `purelb-system` for simplicity, but they can be created in other namespaces if RBAC requires it.
+All PureLB components run in the `purelb-system` namespace.
+
+ServiceGroups and LBNodeAgents are namespaced resources. **As of v0.17.0, PureLB reads ServiceGroups only from its own install namespace** — one created elsewhere is ignored entirely. LBNodeAgents are still read from every namespace.
+
+Restrict `create` and `patch` on `servicegroups.purelb.io` to cluster administrators: a ServiceGroup defines cluster-wide address ranges and which namespaces may draw from them, so the ability to write one is the real tenancy boundary.
 
 ## Security
 

--- a/website/content/docs/reference/annotations/_index.md
+++ b/website/content/docs/reference/annotations/_index.md
@@ -10,8 +10,8 @@ These annotations are set by users on Service resources to control PureLB behavi
 
 Annotation | Value | Description
 -----------|-------|------------
-`purelb.io/service-group` | ServiceGroup name | Select which ServiceGroup to allocate from. If not set, the `default` ServiceGroup is used.
-`purelb.io/addresses` | IP address(es) | Request a specific IP. For dual-stack, comma-separate: `"192.168.1.100,fd00:1::100"`. Must be within the ServiceGroup's pool.
+`purelb.io/service-group` | ServiceGroup name | Select which ServiceGroup to allocate from. If not set, PureLB uses whichever ServiceGroup serves this Service's namespace, falling back to the one named `default`. Refused if the named ServiceGroup does not serve this namespace and enforcement is on — see [namespace restriction]({{< relref "/docs/configuration/service-groups#restricting-a-servicegroup-to-namespaces" >}}).
+`purelb.io/addresses` | IP address(es) | Request a specific IP. For dual-stack, comma-separate: `"192.168.1.100,fd00:1::100"`. Must be within a ServiceGroup's pool, and subject to the same namespace restriction as `purelb.io/service-group` — pinning an address is a way of naming its ServiceGroup. Not supported for `external` (sidecar IPAM) pools.
 `purelb.io/allow-shared-ip` | sharing key (string) | Enable IP sharing between services with the same key. Services must use different ports. Forces `externalTrafficPolicy: Cluster`.
 `purelb.io/allow-local` | `"true"` | Override: allow `externalTrafficPolicy: Local` on local address pools. Not recommended -- local addresses are announced by a single node, so `Local` policy drops traffic when target pods aren't on that node.
 `purelb.io/multi-pool` | `"true"` or `"false"` | Override the ServiceGroup's `multiPool` setting for this service.

--- a/website/content/docs/reference/crd-reference/_index.md
+++ b/website/content/docs/reference/crd-reference/_index.md
@@ -18,7 +18,12 @@ Field | Type | Required | Description
 ------|------|----------|------------
 `local` | ServiceGroupLocalSpec | No | Pool of addresses on the same subnet as nodes
 `remote` | ServiceGroupRemoteSpec | No | Pool of addresses on a different subnet (for BGP routing)
-`netbox` | ServiceGroupNetboxSpec | No | External IPAM via Netbox
+`external` | ServiceGroupExternalSpec | No | Addresses managed by an external IPAM system via a sidecar
+`namespaces` | []string | No | Service namespaces this ServiceGroup serves. Empty means all. Several ServiceGroups may serve one namespace
+`enforceNamespaces` | bool | No | Make `namespaces` a boundary rather than a default. Requires a non-empty `namespaces`
+`namespaceDefault` | bool | No | Which ServiceGroup an unannotated Service gets, where several serve one namespace. Requires a non-empty `namespaces`
+
+Exactly one of `local`, `remote` or `external` must be specified.
 
 ### ServiceGroupLocalSpec
 
@@ -63,7 +68,18 @@ Field | Type | Required | Description
 
 Field | Type | Description
 ------|------|------------
-`allocatedCount` | int | Number of IP addresses currently allocated from this pool
+`announce` | string | Announcement mechanism: `Local` (node interface) or `Remote` (`kube-lb0`, advertised via BGP)
+`ipam` | string | `Cluster` when PureLB allocates, or the external provider's name
+`addresses` | []string | Human-readable summary of the pool's address scope
+`allocatedIPv4` | int64 | IPv4 addresses currently allocated
+`allocatedIPv6` | int64 | IPv6 addresses currently allocated
+`availableIPv4` | int64 | IPv4 addresses still available. Absent when capacity is not knowable
+`availableIPv6` | int64 | IPv6 addresses still available. Absent when capacity is not knowable
+`boundNamespaces` | []string | The namespace list the allocator parsed from `spec.namespaces`
+
+A blank status means PureLB rejected the spec — check the ServiceGroup's events.
+
+`boundNamespaces` confirms what the allocator **read**, which is not the same as what the API server accepted, and it is not a report of what is being *enforced*: it reflects neither `enforceNamespaces` nor an unresolved `namespaceDefault`. It also cannot detect a pruned CRD, because `spec.namespaces` and this field ship in the same CRD and a stale CRD removes both — to check for pruning, apply the field and read the object back.
 
 ---
 

--- a/website/content/docs/reference/metrics/_index.md
+++ b/website/content/docs/reference/metrics/_index.md
@@ -12,7 +12,8 @@ Metric | Type | Labels | Description
 -------|------|--------|------------
 `purelb_address_pool_size` | Gauge | `pool` | Total number of addresses in the pool
 `purelb_address_pool_addresses_in_use` | Gauge | `pool` | Number of addresses currently allocated
-`purelb_address_pool_allocation_rejected_total` | Counter | `pool`, `reason` | Allocation requests rejected (exhaustion, sharing constraints, etc.)
+`purelb_address_pool_allocation_rejected_total` | Counter | `pool`, `reason` | Allocation requests rejected. `reason` is `exhausted`, `port_conflict`, `sharing_key_conflict`, `multipool_refused` (multi-pool asked of a pool that cannot serve it) or `multipool_pool_mismatch` (`purelb.io/allocated-from` disagreed with the addresses held; `pool` is `<unknown>`)
+`purelb_servicegroups_out_of_scope` | Gauge | `namespace`, `name`, `type` | ServiceGroups ignored because they are not in the PureLB install namespace. `type` is `local`, `remote` or `external` — a `remote` group being ignored withdraws its addresses from every node, a `local` one only makes its pool unallocatable
 `purelb_address_pool_multipool_allocations_total` | Counter | `pool` | Multi-pool allocations performed
 `purelb_address_pool_multipool_partial_total` | Counter | `pool` | Multi-pool allocations where some ranges were exhausted or had no active nodes
 `purelb_address_pool_balance_pools_allocations_total` | Counter | `pool` | Balanced allocation (balancePools) allocations performed


### PR DESCRIPTION
Namespace-scoped ServiceGroups, plus the fixes from a full review of everything
that changed since v0.16.6.

## Feature: namespace-scoped ServiceGroups

`spec.namespaces` lists the Service namespaces a ServiceGroup serves. An
unannotated Service in one of them allocates from it; omitting the field means
every namespace, so this is additive and changes nothing on an existing cluster.

Several ServiceGroups may serve one namespace, and that is normal — a
ServiceGroup is exactly one of local/remote/external, so an L2 + BGP tenant
needs two. The list establishes eligibility, not ownership, and
`spec.namespaceDefault` picks which one an unannotated Service gets.
`spec.enforceNamespaces` turns the list into a boundary covering both
`purelb.io/service-group` and `purelb.io/addresses`, since pinning an address
is a way of naming its ServiceGroup.

Verified end-to-end on a 5-node dual-stack cluster: namespace-based selection,
`.status.boundNamespaces` confirming what the allocator parsed, and both denial
directions with accurate events —

```
namespace denied: ServiceGroup "tenant-a-pool" serves a confined namespace and does not serve "tenant-b"
namespace denied: namespace "tenant-a" may only use [tenant-a-pool], not ServiceGroup "default"
```

## Two concurrency defects, one of them live

**The announcer's config was unsynchronised** (`910023da`). `SetConfig` runs on
the CR-controller goroutine while `SetBalancer` runs on the service-sync
goroutine, and the five config-derived fields they shared had no
synchronisation. `SetConfig` blanked the spec pointer on entry and only restored
it after a netlink round trip, so a `SetBalancer` between the nil-guard and any
later dereference took a nil-pointer panic.

This was **crash-looping every node agent on the test cluster** — 14 to 25
restarts per node, roughly one per 10-minute informer resync:

```
panic: runtime error: invalid memory address or nil pointer dereference
  local.(*announcer).tryExtraInterfaces  announcer_local.go:345
  local.(*announcer).SetBalancer         announcer_local.go:292
```

At v0.16.6 `SetBalancer` dereferenced the config exactly once — the nil guard
itself — so the window existed but was unreachable. The multi-interface work
added three post-guard dereferences and made it live. A second, worse mode was
latent on the same fields: the group maps were assigned empty then filled, so a
reader iterating them could hit `concurrent map iteration and map write`, a
runtime fatal error no `recover()` can catch.

Fixed by publishing all five values as one immutable snapshot behind an
`atomic.Pointer` — the discipline the allocator already uses for
`allocatorState`. No lock introduced.

**The renewal timer raced too** (`fe54dbf7`), pre-existing at v0.16.6:
`renewAddress` re-arms the timer from the timer's own goroutine while
`scheduleRenewal` stops it from the service-sync goroutine.

Both fixes were validated by reverting them and confirming the new tests fail
with the production stack. That mattered: for the timer fix, reverting only the
atomic half still passed, which revealed that the `cancelled` marking was the
load-bearing part for that pairing. Both halves are needed.

## External IPAM

- Pool methods took a `context` so network-backed implementations could be
  bounded; all ten call sites passed `context.Background()`. On a
  single-goroutine work queue, a sidecar that accepts and hangs would wedge
  every reconcile in the cluster.
- `Unassign` returned `nil` unconditionally, so a failed `Release` vanished.
  Observed: with the sidecar removed, deleting a Service holding an external
  address completed in one second reporting success while the address stayed
  allocated. Nothing logged, no event — only a raw RPC counter moved.
- `ReleaseIPs` resolved pools only via `Contains`, which `SidecarPool` hardcodes
  false, so a DualStack→SingleStack transition dropped the address from
  `.status` while the external IPAM still held it.
- Allocation failures returned `SyncStateSuccess`, so nothing was ever retried.
  Now classified: transport failures requeue, decisions the allocator makes for
  itself do not.

## Observability

Four places where PureLB knew the right answer and reported something else:
namespace denials produced no metric despite sentinels existing for exactly
that; the precedence log and `ConfigIgnored` event named the wrong LBNodeAgent
(the event landed on the CR actually in force); LBNodeAgents with invalid
selectors were dropped silently; and `kubectl purelb services` showed external
pools as `local`, indistinguishable from cluster IPAM.

```
NAMESPACE   SERVICE     IPS               POOL            TYPE   IPAM         ANNOUNCING
default     ext-probe   172.30.250.225    probe-external  local  sample-ipam  purelb2-1/eth1
echo-test   echo-aff    172.30.250.244    echo-multipool  local  cluster      purelb2-3/eth0
```

## Also

Unused `namespaces` RBAC dropped from both ClusterRoles; announcer pool lookup
made deterministic; log-throttle globals made atomic; ServiceGroup print columns
rebalanced so `kubectl get sg` stops wrapping; per-family counts no longer
`ParseIP` every address on every allocation; `Release` now targets the pool that
held the address instead of every sidecar; `spec.external.announce` validated in
Go against a stale CRD; gofmt gated in `make check`.

## Upgrade notes

**v0.17.0 changes the `v2` API in place** — no version bump, no conversion
webhook, fields removed from the served and stored version. A ServiceGroup still
setting `spec.netbox` is rejected on its next write once the new CRDs are
applied. New guide at `website/content/docs/migration/v0-17-0/` covers the
pre-upgrade check, removed fields, install-namespace scoping, the manifest and
RBAC changes, and rollback.

## Testing

`make check` clean. Full `go test -race -short ./...` passing.

Deployed and exercised on a 5-node dual-stack cluster throughout:

- **C1**: 25–36 forced config deliveries per node in ~90s with concurrent Service
  churn — against roughly one per resync that used to be enough to crash it —
  then a 26-minute watch across two resync boundaries. Zero restarts, zero panics.
- **External IPAM e2e** passing, including the first cluster run of the sidecar
  suite (the `test-sidecar` image had never been published).
- **Retry classification**: a permanent denial increments its counter once and
  does not requeue — `updates_total` flat across 24s, confirming no spin.
- All four dual-stack VIPs reachable and announced from the expected
  node/interface after every change.

## Known gaps

- The H3 dual-stack→single-stack leak is fixed by mechanism and verified through
  the `poolFor` failure it depends on, but the transition itself was not driven
  end-to-end: the sample sidecar is IPv4-only.
- `NETBOX_USER_TOKEN: no-op` is still set in `.github/workflows/ci.yml`, left
  over from the Netbox removal. Harmless, not touched here.
- 3 Dependabot advisories remain open on main (2 high, 1 moderate), unrelated to
  this branch.

